### PR TITLE
phase4/sync-port: mysecond sync + artifact-sync (PR 4b)

### DIFF
--- a/src/commands/artifact-sync.ts
+++ b/src/commands/artifact-sync.ts
@@ -1,15 +1,106 @@
-// `mysecond artifact-sync` — PostToolUse dispatcher that pushes a changed artifact
-// (skill output, doc, plan) up to mysecond.ai's /api/companion/artifacts endpoint.
+// `mysecond artifact-sync --silent` — PostToolUse dispatcher.
 //
-// Stub for v1.1.0 scaffold. Real implementation lands later in PR 4b per
-// EDD-solo-phase-4-pmkit-cli.md §5.5.
+// Invoked by the customer plugin's PostToolUse hook (registered in plugin.json
+// by the regen worker per CAIO-Y1 architectural change in PR #78). Hook command
+// is `bash -lc 'mysecond artifact-sync --silent'` — Claude Code passes the tool
+// event as JSON on stdin.
+//
+// This replaces the legacy v1.0.0 `ensureArtifactSync()` bash script (which
+// `sync-context.js` wrote to `.claude/hooks/artifact-sync.sh`). That entire
+// shell-script-on-disk + settings.json hook registration path is gone — plugin
+// manifest is now the single source of truth for hook registration.
+//
+// Contract: never error loudly. The customer is mid-Claude-action when this
+// fires. Surface failures via stderr only when `--verbose` is passed (PR 4c
+// adds the flag); never block the tool call.
 
+import { artifactsSync } from '../lib/api.js';
 import type { CommandContext } from '../lib/context.js';
+import { shortHash } from '../lib/files.js';
+import { classifyArtifactType, type ArtifactPayload } from '../lib/payload.js';
 
-export async function runArtifactSync(_args: readonly string[], _ctx: CommandContext): Promise<number> {
-  process.stderr.write(
-    'mysecond artifact-sync: not yet implemented in v1.1.0. ' +
-      'Tracking in PR 4b — see specs/EDD-solo-phase-4-pmkit-cli.md §5.\n'
-  );
-  return 1;
+interface ToolEvent {
+  tool_name?: string;
+  tool_input?: { file_path?: string };
+}
+
+const MAX_FILE_BYTES = 3_000_000;
+
+async function readStdin(): Promise<string> {
+  // Node 18+ stdin streams as async iterable.
+  let buf = '';
+  process.stdin.setEncoding('utf8');
+  for await (const chunk of process.stdin) {
+    buf += chunk;
+    if (buf.length > MAX_FILE_BYTES * 2) break;
+  }
+  return buf;
+}
+
+function parseEvent(raw: string): ToolEvent | null {
+  if (raw.trim().length === 0) return null;
+  try {
+    return JSON.parse(raw) as ToolEvent;
+  } catch {
+    return null;
+  }
+}
+
+export async function runArtifactSync(
+  _args: readonly string[],
+  ctx: CommandContext
+): Promise<number> {
+  // Hook protocol: even on errors we exit 0 so Claude Code's tool call doesn't
+  // get blamed for our problems. The whole subcommand is best-effort.
+  if (ctx.apiKey.length === 0) return 0;
+
+  const raw = await readStdin();
+  const event = parseEvent(raw);
+  if (event === null) return 0;
+  if (event.tool_name !== 'Write') return 0;
+
+  const filePath = event.tool_input?.file_path;
+  if (filePath === undefined || filePath.length === 0) return 0;
+
+  // The hook fires from the project dir, so file_path is typically absolute.
+  // Convert to project-relative; reject if outside the project tree.
+  const rootDir = ctx.rootDir;
+  const relativePath = filePath.startsWith(rootDir + '/')
+    ? filePath.slice(rootDir.length + 1)
+    : filePath.startsWith('/')
+    ? null
+    : filePath;
+  if (relativePath === null) return 0;
+
+  const artifactType = classifyArtifactType(relativePath);
+  if (artifactType === null) return 0;
+
+  // Read the file content. If it grew beyond the size guard or disappeared
+  // between the Write and the hook firing, skip silently.
+  let content: string;
+  try {
+    const { readFileSync, statSync } = await import('node:fs');
+    const stat = statSync(filePath);
+    if (stat.size > MAX_FILE_BYTES) return 0;
+    content = readFileSync(filePath, 'utf8');
+  } catch {
+    return 0;
+  }
+
+  const payload: ArtifactPayload = {
+    file_path: relativePath,
+    content,
+    current_hash: shortHash(content),
+    artifact_type: artifactType,
+    pm_name: null,
+    skill_slug: null,
+    produced_at: new Date().toISOString(),
+  };
+
+  try {
+    await artifactsSync(ctx, [payload]);
+  } catch {
+    // Best-effort: any network error is swallowed so the next sync picks it up.
+  }
+  return 0;
 }

--- a/src/commands/artifact-sync.ts
+++ b/src/commands/artifact-sync.ts
@@ -1,22 +1,14 @@
-// `mysecond artifact-sync --silent` — PostToolUse dispatcher.
-//
-// Invoked by the customer plugin's PostToolUse hook (registered in plugin.json
-// by the regen worker per CAIO-Y1 architectural change in PR #78). Hook command
-// is `bash -lc 'mysecond artifact-sync --silent'` — Claude Code passes the tool
-// event as JSON on stdin.
-//
-// This replaces the legacy v1.0.0 `ensureArtifactSync()` bash script (which
-// `sync-context.js` wrote to `.claude/hooks/artifact-sync.sh`). That entire
-// shell-script-on-disk + settings.json hook registration path is gone — plugin
-// manifest is now the single source of truth for hook registration.
-//
-// Contract: never error loudly. The customer is mid-Claude-action when this
-// fires. Surface failures via stderr only when `--verbose` is passed (PR 4c
-// adds the flag); never block the tool call.
+// `mysecond artifact-sync --silent` — PostToolUse dispatcher. EDD §5.5.
+// Hook command (per regen worker): `bash -lc 'mysecond artifact-sync --silent'`.
+// Tool event arrives as JSON on stdin. Always exits 0 — this is best-effort
+// hook plumbing and the customer's tool call shouldn't get blamed for our
+// problems.
+
+import { readFileSync, statSync } from 'node:fs';
 
 import { artifactsSync } from '../lib/api.js';
 import type { CommandContext } from '../lib/context.js';
-import { shortHash } from '../lib/files.js';
+import { relativeFromRoot, shortHash } from '../lib/files.js';
 import { classifyArtifactType, type ArtifactPayload } from '../lib/payload.js';
 
 interface ToolEvent {
@@ -26,8 +18,16 @@ interface ToolEvent {
 
 const MAX_FILE_BYTES = 3_000_000;
 
+// Tools that write files and therefore produce artifacts worth syncing.
+// Hard-string list intentionally — see TODO. Worth tracking separately because
+// Claude Code may add new write-class tool names (e.g. MultiWrite) that we'd
+// silently miss. CAIO-flagged in PR 4b review; matches Anthropic's current
+// PostToolUse hook taxonomy as of 2026-04-22.
+// TODO: subscribe to Claude Code release notes / changelog and bump this list
+// when new write-class tool names are introduced.
+const WRITE_TOOLS: ReadonlySet<string> = new Set(['Write', 'Edit', 'MultiEdit']);
+
 async function readStdin(): Promise<string> {
-  // Node 18+ stdin streams as async iterable.
   let buf = '';
   process.stdin.setEncoding('utf8');
   for await (const chunk of process.stdin) {
@@ -50,36 +50,24 @@ export async function runArtifactSync(
   _args: readonly string[],
   ctx: CommandContext
 ): Promise<number> {
-  // Hook protocol: even on errors we exit 0 so Claude Code's tool call doesn't
-  // get blamed for our problems. The whole subcommand is best-effort.
   if (ctx.apiKey.length === 0) return 0;
 
   const raw = await readStdin();
   const event = parseEvent(raw);
   if (event === null) return 0;
-  if (event.tool_name !== 'Write') return 0;
+  if (event.tool_name === undefined || !WRITE_TOOLS.has(event.tool_name)) return 0;
 
   const filePath = event.tool_input?.file_path;
   if (filePath === undefined || filePath.length === 0) return 0;
 
-  // The hook fires from the project dir, so file_path is typically absolute.
-  // Convert to project-relative; reject if outside the project tree.
-  const rootDir = ctx.rootDir;
-  const relativePath = filePath.startsWith(rootDir + '/')
-    ? filePath.slice(rootDir.length + 1)
-    : filePath.startsWith('/')
-    ? null
-    : filePath;
+  const relativePath = relativeFromRoot(ctx.rootDir, filePath);
   if (relativePath === null) return 0;
 
   const artifactType = classifyArtifactType(relativePath);
   if (artifactType === null) return 0;
 
-  // Read the file content. If it grew beyond the size guard or disappeared
-  // between the Write and the hook firing, skip silently.
   let content: string;
   try {
-    const { readFileSync, statSync } = await import('node:fs');
     const stat = statSync(filePath);
     if (stat.size > MAX_FILE_BYTES) return 0;
     content = readFileSync(filePath, 'utf8');
@@ -100,7 +88,7 @@ export async function runArtifactSync(
   try {
     await artifactsSync(ctx, [payload]);
   } catch {
-    // Best-effort: any network error is swallowed so the next sync picks it up.
+    // Best-effort: TODO(telemetry) emit PostHog event when telemetry lands.
   }
   return 0;
 }

--- a/src/commands/artifact-sync.ts
+++ b/src/commands/artifact-sync.ts
@@ -1,10 +1,12 @@
 // `mysecond artifact-sync` — PostToolUse dispatcher that pushes a changed artifact
 // (skill output, doc, plan) up to mysecond.ai's /api/companion/artifacts endpoint.
 //
-// Stub for v1.1.0 scaffold. Real implementation lands in PR 4b per
-// EDD-solo-phase-4-pmkit-cli.md §5.1.
+// Stub for v1.1.0 scaffold. Real implementation lands later in PR 4b per
+// EDD-solo-phase-4-pmkit-cli.md §5.5.
 
-export async function runArtifactSync(_args: readonly string[]): Promise<number> {
+import type { CommandContext } from '../lib/context.js';
+
+export async function runArtifactSync(_args: readonly string[], _ctx: CommandContext): Promise<number> {
   process.stderr.write(
     'mysecond artifact-sync: not yet implemented in v1.1.0. ' +
       'Tracking in PR 4b — see specs/EDD-solo-phase-4-pmkit-cli.md §5.\n'

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,7 +3,9 @@
 // Stub for v1.1.0 scaffold. Real implementation lands in PR 4c per
 // EDD-solo-phase-4-pmkit-cli.md §6 (13 atomic, idempotent, resumable steps).
 
-export async function runInit(_args: readonly string[]): Promise<number> {
+import type { CommandContext } from '../lib/context.js';
+
+export async function runInit(_args: readonly string[], _ctx: CommandContext): Promise<number> {
   process.stderr.write(
     'mysecond init: not yet implemented in v1.1.0. ' +
       'Tracking in PR 4c — see specs/EDD-solo-phase-4-pmkit-cli.md §6.\n'

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,8 +1,7 @@
 // `mysecond sync` — pull context/skills/agents/workflows from mysecond.ai,
-// push local artifacts back up. Ported from legacy sync-context.js per EDD §5.
+// push local artifacts back up. EDD §5.
 
-import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
 import { cliSync, artifactsSync, confirmFirstSetup } from '../lib/api.js';
 import type { CommandContext } from '../lib/context.js';
@@ -11,14 +10,12 @@ import { MysecondError } from '../lib/errors.js';
 import {
   projectPaths,
   readLocalFile,
-  shortHash,
   writeLocalFile,
   deleteLocalFile,
 } from '../lib/files.js';
 import { markNpmUpdated, shouldRunNpmUpdate } from '../lib/npm.js';
 import {
-  ARTIFACT_DIRS,
-  type ArtifactPayload,
+  scanArtifacts,
   type CompanionFile,
   type ContextFile,
 } from '../lib/payload.js';
@@ -26,6 +23,11 @@ import { readSyncState, writeSyncState, type SyncState } from '../lib/sync-state
 
 const TEAM_OVERRIDE_START = '<!-- TEAM_OVERRIDE:START -->';
 const TEAM_OVERRIDE_END = '<!-- TEAM_OVERRIDE:END -->';
+
+// CAIO finding: SessionStart hooks shouldn't block session start visibly. Tighten
+// the cliSync timeout when running silently (hook path); keep the longer default
+// for manual sync runs where the customer expects a live operation.
+const SILENT_SYNC_TIMEOUT_MS = 8_000;
 
 interface SyncSummary {
   created: number;
@@ -119,52 +121,6 @@ function mergeClaudeMdOverride(claudeMdPath: string, override: string): void {
   writeFileSync(claudeMdPath, next);
 }
 
-function scanArtifacts(rootDir: string): ArtifactPayload[] {
-  const found: ArtifactPayload[] = [];
-  for (const entry of ARTIFACT_DIRS) {
-    const dir = join(rootDir, entry.relativeDir);
-    if (!existsSync(dir)) continue;
-    walkArtifactDir(rootDir, dir, entry.type, found);
-  }
-  return found;
-}
-
-function walkArtifactDir(
-  rootDir: string,
-  currentDir: string,
-  artifactType: ArtifactPayload['artifact_type'],
-  results: ArtifactPayload[]
-): void {
-  const entries = readdirSync(currentDir, { withFileTypes: true });
-  for (const entry of entries) {
-    const fullPath = join(currentDir, entry.name);
-    if (entry.isDirectory()) {
-      walkArtifactDir(rootDir, fullPath, artifactType, results);
-      continue;
-    }
-    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
-
-    const content = readFileSync(fullPath, 'utf8');
-    const relativePath = relative(rootDir, fullPath);
-    // Parent dir naming convention: YYYY-MM-DD-HHMM-<pm-name>
-    const parentDir = currentDir.split('/').pop() ?? '';
-    const pmNameMatch = parentDir.match(/^\d{4}-\d{2}-\d{2}-\d{4}-(.+)$/);
-    const pmName = pmNameMatch && pmNameMatch[1] !== undefined ? pmNameMatch[1] : null;
-    const skillSlug = entry.name
-      .replace(/^\d{4}-\d{2}-\d{2}-\d{4}-/, '')
-      .replace(/\.md$/, '');
-    results.push({
-      file_path: relativePath,
-      content,
-      current_hash: shortHash(content),
-      artifact_type: artifactType,
-      pm_name: pmName,
-      skill_slug: skillSlug.length > 0 ? skillSlug : null,
-      produced_at: new Date().toISOString(),
-    });
-  }
-}
-
 async function upSyncArtifacts(
   ctx: CommandContext,
   state: SyncState
@@ -187,6 +143,11 @@ async function upSyncArtifacts(
 }
 
 function printSummary(summary: SyncSummary, ctx: CommandContext): void {
+  // CAIO finding: stderr from SessionStart hooks is silently dropped on exit 0.
+  // Customer-relevant messages MUST go to stdout when ctx.silent so Claude sees
+  // them as session-start context and can mention them to the customer.
+  const out = ctx.silent ? process.stdout : process.stdout;
+
   if (ctx.silent) {
     const parts: string[] = [];
     const contextChanges =
@@ -198,9 +159,9 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
     if (summary.artifactsPushed > 0) parts.push(`${summary.artifactsPushed} artifacts pushed`);
     const conflicts =
       summary.conflictsCloudKept + summary.conflictsLocalKept + summary.conflictsSkipped;
-    if (conflicts > 0) parts.push(`${conflicts} conflicts`);
+    if (conflicts > 0) parts.push(`${conflicts} conflicts (see .claude/sync-conflicts/)`);
     if (parts.length > 0) {
-      process.stdout.write(`mysecond: ${parts.join(', ')}\n`);
+      out.write(`mysecond: ${parts.join(', ')}\n`);
     }
     return;
   }
@@ -220,11 +181,9 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
   if (summary.claudeMdUpdated) parts.push('CLAUDE.md updated');
   if (parts.length === 0) parts.push('nothing changed');
 
-  process.stdout.write(`✓ Sync complete: ${parts.join(', ')}.\n`);
+  out.write(`✓ Sync complete: ${parts.join(', ')}.\n`);
   if (summary.conflictsCloudKept > 0 || summary.conflictsLocalKept > 0) {
-    process.stdout.write(
-      `  Recover backed-up versions from .claude/sync-conflicts/ if needed.\n`
-    );
+    out.write(`  Recover backed-up versions from .claude/sync-conflicts/ if needed.\n`);
   }
 }
 
@@ -240,7 +199,15 @@ export async function runSync(
   const state = readSyncState(ctx.rootDir);
   const previousPaths = Object.keys(state.files);
 
-  const response = await cliSync(ctx, previousPaths);
+  // Quality bug-catch: capture lastSyncedAt BEFORE the response overwrites it
+  // on line ~225. Without this snapshot, the wasFirstSync check below would
+  // always be true and confirmFirstSetup() would fire on every sync.
+  const priorLastSyncedAt = state.lastSyncedAt;
+
+  const cliSyncOpts: { timeoutMs?: number } = ctx.silent
+    ? { timeoutMs: SILENT_SYNC_TIMEOUT_MS }
+    : {};
+  const response = await cliSync(ctx, previousPaths, cliSyncOpts);
   const contextFiles: ContextFile[] = response.context_files ?? response.files ?? [];
   const customSkills = response.custom_skills ?? [];
   const customAgents = response.custom_agents ?? [];
@@ -250,14 +217,12 @@ export async function runSync(
 
   const paths = projectPaths(ctx.rootDir);
 
-  // Down-sync context files — conflict detection per src/lib/conflict.ts.
   for (const file of contextFiles) {
     const localContent = readLocalFile(paths.contextDir, file.file_path);
     const outcome = resolveConflict({ file, localContent, syncState: state, ctx });
     tally(summary, outcome);
   }
 
-  // Deletions — cloud says these no longer apply; remove locally if present.
   for (const filePath of deletedPaths) {
     if (deleteLocalFile(paths.contextDir, filePath)) {
       delete state.files[filePath];
@@ -265,8 +230,6 @@ export async function runSync(
     }
   }
 
-  // Companion-wins for skills / agents / workflows. No conflict detection — these
-  // are owned by the server and customers should never edit the bundled files.
   for (const file of customSkills) {
     if (syncCompanionFile(paths.skillsDir, file)) summary.skillsUpdated++;
   }
@@ -282,8 +245,9 @@ export async function runSync(
     summary.claudeMdUpdated = true;
   }
 
-  // Up-sync artifacts (best-effort — failure is non-fatal so the down-sync still
-  // succeeds for the customer).
+  // Up-sync is best-effort: failure here doesn't fail the sync command. In
+  // silent mode we swallow the failure entirely (transient hook noise isn't
+  // worth surfacing on session start); in interactive mode we report it.
   try {
     summary.artifactsPushed = await upSyncArtifacts(ctx, state);
   } catch (err) {
@@ -294,21 +258,21 @@ export async function runSync(
     }
   }
 
-  // 24h npm-update timebox — gate is honored, actual `npm update` lands in a
-  // future PR once the customer plugin slug is provisioned by `mysecond init`.
+  // The 24h gate is honored; actual `npm update -g @mysecond/customer-{slug}`
+  // invocation lands when PR 4c provisions the customer plugin slug to local
+  // state. Until then the gate just stamps the timestamp so the cadence starts
+  // from install day.
   if (shouldRunNpmUpdate(state, ctx)) {
     markNpmUpdated(state);
     summary.npmUpdateRan = true;
   }
 
-  // Persist updated state. lastSyncedAt comes from the server response so the
-  // CLI's clock skew can't drift the ledger.
   state.lastSyncedAt = response.syncedAt;
   writeSyncState(ctx.rootDir, state);
 
-  // First-sync confirmation — fire-and-forget; failure doesn't impact the user.
-  const wasFirstSync =
-    state.lastSyncedAt !== null && Object.keys(state.files).length > 0 && previousPaths.length === 0;
+  // First-sync = no prior server timestamp AND no prior tracked paths. Both
+  // checks must use the snapshots captured before any state mutations above.
+  const wasFirstSync = priorLastSyncedAt === null && previousPaths.length === 0;
   if (wasFirstSync) {
     await confirmFirstSetup(ctx);
   }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,18 +1,318 @@
-// `mysecond sync` — pull the latest context, skills, and agents from mysecond.ai.
-//
-// Stub for v1.1.0 scaffold. Real implementation lands later in PR 4b per
-// EDD-solo-phase-4-pmkit-cli.md §5 (port of sync-context.js with debounce,
-// safePath hardening, and Solo payload extensions).
-//
-// Reference: legacy v1.0.0 sync command (preserved in git history at commit 4d281e0)
-// shows the debounce + safePath patterns that the port will preserve.
+// `mysecond sync` — pull context/skills/agents/workflows from mysecond.ai,
+// push local artifacts back up. Ported from legacy sync-context.js per EDD §5.
 
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+import { cliSync, artifactsSync, confirmFirstSetup } from '../lib/api.js';
 import type { CommandContext } from '../lib/context.js';
+import { resolveConflict, type ConflictOutcome } from '../lib/conflict.js';
+import { MysecondError } from '../lib/errors.js';
+import {
+  projectPaths,
+  readLocalFile,
+  shortHash,
+  writeLocalFile,
+  deleteLocalFile,
+} from '../lib/files.js';
+import { markNpmUpdated, shouldRunNpmUpdate } from '../lib/npm.js';
+import {
+  ARTIFACT_DIRS,
+  type ArtifactPayload,
+  type CompanionFile,
+  type ContextFile,
+} from '../lib/payload.js';
+import { readSyncState, writeSyncState, type SyncState } from '../lib/sync-state.js';
 
-export async function runSync(_args: readonly string[], _ctx: CommandContext): Promise<number> {
-  process.stderr.write(
-    'mysecond sync: not yet implemented in v1.1.0. ' +
-      'Tracking in PR 4b — see specs/EDD-solo-phase-4-pmkit-cli.md §5.\n'
-  );
-  return 1;
+const TEAM_OVERRIDE_START = '<!-- TEAM_OVERRIDE:START -->';
+const TEAM_OVERRIDE_END = '<!-- TEAM_OVERRIDE:END -->';
+
+interface SyncSummary {
+  created: number;
+  updatedFromCloud: number;
+  keptLocal: number;
+  conflictsCloudKept: number;
+  conflictsLocalKept: number;
+  conflictsSkipped: number;
+  unchanged: number;
+  deleted: number;
+  skillsUpdated: number;
+  agentsUpdated: number;
+  workflowsUpdated: number;
+  artifactsPushed: number;
+  claudeMdUpdated: boolean;
+  npmUpdateRan: boolean;
+}
+
+function emptySummary(): SyncSummary {
+  return {
+    created: 0,
+    updatedFromCloud: 0,
+    keptLocal: 0,
+    conflictsCloudKept: 0,
+    conflictsLocalKept: 0,
+    conflictsSkipped: 0,
+    unchanged: 0,
+    deleted: 0,
+    skillsUpdated: 0,
+    agentsUpdated: 0,
+    workflowsUpdated: 0,
+    artifactsPushed: 0,
+    claudeMdUpdated: false,
+    npmUpdateRan: false,
+  };
+}
+
+function tally(summary: SyncSummary, outcome: ConflictOutcome): void {
+  switch (outcome.kind) {
+    case 'created':
+      summary.created++;
+      break;
+    case 'updated-from-cloud':
+      summary.updatedFromCloud++;
+      break;
+    case 'kept-local':
+      summary.keptLocal++;
+      break;
+    case 'conflict-cloud-kept':
+      summary.conflictsCloudKept++;
+      break;
+    case 'conflict-local-kept':
+      summary.conflictsLocalKept++;
+      break;
+    case 'conflict-skipped':
+      summary.conflictsSkipped++;
+      break;
+    case 'unchanged':
+      summary.unchanged++;
+      break;
+  }
+}
+
+function syncCompanionFile(baseDir: string, file: CompanionFile): boolean {
+  const local = readLocalFile(baseDir, file.file_path);
+  if (local === file.content) return false;
+  return writeLocalFile(baseDir, file.file_path, file.content);
+}
+
+function mergeClaudeMdOverride(claudeMdPath: string, override: string): void {
+  let base = '';
+  if (existsSync(claudeMdPath)) {
+    base = readFileSync(claudeMdPath, 'utf8');
+  }
+
+  const startIdx = base.indexOf(TEAM_OVERRIDE_START);
+  const endIdx = base.indexOf(TEAM_OVERRIDE_END);
+  const block = `${TEAM_OVERRIDE_START}\n${override}\n${TEAM_OVERRIDE_END}`;
+
+  let next: string;
+  if (startIdx !== -1 && endIdx !== -1) {
+    next = base.slice(0, startIdx) + block + base.slice(endIdx + TEAM_OVERRIDE_END.length);
+  } else {
+    let separator = '';
+    if (base.length > 0) {
+      separator = base.endsWith('\n') ? '\n' : '\n\n';
+    }
+    next = `${base}${separator}${block}\n`;
+  }
+
+  writeFileSync(claudeMdPath, next);
+}
+
+function scanArtifacts(rootDir: string): ArtifactPayload[] {
+  const found: ArtifactPayload[] = [];
+  for (const entry of ARTIFACT_DIRS) {
+    const dir = join(rootDir, entry.relativeDir);
+    if (!existsSync(dir)) continue;
+    walkArtifactDir(rootDir, dir, entry.type, found);
+  }
+  return found;
+}
+
+function walkArtifactDir(
+  rootDir: string,
+  currentDir: string,
+  artifactType: ArtifactPayload['artifact_type'],
+  results: ArtifactPayload[]
+): void {
+  const entries = readdirSync(currentDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      walkArtifactDir(rootDir, fullPath, artifactType, results);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+
+    const content = readFileSync(fullPath, 'utf8');
+    const relativePath = relative(rootDir, fullPath);
+    // Parent dir naming convention: YYYY-MM-DD-HHMM-<pm-name>
+    const parentDir = currentDir.split('/').pop() ?? '';
+    const pmNameMatch = parentDir.match(/^\d{4}-\d{2}-\d{2}-\d{4}-(.+)$/);
+    const pmName = pmNameMatch && pmNameMatch[1] !== undefined ? pmNameMatch[1] : null;
+    const skillSlug = entry.name
+      .replace(/^\d{4}-\d{2}-\d{2}-\d{4}-/, '')
+      .replace(/\.md$/, '');
+    results.push({
+      file_path: relativePath,
+      content,
+      current_hash: shortHash(content),
+      artifact_type: artifactType,
+      pm_name: pmName,
+      skill_slug: skillSlug.length > 0 ? skillSlug : null,
+      produced_at: new Date().toISOString(),
+    });
+  }
+}
+
+async function upSyncArtifacts(
+  ctx: CommandContext,
+  state: SyncState
+): Promise<number> {
+  const artifacts = scanArtifacts(ctx.rootDir);
+  const toSync = artifacts.filter((a) => {
+    const last = state.artifacts[a.file_path];
+    return !last || last.hash !== a.current_hash;
+  });
+  if (toSync.length === 0) return 0;
+
+  const result = await artifactsSync(ctx, toSync);
+  if (result.synced > 0) {
+    const now = new Date().toISOString();
+    for (const a of toSync) {
+      state.artifacts[a.file_path] = { hash: a.current_hash, pushedAt: now };
+    }
+  }
+  return result.synced;
+}
+
+function printSummary(summary: SyncSummary, ctx: CommandContext): void {
+  if (ctx.silent) {
+    const parts: string[] = [];
+    const contextChanges =
+      summary.created + summary.updatedFromCloud + summary.conflictsCloudKept;
+    if (contextChanges > 0) parts.push(`${contextChanges} context updates`);
+    if (summary.skillsUpdated > 0) parts.push(`${summary.skillsUpdated} skills`);
+    if (summary.agentsUpdated > 0) parts.push(`${summary.agentsUpdated} agents`);
+    if (summary.workflowsUpdated > 0) parts.push(`${summary.workflowsUpdated} workflows`);
+    if (summary.artifactsPushed > 0) parts.push(`${summary.artifactsPushed} artifacts pushed`);
+    const conflicts =
+      summary.conflictsCloudKept + summary.conflictsLocalKept + summary.conflictsSkipped;
+    if (conflicts > 0) parts.push(`${conflicts} conflicts`);
+    if (parts.length > 0) {
+      process.stdout.write(`mysecond: ${parts.join(', ')}\n`);
+    }
+    return;
+  }
+
+  const parts: string[] = [];
+  if (summary.created) parts.push(`${summary.created} new`);
+  if (summary.updatedFromCloud) parts.push(`${summary.updatedFromCloud} updated`);
+  const conflicts =
+    summary.conflictsCloudKept + summary.conflictsLocalKept + summary.conflictsSkipped;
+  if (conflicts) parts.push(`${conflicts} conflicts handled`);
+  if (summary.deleted) parts.push(`${summary.deleted} removed`);
+  if (summary.unchanged) parts.push(`${summary.unchanged} unchanged`);
+  if (summary.skillsUpdated) parts.push(`${summary.skillsUpdated} skills`);
+  if (summary.agentsUpdated) parts.push(`${summary.agentsUpdated} agents`);
+  if (summary.workflowsUpdated) parts.push(`${summary.workflowsUpdated} workflows`);
+  if (summary.artifactsPushed) parts.push(`${summary.artifactsPushed} artifacts pushed`);
+  if (summary.claudeMdUpdated) parts.push('CLAUDE.md updated');
+  if (parts.length === 0) parts.push('nothing changed');
+
+  process.stdout.write(`✓ Sync complete: ${parts.join(', ')}.\n`);
+  if (summary.conflictsCloudKept > 0 || summary.conflictsLocalKept > 0) {
+    process.stdout.write(
+      `  Recover backed-up versions from .claude/sync-conflicts/ if needed.\n`
+    );
+  }
+}
+
+export async function runSync(
+  _args: readonly string[],
+  ctx: CommandContext
+): Promise<number> {
+  if (ctx.apiKey.length === 0) {
+    throw MysecondError.invalidApiKey('COMPANION_API_KEY not set');
+  }
+
+  const summary = emptySummary();
+  const state = readSyncState(ctx.rootDir);
+  const previousPaths = Object.keys(state.files);
+
+  const response = await cliSync(ctx, previousPaths);
+  const contextFiles: ContextFile[] = response.context_files ?? response.files ?? [];
+  const customSkills = response.custom_skills ?? [];
+  const customAgents = response.custom_agents ?? [];
+  const customWorkflows = response.custom_workflows ?? [];
+  const claudeMdOverride = response.claude_md_override ?? null;
+  const deletedPaths = response.deleted_paths ?? [];
+
+  const paths = projectPaths(ctx.rootDir);
+
+  // Down-sync context files — conflict detection per src/lib/conflict.ts.
+  for (const file of contextFiles) {
+    const localContent = readLocalFile(paths.contextDir, file.file_path);
+    const outcome = resolveConflict({ file, localContent, syncState: state, ctx });
+    tally(summary, outcome);
+  }
+
+  // Deletions — cloud says these no longer apply; remove locally if present.
+  for (const filePath of deletedPaths) {
+    if (deleteLocalFile(paths.contextDir, filePath)) {
+      delete state.files[filePath];
+      summary.deleted++;
+    }
+  }
+
+  // Companion-wins for skills / agents / workflows. No conflict detection — these
+  // are owned by the server and customers should never edit the bundled files.
+  for (const file of customSkills) {
+    if (syncCompanionFile(paths.skillsDir, file)) summary.skillsUpdated++;
+  }
+  for (const file of customAgents) {
+    if (syncCompanionFile(paths.agentsDir, file)) summary.agentsUpdated++;
+  }
+  for (const file of customWorkflows) {
+    if (syncCompanionFile(paths.workflowsDir, file)) summary.workflowsUpdated++;
+  }
+
+  if (claudeMdOverride) {
+    mergeClaudeMdOverride(paths.claudeMdPath, claudeMdOverride);
+    summary.claudeMdUpdated = true;
+  }
+
+  // Up-sync artifacts (best-effort — failure is non-fatal so the down-sync still
+  // succeeds for the customer).
+  try {
+    summary.artifactsPushed = await upSyncArtifacts(ctx, state);
+  } catch (err) {
+    if (!ctx.silent) {
+      process.stderr.write(
+        `mysecond: artifact up-sync failed (${err instanceof Error ? err.message : String(err)}). Down-sync OK.\n`
+      );
+    }
+  }
+
+  // 24h npm-update timebox — gate is honored, actual `npm update` lands in a
+  // future PR once the customer plugin slug is provisioned by `mysecond init`.
+  if (shouldRunNpmUpdate(state, ctx)) {
+    markNpmUpdated(state);
+    summary.npmUpdateRan = true;
+  }
+
+  // Persist updated state. lastSyncedAt comes from the server response so the
+  // CLI's clock skew can't drift the ledger.
+  state.lastSyncedAt = response.syncedAt;
+  writeSyncState(ctx.rootDir, state);
+
+  // First-sync confirmation — fire-and-forget; failure doesn't impact the user.
+  const wasFirstSync =
+    state.lastSyncedAt !== null && Object.keys(state.files).length > 0 && previousPaths.length === 0;
+  if (wasFirstSync) {
+    await confirmFirstSetup(ctx);
+  }
+
+  printSummary(summary, ctx);
+  return 0;
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,13 +1,15 @@
 // `mysecond sync` — pull the latest context, skills, and agents from mysecond.ai.
 //
-// Stub for v1.1.0 scaffold. Real implementation lands in PR 4b per
+// Stub for v1.1.0 scaffold. Real implementation lands later in PR 4b per
 // EDD-solo-phase-4-pmkit-cli.md §5 (port of sync-context.js with debounce,
 // safePath hardening, and Solo payload extensions).
 //
 // Reference: legacy v1.0.0 sync command (preserved in git history at commit 4d281e0)
-// shows the debounce + safePath patterns that PR 4b will port forward.
+// shows the debounce + safePath patterns that the port will preserve.
 
-export async function runSync(_args: readonly string[]): Promise<number> {
+import type { CommandContext } from '../lib/context.js';
+
+export async function runSync(_args: readonly string[], _ctx: CommandContext): Promise<number> {
   process.stderr.write(
     'mysecond sync: not yet implemented in v1.1.0. ' +
       'Tracking in PR 4b — see specs/EDD-solo-phase-4-pmkit-cli.md §5.\n'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,10 @@
-// @mysecond/cli — entry point.
-//
-// Dispatches to subcommand stubs. Real implementations land in:
-//   - PR 4b: `mysecond sync` + `mysecond artifact-sync`
-//   - PR 4c: `mysecond init`
-//
-// This v1.1.0 scaffold ships with stubs that exit cleanly with a "not yet implemented"
-// message so the binary's shape (registry, --help, --version, unknown-subcommand) can be
-// verified before the real command logic lands.
+// @mysecond/cli — entry point. Parses global flags, builds CommandContext, dispatches.
 
 import { runInit } from './commands/init.js';
 import { runSync } from './commands/sync.js';
 import { runArtifactSync } from './commands/artifact-sync.js';
 import { buildContext, parseGlobalFlags, type CommandContext } from './lib/context.js';
-import { exitFromError, MysecondError } from './lib/errors.js';
+import { exitFromError } from './lib/errors.js';
 
 declare const __VERSION__: string;
 
@@ -88,20 +80,11 @@ export async function main(argv: readonly string[]): Promise<number> {
     return 1;
   }
 
-  // Parse global flags from the subcommand's args (everything after the subcommand name).
-  // Unknown flags fall through to positional args, which subcommands inspect themselves.
-  let ctx: CommandContext;
   try {
     const flags = parseGlobalFlags(args.slice(1));
-    ctx = buildContext(flags);
+    const ctx = buildContext(flags);
     return await match.run(flags.positional, ctx);
   } catch (err) {
-    // parseGlobalFlags throws Error (not MysecondError) for malformed flag values —
-    // treat as user-input error (exit 1) with the original message.
-    if (err instanceof Error && !(err instanceof MysecondError)) {
-      process.stderr.write(`mysecond: ${err.message}\n`);
-      return 1;
-    }
     return exitFromError(err);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,13 +11,15 @@
 import { runInit } from './commands/init.js';
 import { runSync } from './commands/sync.js';
 import { runArtifactSync } from './commands/artifact-sync.js';
+import { buildContext, parseGlobalFlags, type CommandContext } from './lib/context.js';
+import { exitFromError, MysecondError } from './lib/errors.js';
 
 declare const __VERSION__: string;
 
 interface Subcommand {
   name: string;
   summary: string;
-  run: (args: string[]) => Promise<number>;
+  run: (args: string[], ctx: CommandContext) => Promise<number>;
 }
 
 const SUBCOMMANDS: readonly Subcommand[] = [
@@ -49,8 +51,14 @@ function printHelp(): void {
     ...SUBCOMMANDS.map((cmd) => `  ${cmd.name.padEnd(15)}${cmd.summary}`),
     '',
     'Options:',
-    '  --version, -v    Print version and exit',
-    '  --help, -h       Print this help and exit',
+    '  --version, -v          Print version and exit',
+    '  --help, -h             Print this help and exit',
+    '  --silent               Suppress non-essential output (used by hooks)',
+    '  --dry-run              Show what would happen, make no changes',
+    '  --api-key <key>        Override COMPANION_API_KEY env',
+    '  --project-dir <path>   Override $CLAUDE_PROJECT_DIR / cwd',
+    '  --strategy <mode>      Conflict resolution: prompt | cloud-wins | local-wins | skip',
+    '  --force-update         Bypass the 24-hour npm-update timebox in sync',
     '',
     'Docs: https://mysecond.ai',
   ];
@@ -80,15 +88,25 @@ export async function main(argv: readonly string[]): Promise<number> {
     return 1;
   }
 
-  return match.run(args.slice(1));
+  // Parse global flags from the subcommand's args (everything after the subcommand name).
+  // Unknown flags fall through to positional args, which subcommands inspect themselves.
+  let ctx: CommandContext;
+  try {
+    const flags = parseGlobalFlags(args.slice(1));
+    ctx = buildContext(flags);
+    return await match.run(flags.positional, ctx);
+  } catch (err) {
+    // parseGlobalFlags throws Error (not MysecondError) for malformed flag values —
+    // treat as user-input error (exit 1) with the original message.
+    if (err instanceof Error && !(err instanceof MysecondError)) {
+      process.stderr.write(`mysecond: ${err.message}\n`);
+      return 1;
+    }
+    return exitFromError(err);
+  }
 }
 
 main(process.argv).then(
   (code) => process.exit(code),
-  (err) => {
-    // TODO PR 4b: introduce MysecondError class with exitCode field per EDD §8.1
-    // (13 distinct exit values). Right now any unexpected throw collapses to exit 1.
-    process.stderr.write(`mysecond: unexpected error: ${err && err.stack ? err.stack : err}\n`);
-    process.exit(1);
-  }
+  (err) => process.exit(exitFromError(err))
 );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,133 @@
+// HTTP client wrappers for the mysecond-app companion API.
+//
+// All calls use Node 18+ native fetch (no node-fetch dep). Authentication via
+// Bearer token from CommandContext.apiKey. Network errors and non-2xx responses
+// raise typed MysecondError values so callers don't need to inspect HTTP shape.
+
+import type { CommandContext } from './context.js';
+import { MysecondError } from './errors.js';
+import type {
+  ArtifactPayload,
+  ArtifactsResponse,
+  CliSyncResponse,
+} from './payload.js';
+
+interface FetchOptions {
+  method?: 'GET' | 'POST';
+  body?: unknown;
+  query?: Record<string, string | undefined>;
+  // Reject the request if it doesn't complete within this many milliseconds.
+  // Default 30s — long enough for slow networks; short enough to keep
+  // SessionStart hooks from blocking session start.
+  timeoutMs?: number;
+}
+
+interface ApiResponse {
+  status: number;
+  body: unknown;
+}
+
+// Shared low-level fetch — handles timeout, JSON encode/decode, network-error
+// translation. Throws MysecondError on network failure; returns { status, body }
+// for any HTTP status (callers branch on status themselves).
+async function companionFetch(
+  ctx: CommandContext,
+  path: string,
+  opts: FetchOptions = {}
+): Promise<ApiResponse> {
+  const url = new URL(path, ctx.apiBase);
+  if (opts.query) {
+    for (const [key, value] of Object.entries(opts.query)) {
+      if (value !== undefined) url.searchParams.set(key, value);
+    }
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), opts.timeoutMs ?? 30_000);
+
+  try {
+    const response = await fetch(url, {
+      method: opts.method ?? 'GET',
+      headers: {
+        Authorization: `Bearer ${ctx.apiKey}`,
+        ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+      signal: controller.signal,
+    });
+
+    let body: unknown = null;
+    const text = await response.text();
+    if (text.length > 0) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text;
+      }
+    }
+    return { status: response.status, body };
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw MysecondError.networkUnreachable(`request to ${path} timed out`);
+    }
+    throw MysecondError.networkUnreachable(
+      err instanceof Error ? err.message : String(err)
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// GET /api/companion/cli-sync — pull context_files, custom_skills, custom_agents,
+// custom_workflows, claude_md_override, deleted_paths.
+export async function cliSync(
+  ctx: CommandContext,
+  previousPaths: readonly string[]
+): Promise<CliSyncResponse> {
+  const query: Record<string, string | undefined> = {};
+  if (previousPaths.length > 0) {
+    query['previous_paths'] = previousPaths.join(',');
+  }
+  const response = await companionFetch(ctx, '/api/companion/cli-sync', { query });
+
+  if (response.status === 401 || response.status === 403) {
+    throw MysecondError.invalidApiKey(`HTTP ${response.status}`);
+  }
+  if (response.status >= 400) {
+    throw new MysecondError(
+      1,
+      `cli-sync failed (HTTP ${response.status}). Run \`mysecond sync\` to retry.`
+    );
+  }
+  return response.body as CliSyncResponse;
+}
+
+// POST /api/companion/artifacts — up-sync artifact files.
+export async function artifactsSync(
+  ctx: CommandContext,
+  artifacts: readonly ArtifactPayload[]
+): Promise<ArtifactsResponse> {
+  if (artifacts.length === 0) return { synced: 0 };
+  const response = await companionFetch(ctx, '/api/companion/artifacts', {
+    method: 'POST',
+    body: { artifacts },
+  });
+  if (response.status >= 400) {
+    // Up-sync failure is non-fatal — the legacy code logs and moves on so the
+    // down-sync result still reaches the customer. Match that contract by
+    // returning synced: 0 and letting the caller decide whether to surface.
+    return { synced: 0 };
+  }
+  return response.body as ArtifactsResponse;
+}
+
+// POST /api/setup/confirm — first-sync confirmation. Best-effort; non-critical
+// if it fails (web app reconciles on next poll). Returns boolean for telemetry.
+export async function confirmFirstSetup(ctx: CommandContext): Promise<boolean> {
+  try {
+    const response = await companionFetch(ctx, '/api/setup/confirm', { method: 'POST' });
+    return response.status < 400;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,5 @@
 // HTTP client wrappers for the mysecond-app companion API.
-//
-// All calls use Node 18+ native fetch (no node-fetch dep). Authentication via
-// Bearer token from CommandContext.apiKey. Network errors and non-2xx responses
-// raise typed MysecondError values so callers don't need to inspect HTTP shape.
+// Native Node 18+ fetch + Bearer auth from CommandContext.
 
 import type { CommandContext } from './context.js';
 import { MysecondError } from './errors.js';
@@ -16,25 +13,16 @@ interface FetchOptions {
   method?: 'GET' | 'POST';
   body?: unknown;
   query?: Record<string, string | undefined>;
-  // Reject the request if it doesn't complete within this many milliseconds.
-  // Default 30s — long enough for slow networks; short enough to keep
-  // SessionStart hooks from blocking session start.
+  // Default 30s. Callers on hot paths (SessionStart) pass a shorter value to
+  // avoid blocking the customer's session start on a slow network.
   timeoutMs?: number;
 }
 
-interface ApiResponse {
-  status: number;
-  body: unknown;
-}
-
-// Shared low-level fetch — handles timeout, JSON encode/decode, network-error
-// translation. Throws MysecondError on network failure; returns { status, body }
-// for any HTTP status (callers branch on status themselves).
 async function companionFetch(
   ctx: CommandContext,
   path: string,
   opts: FetchOptions = {}
-): Promise<ApiResponse> {
+): Promise<{ status: number; body: unknown }> {
   const url = new URL(path, ctx.apiBase);
   if (opts.query) {
     for (const [key, value] of Object.entries(opts.query)) {
@@ -42,8 +30,9 @@ async function companionFetch(
     }
   }
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), opts.timeoutMs ?? 30_000);
+  // Node 18.17+ AbortSignal.timeout — replaces manual AbortController + setTimeout.
+  // On timeout, the fetch rejects with a TimeoutError (name === 'TimeoutError').
+  const signal = AbortSignal.timeout(opts.timeoutMs ?? 30_000);
 
   try {
     const response = await fetch(url, {
@@ -53,7 +42,7 @@ async function companionFetch(
         ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
       },
       body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
-      signal: controller.signal,
+      signal,
     });
 
     let body: unknown = null;
@@ -67,14 +56,12 @@ async function companionFetch(
     }
     return { status: response.status, body };
   } catch (err) {
-    if (err instanceof Error && err.name === 'AbortError') {
+    if (err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError')) {
       throw MysecondError.networkUnreachable(`request to ${path} timed out`);
     }
     throw MysecondError.networkUnreachable(
       err instanceof Error ? err.message : String(err)
     );
-  } finally {
-    clearTimeout(timeout);
   }
 }
 
@@ -82,13 +69,17 @@ async function companionFetch(
 // custom_workflows, claude_md_override, deleted_paths.
 export async function cliSync(
   ctx: CommandContext,
-  previousPaths: readonly string[]
+  previousPaths: readonly string[],
+  opts: { timeoutMs?: number } = {}
 ): Promise<CliSyncResponse> {
   const query: Record<string, string | undefined> = {};
   if (previousPaths.length > 0) {
     query['previous_paths'] = previousPaths.join(',');
   }
-  const response = await companionFetch(ctx, '/api/companion/cli-sync', { query });
+  const response = await companionFetch(ctx, '/api/companion/cli-sync', {
+    query,
+    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
+  });
 
   if (response.status === 401 || response.status === 403) {
     throw MysecondError.invalidApiKey(`HTTP ${response.status}`);
@@ -102,7 +93,9 @@ export async function cliSync(
   return response.body as CliSyncResponse;
 }
 
-// POST /api/companion/artifacts — up-sync artifact files.
+// POST /api/companion/artifacts — up-sync artifact files. Up-sync failure is
+// non-fatal: the down-sync result still reaches the customer. Caller decides
+// whether to surface the partial-success.
 export async function artifactsSync(
   ctx: CommandContext,
   artifacts: readonly ArtifactPayload[]
@@ -113,16 +106,13 @@ export async function artifactsSync(
     body: { artifacts },
   });
   if (response.status >= 400) {
-    // Up-sync failure is non-fatal — the legacy code logs and moves on so the
-    // down-sync result still reaches the customer. Match that contract by
-    // returning synced: 0 and letting the caller decide whether to surface.
     return { synced: 0 };
   }
   return response.body as ArtifactsResponse;
 }
 
 // POST /api/setup/confirm — first-sync confirmation. Best-effort; non-critical
-// if it fails (web app reconciles on next poll). Returns boolean for telemetry.
+// if it fails (web app reconciles on next poll).
 export async function confirmFirstSetup(ctx: CommandContext): Promise<boolean> {
   try {
     const response = await companionFetch(ctx, '/api/setup/confirm', { method: 'POST' });

--- a/src/lib/conflict.ts
+++ b/src/lib/conflict.ts
@@ -1,0 +1,173 @@
+// Conflict resolution for context files — minimum safety net (Option 1).
+//
+// Per Ron + CXO call (PR 4b design session 2026-04-22): when both local and cloud
+// versions of a context file have changed since last sync, take the cloud version
+// and write a timestamped backup of the local version so the customer can recover
+// it manually. Emit a single stderr line. No interactive prompt by default.
+//
+// Solo conflicts are rare (0-2x/month per customer). Heavier UX (interactive
+// strategy flag, recent-conflicts log file, CLAUDE.md @import surface) deferred
+// until Team tier or until customer feedback demands it.
+//
+// The --strategy flag (parsed in src/lib/context.ts) gives advanced users an
+// override: prompt | cloud-wins | local-wins | skip. The default is set by
+// buildContext() based on TTY detection.
+
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { CommandContext } from './context.js';
+import { projectPaths, sha256, writeLocalFile } from './files.js';
+import type { ContextFile } from './payload.js';
+import type { SyncState } from './sync-state.js';
+
+export type ConflictOutcome =
+  | { kind: 'unchanged' }
+  | { kind: 'created'; writtenPath: string }
+  | { kind: 'updated-from-cloud'; writtenPath: string }
+  | { kind: 'kept-local' }
+  | { kind: 'conflict-cloud-kept'; writtenPath: string; backupPath: string }
+  | { kind: 'conflict-local-kept'; backupPath: string }
+  | { kind: 'conflict-skipped' };
+
+interface SyncContextFileInput {
+  file: ContextFile;
+  localContent: string | null;
+  syncState: SyncState;
+  ctx: CommandContext;
+}
+
+// Pure conflict classifier — no I/O. Decides the resolution path based on what
+// changed since last sync. Caller does the actual writes.
+export function classifyConflict(input: SyncContextFileInput): {
+  cloudChanged: boolean;
+  localChanged: boolean;
+  isFirstSeen: boolean;
+} {
+  const { file, localContent, syncState } = input;
+  const lastSynced = syncState.files[file.file_path];
+
+  if (localContent === null) {
+    return { cloudChanged: true, localChanged: false, isFirstSeen: true };
+  }
+  if (!lastSynced) {
+    // First sync after the file already existed locally. Treat byte-equal as
+    // "in sync"; otherwise the divergence is a conflict.
+    const sameBytes = localContent === file.content;
+    return { cloudChanged: !sameBytes, localChanged: !sameBytes, isFirstSeen: true };
+  }
+
+  const localHash = sha256(localContent);
+  return {
+    cloudChanged: file.current_hash !== lastSynced.cloudHash,
+    localChanged: localHash !== lastSynced.localHash,
+    isFirstSeen: false,
+  };
+}
+
+// Resolve a conflict according to ctx.strategy. Writes any backup files needed
+// and returns the outcome for the caller to summarize.
+export function resolveConflict(input: SyncContextFileInput): ConflictOutcome {
+  const { file, localContent, syncState, ctx } = input;
+  const { contextDir, conflictsDir } = projectPaths(ctx.rootDir);
+  const lastSynced = syncState.files[file.file_path];
+  const nowIso = new Date().toISOString();
+
+  // Branch 1: local doesn't exist — pure create from cloud.
+  if (localContent === null) {
+    const ok = writeLocalFile(contextDir, file.file_path, file.content);
+    if (!ok) return { kind: 'conflict-skipped' };
+    syncState.files[file.file_path] = {
+      localHash: sha256(file.content),
+      cloudHash: file.current_hash,
+      lastSyncedAt: nowIso,
+    };
+    return { kind: 'created', writtenPath: file.file_path };
+  }
+
+  const { cloudChanged, localChanged, isFirstSeen } = classifyConflict(input);
+
+  // Branch 2: nothing diverged — record current hashes and move on.
+  if (!cloudChanged && !localChanged) {
+    if (!lastSynced) {
+      syncState.files[file.file_path] = {
+        localHash: sha256(localContent),
+        cloudHash: file.current_hash,
+        lastSyncedAt: nowIso,
+      };
+    }
+    return { kind: 'unchanged' };
+  }
+
+  // Branch 3: only cloud changed — pull cloud over local.
+  if (cloudChanged && !localChanged) {
+    const ok = writeLocalFile(contextDir, file.file_path, file.content);
+    if (!ok) return { kind: 'conflict-skipped' };
+    syncState.files[file.file_path] = {
+      localHash: sha256(file.content),
+      cloudHash: file.current_hash,
+      lastSyncedAt: nowIso,
+    };
+    return { kind: 'updated-from-cloud', writtenPath: file.file_path };
+  }
+
+  // Branch 4: only local changed — keep local; record so future syncs see this
+  // as the new baseline. Cloud version remains stale on the server (legacy
+  // architecture: context files don't push up via this path).
+  if (localChanged && !cloudChanged) {
+    syncState.files[file.file_path] = {
+      localHash: sha256(localContent),
+      cloudHash: file.current_hash,
+      lastSyncedAt: nowIso,
+    };
+    return { kind: 'kept-local' };
+  }
+
+  // Branch 5: both changed (or first-seen with divergent bytes) — real conflict.
+  // Apply the strategy. For Option 1 minimum safety net, "cloud-wins" is the
+  // default for non-TTY surfaces; backups always written either way.
+  const safeName = file.file_path.replace(/[^A-Za-z0-9._-]+/g, '_');
+  const stamp = nowIso.replace(/[:.]/g, '-');
+  mkdirSync(conflictsDir, { recursive: true });
+
+  if (ctx.strategy === 'skip' || (ctx.strategy === 'prompt' && isFirstSeen && ctx.silent)) {
+    // Skip resolution but still record the cloud version so the customer can
+    // diff manually if they care.
+    const cloudBackup = join(conflictsDir, `${safeName}-cloud-${stamp}.md`);
+    writeLocalFile(conflictsDir, `${safeName}-cloud-${stamp}.md`, file.content);
+    process.stderr.write(
+      `Conflict in context/${file.file_path} — skipped. Cloud version saved to ${cloudBackup}\n`
+    );
+    return { kind: 'conflict-skipped' };
+  }
+
+  if (ctx.strategy === 'local-wins') {
+    const cloudBackup = join(conflictsDir, `${safeName}-cloud-${stamp}.md`);
+    writeLocalFile(conflictsDir, `${safeName}-cloud-${stamp}.md`, file.content);
+    syncState.files[file.file_path] = {
+      localHash: sha256(localContent),
+      cloudHash: file.current_hash,
+      lastSyncedAt: nowIso,
+    };
+    process.stderr.write(
+      `Conflict in context/${file.file_path} — kept local. Cloud version saved to ${cloudBackup}\n`
+    );
+    return { kind: 'conflict-local-kept', backupPath: cloudBackup };
+  }
+
+  // Default + cloud-wins + non-interactive prompt fallback: take cloud, back up
+  // local. This is the Option 1 minimum safety net path most customers hit.
+  const localBackup = join(conflictsDir, `${safeName}-local-${stamp}.md`);
+  writeLocalFile(conflictsDir, `${safeName}-local-${stamp}.md`, localContent);
+  const ok = writeLocalFile(contextDir, file.file_path, file.content);
+  if (!ok) return { kind: 'conflict-skipped' };
+  syncState.files[file.file_path] = {
+    localHash: sha256(file.content),
+    cloudHash: file.current_hash,
+    lastSyncedAt: nowIso,
+  };
+  process.stderr.write(
+    `Conflict in context/${file.file_path} — kept cloud version (your local edits saved to ${localBackup})\n`
+  );
+  return { kind: 'conflict-cloud-kept', writtenPath: file.file_path, backupPath: localBackup };
+}

--- a/src/lib/conflict.ts
+++ b/src/lib/conflict.ts
@@ -1,17 +1,14 @@
-// Conflict resolution for context files — minimum safety net (Option 1).
+// Conflict resolution for context files — minimum safety net (Option 1 per
+// Ron + CXO 2026-04-22 design call). When local and cloud both diverged since
+// last sync: pick a side per ctx.strategy, write a timestamped backup of the
+// loser, emit one notification line. Solo conflicts are 0-2x/month per
+// customer; heavier UX (interactive prompt protocol, RECENT.md log surface,
+// CLAUDE.md @import breadcrumb) deferred until customer feedback demands it.
 //
-// Per Ron + CXO call (PR 4b design session 2026-04-22): when both local and cloud
-// versions of a context file have changed since last sync, take the cloud version
-// and write a timestamped backup of the local version so the customer can recover
-// it manually. Emit a single stderr line. No interactive prompt by default.
-//
-// Solo conflicts are rare (0-2x/month per customer). Heavier UX (interactive
-// strategy flag, recent-conflicts log file, CLAUDE.md @import surface) deferred
-// until Team tier or until customer feedback demands it.
-//
-// The --strategy flag (parsed in src/lib/context.ts) gives advanced users an
-// override: prompt | cloud-wins | local-wins | skip. The default is set by
-// buildContext() based on TTY detection.
+// CAIO finding (PR 4b review): stderr from SessionStart hooks is silently
+// dropped on exit 0. Conflict notifications must go to STDOUT in --silent mode
+// so Claude sees them as session-start context and can mention them to the
+// customer. TTY (terminal) keeps stderr where it's visible directly.
 
 import { mkdirSync } from 'node:fs';
 import { join } from 'node:path';
@@ -37,13 +34,13 @@ interface SyncContextFileInput {
   ctx: CommandContext;
 }
 
-// Pure conflict classifier — no I/O. Decides the resolution path based on what
-// changed since last sync. Caller does the actual writes.
-export function classifyConflict(input: SyncContextFileInput): {
+interface ChangeFlags {
   cloudChanged: boolean;
   localChanged: boolean;
   isFirstSeen: boolean;
-} {
+}
+
+function classifyConflict(input: SyncContextFileInput): ChangeFlags {
   const { file, localContent, syncState } = input;
   const lastSynced = syncState.files[file.file_path];
 
@@ -52,7 +49,10 @@ export function classifyConflict(input: SyncContextFileInput): {
   }
   if (!lastSynced) {
     // First sync after the file already existed locally. Treat byte-equal as
-    // "in sync"; otherwise the divergence is a conflict.
+    // "in sync"; otherwise flag both sides as changed so it falls into the
+    // conflict path. The asymmetric assignment (both true OR both false from
+    // a single sameBytes check) is intentional — we have no baseline to
+    // distinguish which side moved, so we treat any divergence as a conflict.
     const sameBytes = localContent === file.content;
     return { cloudChanged: !sameBytes, localChanged: !sameBytes, isFirstSeen: true };
   }
@@ -65,78 +65,79 @@ export function classifyConflict(input: SyncContextFileInput): {
   };
 }
 
-// Resolve a conflict according to ctx.strategy. Writes any backup files needed
-// and returns the outcome for the caller to summarize.
+function recordSyncedFile(
+  state: SyncState,
+  filePath: string,
+  localContent: string,
+  cloudHash: string,
+  nowIso: string
+): void {
+  state.files[filePath] = {
+    localHash: sha256(localContent),
+    cloudHash,
+    lastSyncedAt: nowIso,
+  };
+}
+
+function emitNotice(message: string, ctx: CommandContext): void {
+  // CAIO: stdout in silent mode (SessionStart hook) so Claude reads it as
+  // session-start context. Stderr in TTY mode where the customer sees it.
+  const stream = ctx.silent ? process.stdout : process.stderr;
+  stream.write(message + '\n');
+}
+
 export function resolveConflict(input: SyncContextFileInput): ConflictOutcome {
   const { file, localContent, syncState, ctx } = input;
   const { contextDir, conflictsDir } = projectPaths(ctx.rootDir);
-  const lastSynced = syncState.files[file.file_path];
   const nowIso = new Date().toISOString();
 
-  // Branch 1: local doesn't exist — pure create from cloud.
   if (localContent === null) {
     const ok = writeLocalFile(contextDir, file.file_path, file.content);
     if (!ok) return { kind: 'conflict-skipped' };
-    syncState.files[file.file_path] = {
-      localHash: sha256(file.content),
-      cloudHash: file.current_hash,
-      lastSyncedAt: nowIso,
-    };
+    recordSyncedFile(syncState, file.file_path, file.content, file.current_hash, nowIso);
     return { kind: 'created', writtenPath: file.file_path };
   }
 
   const { cloudChanged, localChanged, isFirstSeen } = classifyConflict(input);
 
-  // Branch 2: nothing diverged — record current hashes and move on.
   if (!cloudChanged && !localChanged) {
-    if (!lastSynced) {
-      syncState.files[file.file_path] = {
-        localHash: sha256(localContent),
-        cloudHash: file.current_hash,
-        lastSyncedAt: nowIso,
-      };
+    if (!syncState.files[file.file_path]) {
+      recordSyncedFile(syncState, file.file_path, localContent, file.current_hash, nowIso);
     }
     return { kind: 'unchanged' };
   }
 
-  // Branch 3: only cloud changed — pull cloud over local.
   if (cloudChanged && !localChanged) {
     const ok = writeLocalFile(contextDir, file.file_path, file.content);
     if (!ok) return { kind: 'conflict-skipped' };
-    syncState.files[file.file_path] = {
-      localHash: sha256(file.content),
-      cloudHash: file.current_hash,
-      lastSyncedAt: nowIso,
-    };
+    recordSyncedFile(syncState, file.file_path, file.content, file.current_hash, nowIso);
     return { kind: 'updated-from-cloud', writtenPath: file.file_path };
   }
 
-  // Branch 4: only local changed — keep local; record so future syncs see this
-  // as the new baseline. Cloud version remains stale on the server (legacy
-  // architecture: context files don't push up via this path).
   if (localChanged && !cloudChanged) {
-    syncState.files[file.file_path] = {
-      localHash: sha256(localContent),
-      cloudHash: file.current_hash,
-      lastSyncedAt: nowIso,
-    };
+    recordSyncedFile(syncState, file.file_path, localContent, file.current_hash, nowIso);
     return { kind: 'kept-local' };
   }
 
-  // Branch 5: both changed (or first-seen with divergent bytes) — real conflict.
-  // Apply the strategy. For Option 1 minimum safety net, "cloud-wins" is the
-  // default for non-TTY surfaces; backups always written either way.
+  // Real conflict — both sides moved. Write backup, apply chosen side per
+  // strategy, emit notification. Backup naming uses path-safe characters so
+  // file_paths with slashes/dots produce a single readable filename.
   const safeName = file.file_path.replace(/[^A-Za-z0-9._-]+/g, '_');
   const stamp = nowIso.replace(/[:.]/g, '-');
   mkdirSync(conflictsDir, { recursive: true });
 
+  // Edge case (CTO finding): in --silent mode, ctx.strategy defaults to
+  // cloud-wins via buildContext, so this branch only fires when the customer
+  // explicitly passed --strategy=prompt (unusual in a hook context). On a
+  // brand-new install isFirstSeen is true for every file — a real conflict
+  // there gets silently skipped rather than auto-resolved. Acceptable given
+  // 0-2 conflicts/month, but documented so a future dev doesn't "fix" it.
   if (ctx.strategy === 'skip' || (ctx.strategy === 'prompt' && isFirstSeen && ctx.silent)) {
-    // Skip resolution but still record the cloud version so the customer can
-    // diff manually if they care.
     const cloudBackup = join(conflictsDir, `${safeName}-cloud-${stamp}.md`);
     writeLocalFile(conflictsDir, `${safeName}-cloud-${stamp}.md`, file.content);
-    process.stderr.write(
-      `Conflict in context/${file.file_path} — skipped. Cloud version saved to ${cloudBackup}\n`
+    emitNotice(
+      `Conflict in context/${file.file_path} — skipped. Cloud version saved to ${cloudBackup}`,
+      ctx
     );
     return { kind: 'conflict-skipped' };
   }
@@ -144,30 +145,24 @@ export function resolveConflict(input: SyncContextFileInput): ConflictOutcome {
   if (ctx.strategy === 'local-wins') {
     const cloudBackup = join(conflictsDir, `${safeName}-cloud-${stamp}.md`);
     writeLocalFile(conflictsDir, `${safeName}-cloud-${stamp}.md`, file.content);
-    syncState.files[file.file_path] = {
-      localHash: sha256(localContent),
-      cloudHash: file.current_hash,
-      lastSyncedAt: nowIso,
-    };
-    process.stderr.write(
-      `Conflict in context/${file.file_path} — kept local. Cloud version saved to ${cloudBackup}\n`
+    recordSyncedFile(syncState, file.file_path, localContent, file.current_hash, nowIso);
+    emitNotice(
+      `Conflict in context/${file.file_path} — kept local. Cloud version saved to ${cloudBackup}`,
+      ctx
     );
     return { kind: 'conflict-local-kept', backupPath: cloudBackup };
   }
 
-  // Default + cloud-wins + non-interactive prompt fallback: take cloud, back up
-  // local. This is the Option 1 minimum safety net path most customers hit.
+  // Default + cloud-wins + non-interactive prompt fallback: take cloud, back
+  // up local. Most customers hit this path.
   const localBackup = join(conflictsDir, `${safeName}-local-${stamp}.md`);
   writeLocalFile(conflictsDir, `${safeName}-local-${stamp}.md`, localContent);
   const ok = writeLocalFile(contextDir, file.file_path, file.content);
   if (!ok) return { kind: 'conflict-skipped' };
-  syncState.files[file.file_path] = {
-    localHash: sha256(file.content),
-    cloudHash: file.current_hash,
-    lastSyncedAt: nowIso,
-  };
-  process.stderr.write(
-    `Conflict in context/${file.file_path} — kept cloud version (your local edits saved to ${localBackup})\n`
+  recordSyncedFile(syncState, file.file_path, file.content, file.current_hash, nowIso);
+  emitNotice(
+    `Conflict in context/${file.file_path} — kept cloud version (your local edits saved to ${localBackup})`,
+    ctx
   );
   return { kind: 'conflict-cloud-kept', writtenPath: file.file_path, backupPath: localBackup };
 }

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,11 +1,10 @@
-// CommandContext — runtime context built once in main() and threaded through every
-// subcommand. Centralizes config resolution so subcommands don't re-parse env vars,
-// re-read .env files, or re-derive paths.
-//
-// Per EDD-solo-phase-4-pmkit-cli.md §5 + CTO PR 4a forward-work item #1.
+// CommandContext — runtime context built once in main() and threaded through
+// every subcommand.
 
 import { existsSync, readFileSync } from 'node:fs';
 import { isAbsolute, resolve } from 'node:path';
+
+import { MysecondError } from './errors.js';
 
 export type ConflictStrategy = 'prompt' | 'cloud-wins' | 'local-wins' | 'skip';
 
@@ -52,20 +51,21 @@ export function parseGlobalFlags(args: readonly string[]): ParsedFlags {
       out.forceUpdate = true;
     } else if (arg === '--api-key') {
       const next = args[i + 1];
-      if (next === undefined) throw new Error('--api-key requires a value');
+      if (next === undefined) throw MysecondError.invalidFlag('--api-key', 'requires a value');
       out.apiKey = next;
       i++;
     } else if (arg === '--project-dir') {
       const next = args[i + 1];
-      if (next === undefined) throw new Error('--project-dir requires a value');
+      if (next === undefined) throw MysecondError.invalidFlag('--project-dir', 'requires a value');
       out.projectDir = next;
       i++;
     } else if (arg === '--strategy') {
       const next = args[i + 1];
-      if (next === undefined) throw new Error('--strategy requires a value');
+      if (next === undefined) throw MysecondError.invalidFlag('--strategy', 'requires a value');
       if (!STRATEGIES.has(next)) {
-        throw new Error(
-          `--strategy must be one of: prompt, cloud-wins, local-wins, skip (got '${next}')`
+        throw MysecondError.invalidFlag(
+          '--strategy',
+          `must be one of: prompt, cloud-wins, local-wins, skip (got '${next}')`
         );
       }
       out.strategy = next as ConflictStrategy;

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,0 +1,123 @@
+// CommandContext — runtime context built once in main() and threaded through every
+// subcommand. Centralizes config resolution so subcommands don't re-parse env vars,
+// re-read .env files, or re-derive paths.
+//
+// Per EDD-solo-phase-4-pmkit-cli.md §5 + CTO PR 4a forward-work item #1.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+
+export type ConflictStrategy = 'prompt' | 'cloud-wins' | 'local-wins' | 'skip';
+
+export interface CommandContext {
+  apiBase: string;
+  apiKey: string;
+  rootDir: string;
+  silent: boolean;
+  dryRun: boolean;
+  forceUpdate: boolean;
+  strategy: ConflictStrategy;
+}
+
+export interface ParsedFlags {
+  apiKey: string | null;
+  projectDir: string | null;
+  silent: boolean;
+  dryRun: boolean;
+  forceUpdate: boolean;
+  strategy: ConflictStrategy | null;
+  positional: string[];
+}
+
+const STRATEGIES: ReadonlySet<string> = new Set(['prompt', 'cloud-wins', 'local-wins', 'skip']);
+
+export function parseGlobalFlags(args: readonly string[]): ParsedFlags {
+  const out: ParsedFlags = {
+    apiKey: null,
+    projectDir: null,
+    silent: false,
+    dryRun: false,
+    forceUpdate: false,
+    strategy: null,
+    positional: [],
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--silent') {
+      out.silent = true;
+    } else if (arg === '--dry-run') {
+      out.dryRun = true;
+    } else if (arg === '--force-update') {
+      out.forceUpdate = true;
+    } else if (arg === '--api-key') {
+      const next = args[i + 1];
+      if (next === undefined) throw new Error('--api-key requires a value');
+      out.apiKey = next;
+      i++;
+    } else if (arg === '--project-dir') {
+      const next = args[i + 1];
+      if (next === undefined) throw new Error('--project-dir requires a value');
+      out.projectDir = next;
+      i++;
+    } else if (arg === '--strategy') {
+      const next = args[i + 1];
+      if (next === undefined) throw new Error('--strategy requires a value');
+      if (!STRATEGIES.has(next)) {
+        throw new Error(
+          `--strategy must be one of: prompt, cloud-wins, local-wins, skip (got '${next}')`
+        );
+      }
+      out.strategy = next as ConflictStrategy;
+      i++;
+    } else if (arg !== undefined) {
+      out.positional.push(arg);
+    }
+  }
+
+  return out;
+}
+
+// Loads .env from the project dir into process.env (without dotenv dep).
+// Existing process.env entries take precedence — matches legacy sync-context.js behavior.
+function loadDotenv(rootDir: string): void {
+  const envPath = resolve(rootDir, '.env');
+  if (!existsSync(envPath)) return;
+  for (const line of readFileSync(envPath, 'utf-8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).replace(/^export\s+/, '').trim();
+    const val = trimmed.slice(eqIdx + 1).trim().replace(/^["']|["']$/g, '');
+    if (process.env[key] === undefined) process.env[key] = val;
+  }
+}
+
+export function buildContext(flags: ParsedFlags): CommandContext {
+  // Resolve rootDir BEFORE loading .env (so we know where to look for .env).
+  // Precedence: --project-dir flag > $CLAUDE_PROJECT_DIR env > cwd().
+  const rawRoot = flags.projectDir ?? process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+  const rootDir = isAbsolute(rawRoot) ? rawRoot : resolve(process.cwd(), rawRoot);
+
+  loadDotenv(rootDir);
+
+  const apiBase = process.env.COMPANION_API_URL ?? 'https://app.mysecond.ai';
+  const apiKey = flags.apiKey ?? process.env.COMPANION_API_KEY ?? '';
+
+  // Strategy default: prompt if interactive (TTY) and not silent; cloud-wins otherwise.
+  // CXO call (PR 4b design): keep customer in control where possible, default to safe
+  // auto-resolve in non-interactive surfaces (Claude Code chat hooks, CI, --silent).
+  const isInteractive = Boolean(process.stdin.isTTY) && !flags.silent;
+  const strategy: ConflictStrategy = flags.strategy ?? (isInteractive ? 'prompt' : 'cloud-wins');
+
+  return {
+    apiBase,
+    apiKey,
+    rootDir,
+    silent: flags.silent,
+    dryRun: flags.dryRun,
+    forceUpdate: flags.forceUpdate,
+    strategy,
+  };
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -102,6 +102,10 @@ export class MysecondError extends Error {
       'mysecond is paused for a brief rollback window. Try again in a few minutes.'
     );
   }
+
+  static invalidFlag(flagName: string, detail: string): MysecondError {
+    return new MysecondError(1, `${flagName}: ${detail}`);
+  }
 }
 
 // Helper for main() catch — translates any thrown value into an exit code + stderr message.

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,118 @@
+// MysecondError — typed error class with explicit exit codes per EDD §8.1.
+//
+// EDD §8.1 defines 13 distinct exit codes (canonical table). Each customer-facing
+// failure path throws a MysecondError with the appropriate code; main()'s catch
+// translates to process.exit() + actionable stderr message. Avoids the failure mode
+// where every unexpected throw collapses to exit 1, which makes ops debugging harder
+// and blocks customer-facing copy from referencing specific codes.
+//
+// Per EDD §0 Decision 0-B + CTO PR 4a forward-work item #2 (TODO marker in
+// src/index.ts catch block points here).
+
+export type ExitCode =
+  | 0    // success
+  | 1    // generic / 1a invalid_key / 1b subscription_cancelled / 1c plugin_revoked (sub-coded via subCode)
+  | 2    // local state conflict
+  | 3    // 3a schema_drift / 3b network unreachable / 3c Node version too old / 3d Claude Code too old
+  | 4    // regen-gap timeout
+  | 5    // admin restricted
+  | 6    // regen_failed
+  | 7    // rollback pause
+  | 8    // auth-thrash circuit
+  | 130; // SIGINT
+
+export type ExitSubCode =
+  | 'invalid_key'
+  | 'subscription_cancelled'
+  | 'plugin_revoked'
+  | 'schema_drift'
+  | 'network'
+  | 'node_too_old'
+  | 'claude_code_too_old';
+
+export class MysecondError extends Error {
+  readonly exitCode: ExitCode;
+  readonly subCode?: ExitSubCode;
+
+  constructor(exitCode: ExitCode, message: string, options?: { subCode?: ExitSubCode; cause?: unknown }) {
+    // Use Error's native `cause` (ES2022) so `instanceof Error` consumers get the
+    // original cause chain via err.cause without a parallel field.
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
+    this.name = 'MysecondError';
+    this.exitCode = exitCode;
+    this.subCode = options?.subCode;
+  }
+
+  // Convenience factories for the most common throw sites. Adding more as PR 4c
+  // implements the 13 init steps and triggers each exit code.
+  static invalidApiKey(detail?: string): MysecondError {
+    return new MysecondError(
+      1,
+      `Invalid API key. Get a new one at https://mysecond.ai/activate/complete${detail ? ` (${detail})` : ''}.`,
+      { subCode: 'invalid_key' }
+    );
+  }
+
+  static subscriptionCancelled(): MysecondError {
+    return new MysecondError(
+      1,
+      'Your mySecond subscription is inactive. Reactivate at https://mysecond.ai/account.',
+      { subCode: 'subscription_cancelled' }
+    );
+  }
+
+  static pluginRevoked(): MysecondError {
+    return new MysecondError(
+      1,
+      'Your mySecond plugin access has been revoked. Contact support@mysecond.ai.',
+      { subCode: 'plugin_revoked' }
+    );
+  }
+
+  static localStateConflict(detail: string): MysecondError {
+    return new MysecondError(2, `Local state conflict: ${detail}. Run with --fix to resolve.`);
+  }
+
+  static networkUnreachable(detail?: string): MysecondError {
+    return new MysecondError(
+      3,
+      `Cannot reach mysecond.ai${detail ? ` (${detail})` : ''}. Check your internet connection and try again.`,
+      { subCode: 'network' }
+    );
+  }
+
+  static nodeTooOld(actualVersion: string): MysecondError {
+    return new MysecondError(
+      3,
+      `mysecond requires Node 18 or newer — you're on ${actualVersion}. Upgrade Node (nvm install 18 / brew upgrade node) and re-run.`,
+      { subCode: 'node_too_old' }
+    );
+  }
+
+  static authThrashCircuit(retryCount: number): MysecondError {
+    return new MysecondError(
+      8,
+      `Auth-thrash circuit tripped after ${retryCount} consecutive 401 retries. Contact support@mysecond.ai — your API key may need manual reset.`
+    );
+  }
+
+  static rollbackPause(): MysecondError {
+    return new MysecondError(
+      7,
+      'mysecond is paused for a brief rollback window. Try again in a few minutes.'
+    );
+  }
+}
+
+// Helper for main() catch — translates any thrown value into an exit code + stderr message.
+export function exitFromError(err: unknown): number {
+  if (err instanceof MysecondError) {
+    process.stderr.write(`mysecond: ${err.message}\n`);
+    return err.exitCode;
+  }
+  // Unexpected throw — surface stack so customer + support can debug.
+  process.stderr.write(
+    `mysecond: unexpected error: ${err instanceof Error && err.stack ? err.stack : String(err)}\n`
+  );
+  return 1;
+}

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,0 +1,114 @@
+// File utilities — sha256, safe path resolution, atomic-style local I/O.
+//
+// Ported from legacy v1.0.0 sync-context.js lines 213-273 + safePath hardening
+// preserved from /simplify pass at commit 4d281e0 in this repo's git history.
+
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, isAbsolute, join, normalize, relative, resolve } from 'node:path';
+
+export function sha256(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+export function shortHash(content: string): string {
+  return sha256(content).slice(0, 12);
+}
+
+// safePath — resolve a relative path under baseDir, refusing path traversal,
+// absolute paths, and any resolved location that escapes baseDir.
+//
+// Threat model: server response includes a `file_path` like "context/company.md".
+// A compromised or malicious server could return "../../../etc/passwd" or
+// "/etc/passwd" — without this guard, writeLocalFile would happily clobber
+// arbitrary files on the customer's machine.
+export function safePath(baseDir: string, filePath: string): string | null {
+  const normalized = normalize(filePath);
+  if (isAbsolute(normalized) || normalized.startsWith('..') || normalized.includes('/../')) {
+    return null;
+  }
+  const resolved = resolve(baseDir, normalized);
+  // Final containment check: even after normalization, the resolved path must
+  // live under baseDir. relative() returns a path that starts with '..' or is
+  // absolute if it escapes.
+  const rel = relative(baseDir, resolved);
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    return null;
+  }
+  return resolved;
+}
+
+export function readLocalFile(baseDir: string, filePath: string): string | null {
+  const safe = safePath(baseDir, filePath);
+  if (safe === null) return null;
+  try {
+    return readFileSync(safe, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+export function writeLocalFile(baseDir: string, filePath: string, content: string): boolean {
+  const safe = safePath(baseDir, filePath);
+  if (safe === null) {
+    process.stderr.write(`mysecond: skipped suspicious path: ${filePath}\n`);
+    return false;
+  }
+  const dir = dirname(safe);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(safe, content);
+  return true;
+}
+
+export function deleteLocalFile(baseDir: string, filePath: string): boolean {
+  const safe = safePath(baseDir, filePath);
+  if (safe === null) return false;
+  try {
+    unlinkSync(safe);
+  } catch {
+    return false;
+  }
+  // Clean up empty parent directories up to (but not including) baseDir.
+  let dir = dirname(safe);
+  while (dir !== baseDir && dir.startsWith(baseDir + '/')) {
+    try {
+      const entries = readdirSync(dir);
+      if (entries.length > 0) break;
+      rmdirSync(dir);
+    } catch {
+      break;
+    }
+    dir = dirname(dir);
+  }
+  return true;
+}
+
+export interface ProjectPaths {
+  contextDir: string;
+  skillsDir: string;
+  agentsDir: string;
+  workflowsDir: string;
+  claudeMdPath: string;
+  syncStatePath: string;
+  conflictsDir: string;
+}
+
+export function projectPaths(rootDir: string): ProjectPaths {
+  return {
+    contextDir: join(rootDir, 'context'),
+    skillsDir: join(rootDir, '.claude', 'skills'),
+    agentsDir: join(rootDir, '.claude', 'agents'),
+    workflowsDir: join(rootDir, 'workflows'),
+    claudeMdPath: join(rootDir, 'CLAUDE.md'),
+    syncStatePath: join(rootDir, '.claude', 'sync-state.json'),
+    conflictsDir: join(rootDir, '.claude', 'sync-conflicts'),
+  };
+}

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,11 +1,7 @@
 // File utilities — sha256, safe path resolution, atomic-style local I/O.
-//
-// Ported from legacy v1.0.0 sync-context.js lines 213-273 + safePath hardening
-// preserved from /simplify pass at commit 4d281e0 in this repo's git history.
 
 import { createHash } from 'node:crypto';
 import {
-  existsSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -13,7 +9,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, isAbsolute, join, normalize, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
 
 export function sha256(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex');
@@ -24,26 +20,33 @@ export function shortHash(content: string): string {
 }
 
 // safePath — resolve a relative path under baseDir, refusing path traversal,
-// absolute paths, and any resolved location that escapes baseDir.
-//
-// Threat model: server response includes a `file_path` like "context/company.md".
-// A compromised or malicious server could return "../../../etc/passwd" or
-// "/etc/passwd" — without this guard, writeLocalFile would happily clobber
-// arbitrary files on the customer's machine.
+// absolute paths, and any resolved location that escapes baseDir. Threat model:
+// a compromised server returning "../../etc/passwd" or "/etc/passwd" would
+// otherwise let writeLocalFile clobber arbitrary files.
 export function safePath(baseDir: string, filePath: string): string | null {
   const normalized = normalize(filePath);
   if (isAbsolute(normalized) || normalized.startsWith('..') || normalized.includes('/../')) {
     return null;
   }
   const resolved = resolve(baseDir, normalized);
-  // Final containment check: even after normalization, the resolved path must
-  // live under baseDir. relative() returns a path that starts with '..' or is
-  // absolute if it escapes.
   const rel = relative(baseDir, resolved);
   if (rel.startsWith('..') || isAbsolute(rel)) {
     return null;
   }
   return resolved;
+}
+
+// Convert an absolute path back to a project-relative one if it lives inside
+// rootDir. Returns null for paths outside the project tree, or for relative
+// inputs that aren't already within a recognized project layout. Cross-platform
+// safe via path.sep (no hardcoded '/').
+export function relativeFromRoot(rootDir: string, filePath: string): string | null {
+  if (filePath.startsWith(rootDir + sep) || filePath === rootDir) {
+    return filePath.slice(rootDir.length + 1);
+  }
+  if (isAbsolute(filePath)) return null;
+  // Relative input — accept as-is; downstream callers re-validate via safePath.
+  return filePath;
 }
 
 export function readLocalFile(baseDir: string, filePath: string): string | null {
@@ -62,8 +65,9 @@ export function writeLocalFile(baseDir: string, filePath: string, content: strin
     process.stderr.write(`mysecond: skipped suspicious path: ${filePath}\n`);
     return false;
   }
-  const dir = dirname(safe);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  // mkdirSync({ recursive: true }) is a no-op if the directory exists; the
+  // existsSync pre-check was redundant.
+  mkdirSync(dirname(safe), { recursive: true });
   writeFileSync(safe, content);
   return true;
 }
@@ -76,9 +80,10 @@ export function deleteLocalFile(baseDir: string, filePath: string): boolean {
   } catch {
     return false;
   }
-  // Clean up empty parent directories up to (but not including) baseDir.
+  // Clean up empty parent directories up to (but not including) baseDir. Use
+  // path.sep so the containment check works on Windows where sep === '\\'.
   let dir = dirname(safe);
-  while (dir !== baseDir && dir.startsWith(baseDir + '/')) {
+  while (dir !== baseDir && dir.startsWith(baseDir + sep)) {
     try {
       const entries = readdirSync(dir);
       if (entries.length > 0) break;

--- a/src/lib/npm.ts
+++ b/src/lib/npm.ts
@@ -1,0 +1,32 @@
+// 24-hour npm-update timebox per EDD §5.3.
+//
+// `mysecond sync --silent` runs on every Claude Code SessionStart — could be
+// dozens of times per day per customer. Running `npm update -g @mysecond/...`
+// every time would flood GitHub Packages, slow session start by 3-10s, and
+// trigger "why is Claude Code so slow to start?" complaints.
+//
+// Rule: cache lastNpmUpdateAt in .claude/sync-state.json. Skip the update if
+// less than 24h has passed. `--force-update` bypasses the gate.
+//
+// PR 4b ships the gate logic + the structured wrapper for the future
+// `npm update` invocation. Actual `execa('npm', ...)` + 401 retry per EDD §5.4
+// lands when the customer plugin slug is known to the CLI (post-PR-4c, since
+// only `mysecond init` provisions the slug into local state). For now the
+// timebox is honored as a no-op placeholder so the gate is exercised by tests.
+
+import type { CommandContext } from './context.js';
+import type { SyncState } from './sync-state.js';
+
+export const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+export function shouldRunNpmUpdate(state: SyncState, ctx: CommandContext): boolean {
+  if (ctx.forceUpdate) return true;
+  if (state.lastNpmUpdateAt === null) return true;
+  const last = Date.parse(state.lastNpmUpdateAt);
+  if (Number.isNaN(last)) return true;
+  return Date.now() - last >= TWENTY_FOUR_HOURS_MS;
+}
+
+export function markNpmUpdated(state: SyncState): void {
+  state.lastNpmUpdateAt = new Date().toISOString();
+}

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -1,0 +1,76 @@
+// Payload type definitions for the mysecond-app companion API.
+//
+// Mirrors the wire format of GET /api/companion/cli-sync (down-sync) and
+// POST /api/companion/artifacts (up-sync). Solo extensions per EDD §5.2.
+
+export interface ContextFile {
+  file_path: string;
+  content: string;
+  current_hash: string;
+}
+
+export interface CompanionFile {
+  file_path: string;
+  content: string;
+}
+
+export interface CliSyncResponse {
+  // Server may return either shape (legacy `files` or current `context_files`).
+  context_files?: ContextFile[];
+  files?: ContextFile[];
+  custom_skills?: CompanionFile[];
+  custom_agents?: CompanionFile[];
+  custom_workflows?: CompanionFile[];
+  claude_md_override?: string | null;
+  deleted_paths?: string[];
+  syncedAt: string;
+  // Solo extensions (server authoritative; CLI sends nothing on this endpoint
+  // since it's GET, but server may echo for debugging).
+  workspace_scope?: 'solo' | 'team';
+  customer_id?: string;
+}
+
+export interface ArtifactPayload {
+  file_path: string;
+  content: string;
+  current_hash: string;
+  artifact_type: 'prd' | 'research' | 'strategy' | 'launch' | 'analytics' | 'other';
+  pm_name: string | null;
+  skill_slug: string | null;
+  produced_at: string;
+}
+
+export interface ArtifactsResponse {
+  synced: number;
+}
+
+// Artifact source dirs — same as legacy ARTIFACT_DIRS (sync-context.js:400-406).
+// Subdirectories of these get scanned recursively for .md files.
+export interface ArtifactDir {
+  relativeDir: string;
+  type: ArtifactPayload['artifact_type'];
+}
+
+export const ARTIFACT_DIRS: readonly ArtifactDir[] = [
+  { relativeDir: 'specs/outputs', type: 'prd' },
+  { relativeDir: 'discovery/outputs', type: 'research' },
+  { relativeDir: 'strategy/outputs', type: 'strategy' },
+  { relativeDir: 'launch/outputs', type: 'launch' },
+  { relativeDir: 'analytics/outputs', type: 'analytics' },
+];
+
+// Classify a write event's file path into an artifact_type for PostToolUse.
+// Returns null when the path is not a tracked artifact location.
+export function classifyArtifactType(
+  relativePath: string
+): ArtifactPayload['artifact_type'] | null {
+  if (relativePath.startsWith('/') || relativePath.includes('..')) return null;
+  if (relativePath.includes('/tests/')) return null;
+  if (relativePath.startsWith('specs/outputs/')) return 'prd';
+  if (relativePath.startsWith('strategy/outputs/')) return 'strategy';
+  if (relativePath.startsWith('discovery/outputs/')) return 'research';
+  if (relativePath.startsWith('launch/outputs/')) return 'launch';
+  if (relativePath.startsWith('analytics/outputs/')) return 'other';
+  if (/^workflows\/[^/]+\/outputs\//.test(relativePath)) return 'other';
+  return null;
+}

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -1,7 +1,20 @@
 // Payload type definitions for the mysecond-app companion API.
-//
-// Mirrors the wire format of GET /api/companion/cli-sync (down-sync) and
-// POST /api/companion/artifacts (up-sync). Solo extensions per EDD §5.2.
+// Mirrors GET /api/companion/cli-sync (down-sync) and POST /api/companion/artifacts.
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, join, relative } from 'node:path';
+
+import { shortHash } from './files.js';
+
+export const ARTIFACT_TYPES = [
+  'prd',
+  'research',
+  'strategy',
+  'launch',
+  'analytics',
+  'other',
+] as const;
+export type ArtifactType = (typeof ARTIFACT_TYPES)[number];
 
 export interface ContextFile {
   file_path: string;
@@ -24,8 +37,8 @@ export interface CliSyncResponse {
   claude_md_override?: string | null;
   deleted_paths?: string[];
   syncedAt: string;
-  // Solo extensions (server authoritative; CLI sends nothing on this endpoint
-  // since it's GET, but server may echo for debugging).
+  // Solo extensions (server authoritative; CLI sends nothing on cli-sync since
+  // it's GET, but server may echo for debugging).
   workspace_scope?: 'solo' | 'team';
   customer_id?: string;
 }
@@ -34,7 +47,7 @@ export interface ArtifactPayload {
   file_path: string;
   content: string;
   current_hash: string;
-  artifact_type: 'prd' | 'research' | 'strategy' | 'launch' | 'analytics' | 'other';
+  artifact_type: ArtifactType;
   pm_name: string | null;
   skill_slug: string | null;
   produced_at: string;
@@ -44,11 +57,9 @@ export interface ArtifactsResponse {
   synced: number;
 }
 
-// Artifact source dirs — same as legacy ARTIFACT_DIRS (sync-context.js:400-406).
-// Subdirectories of these get scanned recursively for .md files.
 export interface ArtifactDir {
   relativeDir: string;
-  type: ArtifactPayload['artifact_type'];
+  type: ArtifactType;
 }
 
 export const ARTIFACT_DIRS: readonly ArtifactDir[] = [
@@ -60,17 +71,64 @@ export const ARTIFACT_DIRS: readonly ArtifactDir[] = [
 ];
 
 // Classify a write event's file path into an artifact_type for PostToolUse.
-// Returns null when the path is not a tracked artifact location.
-export function classifyArtifactType(
-  relativePath: string
-): ArtifactPayload['artifact_type'] | null {
+// Single source of truth — must agree with ARTIFACT_DIRS for the same paths or
+// the same file gets typed differently depending on which sync path it took
+// (PostToolUse single-file dispatch vs SessionStart full scan).
+export function classifyArtifactType(relativePath: string): ArtifactType | null {
   if (relativePath.startsWith('/') || relativePath.includes('..')) return null;
   if (relativePath.includes('/tests/')) return null;
-  if (relativePath.startsWith('specs/outputs/')) return 'prd';
-  if (relativePath.startsWith('strategy/outputs/')) return 'strategy';
-  if (relativePath.startsWith('discovery/outputs/')) return 'research';
-  if (relativePath.startsWith('launch/outputs/')) return 'launch';
-  if (relativePath.startsWith('analytics/outputs/')) return 'other';
+  for (const dir of ARTIFACT_DIRS) {
+    if (relativePath.startsWith(dir.relativeDir + '/')) return dir.type;
+  }
+  // Workflow outputs aren't in ARTIFACT_DIRS (they're scanned per-workflow not
+  // per-tier), but the PostToolUse hook still classifies them.
   if (/^workflows\/[^/]+\/outputs\//.test(relativePath)) return 'other';
   return null;
+}
+
+// Walk ARTIFACT_DIRS under rootDir and produce payloads for every .md file.
+// Pulled out of sync.ts so the artifact-source knowledge lives next to
+// ARTIFACT_DIRS + classifyArtifactType.
+export function scanArtifacts(rootDir: string): ArtifactPayload[] {
+  const found: ArtifactPayload[] = [];
+  for (const entry of ARTIFACT_DIRS) {
+    const dir = join(rootDir, entry.relativeDir);
+    if (!existsSync(dir)) continue;
+    walkArtifactDir(rootDir, dir, entry.type, found);
+  }
+  return found;
+}
+
+function walkArtifactDir(
+  rootDir: string,
+  currentDir: string,
+  artifactType: ArtifactType,
+  results: ArtifactPayload[]
+): void {
+  for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+    const fullPath = join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      walkArtifactDir(rootDir, fullPath, artifactType, results);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+
+    const content = readFileSync(fullPath, 'utf8');
+    const relativePath = relative(rootDir, fullPath);
+    const parentDir = basename(currentDir);
+    const pmNameMatch = parentDir.match(/^\d{4}-\d{2}-\d{2}-\d{4}-(.+)$/);
+    const pmName = pmNameMatch && pmNameMatch[1] !== undefined ? pmNameMatch[1] : null;
+    const skillSlug = entry.name
+      .replace(/^\d{4}-\d{2}-\d{2}-\d{4}-/, '')
+      .replace(/\.md$/, '');
+    results.push({
+      file_path: relativePath,
+      content,
+      current_hash: shortHash(content),
+      artifact_type: artifactType,
+      pm_name: pmName,
+      skill_slug: skillSlug.length > 0 ? skillSlug : null,
+      produced_at: new Date().toISOString(),
+    });
+  }
 }

--- a/src/lib/sync-state.ts
+++ b/src/lib/sync-state.ts
@@ -1,0 +1,57 @@
+// .claude/sync-state.json — read/write the local sync ledger.
+//
+// Schema preserved from legacy sync-context.js. Adds last_npm_update_at for
+// the 24-hour npm-update timebox per EDD §5.3.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { projectPaths } from './files.js';
+
+export interface SyncStateFileEntry {
+  localHash: string;
+  cloudHash: string;
+  lastSyncedAt: string;
+}
+
+export interface SyncStateArtifactEntry {
+  hash: string;
+  pushedAt: string;
+}
+
+export interface SyncState {
+  files: Record<string, SyncStateFileEntry>;
+  artifacts: Record<string, SyncStateArtifactEntry>;
+  lastSyncedAt: string | null;
+  lastNpmUpdateAt: string | null;
+}
+
+const EMPTY_STATE: SyncState = {
+  files: {},
+  artifacts: {},
+  lastSyncedAt: null,
+  lastNpmUpdateAt: null,
+};
+
+export function readSyncState(rootDir: string): SyncState {
+  const path = projectPaths(rootDir).syncStatePath;
+  try {
+    const raw = readFileSync(path, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<SyncState>;
+    return {
+      ...EMPTY_STATE,
+      ...parsed,
+      files: parsed.files ?? {},
+      artifacts: parsed.artifacts ?? {},
+    };
+  } catch {
+    return { ...EMPTY_STATE };
+  }
+}
+
+export function writeSyncState(rootDir: string, state: SyncState): void {
+  const path = projectPaths(rootDir).syncStatePath;
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(path, JSON.stringify(state, null, 2) + '\n');
+}

--- a/src/lib/sync-state.ts
+++ b/src/lib/sync-state.ts
@@ -1,9 +1,6 @@
 // .claude/sync-state.json — read/write the local sync ledger.
-//
-// Schema preserved from legacy sync-context.js. Adds last_npm_update_at for
-// the 24-hour npm-update timebox per EDD §5.3.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 import { projectPaths } from './files.js';
@@ -23,6 +20,7 @@ export interface SyncState {
   files: Record<string, SyncStateFileEntry>;
   artifacts: Record<string, SyncStateArtifactEntry>;
   lastSyncedAt: string | null;
+  // EDD §5.3 — 24h npm-update timebox cache.
   lastNpmUpdateAt: string | null;
 }
 
@@ -51,7 +49,7 @@ export function readSyncState(rootDir: string): SyncState {
 
 export function writeSyncState(rootDir: string, state: SyncState): void {
   const path = projectPaths(rootDir).syncStatePath;
-  const dir = dirname(path);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  // mkdirSync recursive is a no-op if the directory exists.
+  mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(state, null, 2) + '\n');
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -16,7 +16,10 @@ const REPO_ROOT = resolve(__dirname, '..');
 const BIN = resolve(REPO_ROOT, 'bin', 'mysecond.cjs');
 const DIST = resolve(REPO_ROOT, 'dist', 'mysecond.mjs');
 
-const STUB_SUBCOMMANDS = ['init', 'sync', 'artifact-sync'] as const;
+// init is the only command still stubbed in v1.1.0-rc.0; PR 4c implements it.
+// sync + artifact-sync are real implementations as of PR 4b.
+const SUBCOMMAND_NAMES = ['init', 'sync', 'artifact-sync'] as const;
+const STILL_STUB_SUBCOMMANDS = ['init'] as const;
 
 interface ExecResult {
   status: number;
@@ -24,13 +27,34 @@ interface ExecResult {
   stderr: string;
 }
 
-function runBin(args: readonly string[]): ExecResult {
-  const opts: ExecFileSyncOptionsWithStringEncoding = {
+interface RunBinOptions {
+  envOverride?: Record<string, string | undefined>;
+  stdin?: string;
+}
+
+function runBin(args: readonly string[], opts: RunBinOptions = {}): ExecResult {
+  // Build env: start from process.env, apply overrides (undefined means delete).
+  const baseEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) baseEnv[k] = v;
+  }
+  if (opts.envOverride) {
+    for (const [k, v] of Object.entries(opts.envOverride)) {
+      if (v === undefined) {
+        delete baseEnv[k];
+      } else {
+        baseEnv[k] = v;
+      }
+    }
+  }
+  const execOpts: ExecFileSyncOptionsWithStringEncoding = {
     encoding: 'utf8',
     cwd: REPO_ROOT,
+    env: baseEnv,
+    input: opts.stdin ?? '',
   };
   try {
-    const stdout = execFileSync('node', [BIN, ...args], opts);
+    const stdout = execFileSync('node', [BIN, ...args], execOpts);
     return { status: 0, stdout, stderr: '' };
   } catch (err) {
     const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
@@ -66,12 +90,10 @@ describe('mysecond CLI shape', () => {
     expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
   });
 
-  it('lists all stub subcommands in --help output', () => {
+  it('lists all subcommands in --help output', () => {
     const result = runBin(['--help']);
     expect(result.status).toBe(0);
-    // Tight regex: each subcommand appears as a leading-indented help row, not as a
-    // substring inside another word (e.g., 'init' inside 'not yet implemented').
-    for (const name of STUB_SUBCOMMANDS) {
+    for (const name of SUBCOMMAND_NAMES) {
       expect(result.stdout).toMatch(new RegExp(`^\\s+${name}\\s`, 'm'));
     }
   });
@@ -88,10 +110,43 @@ describe('mysecond CLI shape', () => {
     expect(result.stderr).toContain('unknown subcommand');
   });
 
-  it.each(STUB_SUBCOMMANDS)('%s stub exits 1 with not-implemented message', (name) => {
+  it.each(STILL_STUB_SUBCOMMANDS)('%s stub exits 1 with not-implemented message', (name) => {
     const result = runBin([name]);
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('not yet implemented');
     expect(result.stderr).toContain(name);
+  });
+
+  it('sync without API key exits 1 with invalid-key message', () => {
+    const result = runBin(['sync'], {
+      envOverride: { COMPANION_API_KEY: undefined },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Invalid API key');
+  });
+
+  it('artifact-sync exits 0 silently when stdin is empty (best-effort hook)', () => {
+    const result = runBin(['artifact-sync', '--silent'], {
+      envOverride: { COMPANION_API_KEY: undefined },
+      stdin: '',
+    });
+    // Hook contract: never blame the customer's tool call. Always exit 0.
+    expect(result.status).toBe(0);
+  });
+
+  it('artifact-sync exits 0 when tool_name is not Write', () => {
+    const result = runBin(['artifact-sync', '--silent'], {
+      envOverride: { COMPANION_API_KEY: 'fake-key-not-used' },
+      stdin: JSON.stringify({ tool_name: 'Read', tool_input: { file_path: '/tmp/x.md' } }),
+    });
+    expect(result.status).toBe(0);
+  });
+
+  it('rejects --strategy with invalid value', () => {
+    const result = runBin(['sync', '--strategy', 'invalid'], {
+      envOverride: { COMPANION_API_KEY: 'fake-key' },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('--strategy must be one of');
   });
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -147,6 +147,17 @@ describe('mysecond CLI shape', () => {
       envOverride: { COMPANION_API_KEY: 'fake-key' },
     });
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain('--strategy must be one of');
+    expect(result.stderr).toContain('--strategy: must be one of');
+  });
+
+  it('artifact-sync handles Edit tool (not just Write)', () => {
+    const result = runBin(['artifact-sync', '--silent'], {
+      envOverride: { COMPANION_API_KEY: 'fake-key' },
+      stdin: JSON.stringify({ tool_name: 'Edit', tool_input: { file_path: '/tmp/x.md' } }),
+    });
+    // /tmp/x.md is outside any rootDir/artifact-dir, so the path filter catches
+    // it and we still exit 0 — but the Edit tool name is no longer rejected
+    // outright. Verifying the hook doesn't blame the customer.
+    expect(result.status).toBe(0);
   });
 });

--- a/tests/integration/_helpers/tmp-home.ts
+++ b/tests/integration/_helpers/tmp-home.ts
@@ -1,0 +1,56 @@
+// tmp-home — fixture helper for integration tests that touch the filesystem.
+//
+// Per EDD-solo-phase-4-pmkit-cli.md §6 (PR 4c) + CTO PR 4a forward-work item #4.
+// PR 4b (sync) doesn't yet need filesystem-heavy tests, but lands the helper now so
+// PR 4c (init, 13 atomic steps touching ~/.npmrc + .claude/ + .env) doesn't need to
+// invent its own pattern.
+//
+// Usage:
+//   const tmp = await mkTmpHome();
+//   try {
+//     // process.env.HOME is now tmp.home; write files freely
+//     await myCommand(['init', '--project-dir', tmp.project]);
+//   } finally {
+//     await tmp.cleanup();
+//   }
+
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export interface TmpHomeFixture {
+  home: string;
+  project: string;
+  cleanup: () => Promise<void>;
+}
+
+export async function mkTmpHome(): Promise<TmpHomeFixture> {
+  const root = await mkdtemp(join(tmpdir(), 'mysecond-test-'));
+  const home = join(root, 'home');
+  const project = join(root, 'project');
+  await mkdir(home, { recursive: true });
+  await mkdir(project, { recursive: true });
+
+  const originalHome = process.env.HOME;
+  const originalProjectDir = process.env.CLAUDE_PROJECT_DIR;
+  process.env.HOME = home;
+  process.env.CLAUDE_PROJECT_DIR = project;
+
+  return {
+    home,
+    project,
+    cleanup: async () => {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      if (originalProjectDir === undefined) {
+        delete process.env.CLAUDE_PROJECT_DIR;
+      } else {
+        process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
+      }
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}

--- a/tests/lib/conflict.test.ts
+++ b/tests/lib/conflict.test.ts
@@ -1,0 +1,187 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveConflict } from '../../src/lib/conflict.js';
+import type { CommandContext } from '../../src/lib/context.js';
+import { sha256, writeLocalFile } from '../../src/lib/files.js';
+import type { ContextFile } from '../../src/lib/payload.js';
+import type { SyncState } from '../../src/lib/sync-state.js';
+
+function tmpProject(): string {
+  return mkdtempSync(join(tmpdir(), 'mysecond-conflict-'));
+}
+
+function ctx(rootDir: string, overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'k',
+    rootDir,
+    silent: false,
+    dryRun: false,
+    forceUpdate: false,
+    strategy: 'cloud-wins',
+    ...overrides,
+  };
+}
+
+function emptyState(): SyncState {
+  return { files: {}, artifacts: {}, lastSyncedAt: null, lastNpmUpdateAt: null };
+}
+
+function file(filePath: string, content: string): ContextFile {
+  return { file_path: filePath, content, current_hash: sha256(content) };
+}
+
+describe('resolveConflict — first-time create', () => {
+  it('writes cloud version when local is missing', () => {
+    const root = tmpProject();
+    const state = emptyState();
+    const outcome = resolveConflict({
+      file: file('company.md', 'hello'),
+      localContent: null,
+      syncState: state,
+      ctx: ctx(root),
+    });
+    expect(outcome.kind).toBe('created');
+    expect(readFileSync(join(root, 'context/company.md'), 'utf8')).toBe('hello');
+    expect(state.files['company.md']).toBeDefined();
+  });
+});
+
+describe('resolveConflict — no divergence', () => {
+  it('reports unchanged when local + cloud match a recorded hash', () => {
+    const root = tmpProject();
+    writeLocalFile(join(root, 'context'), 'company.md', 'hello');
+    const state = emptyState();
+    state.files['company.md'] = {
+      localHash: sha256('hello'),
+      cloudHash: sha256('hello'),
+      lastSyncedAt: new Date().toISOString(),
+    };
+    const outcome = resolveConflict({
+      file: file('company.md', 'hello'),
+      localContent: 'hello',
+      syncState: state,
+      ctx: ctx(root),
+    });
+    expect(outcome.kind).toBe('unchanged');
+  });
+});
+
+describe('resolveConflict — only cloud changed', () => {
+  it('overwrites local with cloud version', () => {
+    const root = tmpProject();
+    writeLocalFile(join(root, 'context'), 'company.md', 'old');
+    const state = emptyState();
+    state.files['company.md'] = {
+      localHash: sha256('old'),
+      cloudHash: sha256('old'),
+      lastSyncedAt: new Date().toISOString(),
+    };
+    const outcome = resolveConflict({
+      file: file('company.md', 'new-cloud'),
+      localContent: 'old',
+      syncState: state,
+      ctx: ctx(root),
+    });
+    expect(outcome.kind).toBe('updated-from-cloud');
+    expect(readFileSync(join(root, 'context/company.md'), 'utf8')).toBe('new-cloud');
+  });
+});
+
+describe('resolveConflict — only local changed', () => {
+  it('keeps local untouched and updates the ledger', () => {
+    const root = tmpProject();
+    writeLocalFile(join(root, 'context'), 'company.md', 'local-edit');
+    const state = emptyState();
+    state.files['company.md'] = {
+      localHash: sha256('original'),
+      cloudHash: sha256('original'),
+      lastSyncedAt: new Date().toISOString(),
+    };
+    const outcome = resolveConflict({
+      file: file('company.md', 'original'),
+      localContent: 'local-edit',
+      syncState: state,
+      ctx: ctx(root),
+    });
+    expect(outcome.kind).toBe('kept-local');
+    expect(readFileSync(join(root, 'context/company.md'), 'utf8')).toBe('local-edit');
+  });
+});
+
+describe('resolveConflict — both changed (Option 1 minimum safety net)', () => {
+  it('cloud-wins strategy: writes cloud, backs up local, returns conflict-cloud-kept', () => {
+    const root = tmpProject();
+    writeLocalFile(join(root, 'context'), 'company.md', 'local-edit');
+    const state = emptyState();
+    state.files['company.md'] = {
+      localHash: sha256('original'),
+      cloudHash: sha256('original'),
+      lastSyncedAt: new Date().toISOString(),
+    };
+    const outcome = resolveConflict({
+      file: file('company.md', 'cloud-edit'),
+      localContent: 'local-edit',
+      syncState: state,
+      ctx: ctx(root, { strategy: 'cloud-wins' }),
+    });
+    expect(outcome.kind).toBe('conflict-cloud-kept');
+
+    // Local file now contains cloud version
+    expect(readFileSync(join(root, 'context/company.md'), 'utf8')).toBe('cloud-edit');
+
+    // Backup file exists in .claude/sync-conflicts/ with the local content
+    const backups = readdirSync(join(root, '.claude/sync-conflicts'));
+    const localBackup = backups.find((f) => f.includes('-local-'));
+    expect(localBackup).toBeDefined();
+    expect(readFileSync(join(root, '.claude/sync-conflicts', localBackup!), 'utf8')).toBe(
+      'local-edit'
+    );
+  });
+
+  it('local-wins strategy: keeps local, backs up cloud, returns conflict-local-kept', () => {
+    const root = tmpProject();
+    writeLocalFile(join(root, 'context'), 'company.md', 'local-edit');
+    const state = emptyState();
+    state.files['company.md'] = {
+      localHash: sha256('original'),
+      cloudHash: sha256('original'),
+      lastSyncedAt: new Date().toISOString(),
+    };
+    const outcome = resolveConflict({
+      file: file('company.md', 'cloud-edit'),
+      localContent: 'local-edit',
+      syncState: state,
+      ctx: ctx(root, { strategy: 'local-wins' }),
+    });
+    expect(outcome.kind).toBe('conflict-local-kept');
+    expect(readFileSync(join(root, 'context/company.md'), 'utf8')).toBe('local-edit');
+
+    const backups = readdirSync(join(root, '.claude/sync-conflicts'));
+    const cloudBackup = backups.find((f) => f.includes('-cloud-'));
+    expect(cloudBackup).toBeDefined();
+  });
+
+  it('skip strategy: leaves local alone, only saves cloud version for inspection', () => {
+    const root = tmpProject();
+    writeLocalFile(join(root, 'context'), 'company.md', 'local-edit');
+    const state = emptyState();
+    state.files['company.md'] = {
+      localHash: sha256('original'),
+      cloudHash: sha256('original'),
+      lastSyncedAt: new Date().toISOString(),
+    };
+    const outcome = resolveConflict({
+      file: file('company.md', 'cloud-edit'),
+      localContent: 'local-edit',
+      syncState: state,
+      ctx: ctx(root, { strategy: 'skip' }),
+    });
+    expect(outcome.kind).toBe('conflict-skipped');
+    expect(readFileSync(join(root, 'context/company.md'), 'utf8')).toBe('local-edit');
+  });
+});

--- a/tests/lib/context.test.ts
+++ b/tests/lib/context.test.ts
@@ -33,11 +33,11 @@ describe('parseGlobalFlags', () => {
   });
 
   it('throws on missing value for --api-key', () => {
-    expect(() => parseGlobalFlags(['--api-key'])).toThrow('--api-key requires a value');
+    expect(() => parseGlobalFlags(['--api-key'])).toThrow('--api-key: requires a value');
   });
 
   it('throws on invalid --strategy value', () => {
-    expect(() => parseGlobalFlags(['--strategy', 'bogus'])).toThrow('--strategy must be one of');
+    expect(() => parseGlobalFlags(['--strategy', 'bogus'])).toThrow('--strategy: must be one of');
   });
 
   it('collects positional args', () => {

--- a/tests/lib/context.test.ts
+++ b/tests/lib/context.test.ts
@@ -1,0 +1,114 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildContext, parseGlobalFlags } from '../../src/lib/context.js';
+
+describe('parseGlobalFlags', () => {
+  it('parses no args as defaults', () => {
+    const f = parseGlobalFlags([]);
+    expect(f.silent).toBe(false);
+    expect(f.dryRun).toBe(false);
+    expect(f.forceUpdate).toBe(false);
+    expect(f.apiKey).toBeNull();
+    expect(f.projectDir).toBeNull();
+    expect(f.strategy).toBeNull();
+    expect(f.positional).toEqual([]);
+  });
+
+  it('parses boolean flags', () => {
+    const f = parseGlobalFlags(['--silent', '--dry-run', '--force-update']);
+    expect(f.silent).toBe(true);
+    expect(f.dryRun).toBe(true);
+    expect(f.forceUpdate).toBe(true);
+  });
+
+  it('parses value flags', () => {
+    const f = parseGlobalFlags(['--api-key', 'k', '--project-dir', '/p', '--strategy', 'cloud-wins']);
+    expect(f.apiKey).toBe('k');
+    expect(f.projectDir).toBe('/p');
+    expect(f.strategy).toBe('cloud-wins');
+  });
+
+  it('throws on missing value for --api-key', () => {
+    expect(() => parseGlobalFlags(['--api-key'])).toThrow('--api-key requires a value');
+  });
+
+  it('throws on invalid --strategy value', () => {
+    expect(() => parseGlobalFlags(['--strategy', 'bogus'])).toThrow('--strategy must be one of');
+  });
+
+  it('collects positional args', () => {
+    const f = parseGlobalFlags(['arg1', '--silent', 'arg2']);
+    expect(f.positional).toEqual(['arg1', 'arg2']);
+  });
+});
+
+describe('buildContext', () => {
+  let savedHome: string | undefined;
+  let savedKey: string | undefined;
+  let savedUrl: string | undefined;
+  let savedClaudeDir: string | undefined;
+
+  beforeEach(() => {
+    savedHome = process.env.HOME;
+    savedKey = process.env.COMPANION_API_KEY;
+    savedUrl = process.env.COMPANION_API_URL;
+    savedClaudeDir = process.env.CLAUDE_PROJECT_DIR;
+    delete process.env.COMPANION_API_KEY;
+    delete process.env.COMPANION_API_URL;
+    delete process.env.CLAUDE_PROJECT_DIR;
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedKey === undefined) delete process.env.COMPANION_API_KEY;
+    else process.env.COMPANION_API_KEY = savedKey;
+    if (savedUrl === undefined) delete process.env.COMPANION_API_URL;
+    else process.env.COMPANION_API_URL = savedUrl;
+    if (savedClaudeDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = savedClaudeDir;
+  });
+
+  it('defaults apiBase to production', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    const ctx = buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(ctx.apiBase).toBe('https://app.mysecond.ai');
+  });
+
+  it('reads apiKey + apiBase from .env in rootDir', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    writeFileSync(
+      join(tmp, '.env'),
+      'COMPANION_API_KEY=from-dotenv\nCOMPANION_API_URL=https://staging.mysecond.ai\n'
+    );
+    const ctx = buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(ctx.apiKey).toBe('from-dotenv');
+    expect(ctx.apiBase).toBe('https://staging.mysecond.ai');
+  });
+
+  it('--api-key flag wins over env', () => {
+    process.env.COMPANION_API_KEY = 'from-env';
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    const ctx = buildContext(parseGlobalFlags(['--project-dir', tmp, '--api-key', 'from-flag']));
+    expect(ctx.apiKey).toBe('from-flag');
+  });
+
+  it('strategy defaults to cloud-wins in --silent mode', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    const ctx = buildContext(parseGlobalFlags(['--project-dir', tmp, '--silent']));
+    expect(ctx.strategy).toBe('cloud-wins');
+    expect(ctx.silent).toBe(true);
+  });
+
+  it('--strategy flag wins over default', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    const ctx = buildContext(
+      parseGlobalFlags(['--project-dir', tmp, '--silent', '--strategy', 'local-wins'])
+    );
+    expect(ctx.strategy).toBe('local-wins');
+  });
+});

--- a/tests/lib/files.test.ts
+++ b/tests/lib/files.test.ts
@@ -1,0 +1,101 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  deleteLocalFile,
+  projectPaths,
+  readLocalFile,
+  safePath,
+  sha256,
+  shortHash,
+  writeLocalFile,
+} from '../../src/lib/files.js';
+
+function tmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'mysecond-files-'));
+}
+
+describe('sha256 / shortHash', () => {
+  it('hashes deterministically', () => {
+    expect(sha256('hello')).toBe(sha256('hello'));
+    expect(sha256('hello')).not.toBe(sha256('world'));
+  });
+
+  it('shortHash returns 12 hex chars', () => {
+    expect(shortHash('anything')).toMatch(/^[0-9a-f]{12}$/);
+  });
+});
+
+describe('safePath', () => {
+  const base = '/Users/test/project';
+
+  it('accepts a normal relative path', () => {
+    expect(safePath(base, 'context/company.md')).toBe(`${base}/context/company.md`);
+  });
+
+  it('rejects absolute paths', () => {
+    expect(safePath(base, '/etc/passwd')).toBeNull();
+  });
+
+  it('rejects path traversal', () => {
+    expect(safePath(base, '../../../etc/passwd')).toBeNull();
+    expect(safePath(base, 'subdir/../../escape')).toBeNull();
+  });
+
+  it('handles dot-prefix files safely', () => {
+    expect(safePath(base, '.env')).toBe(`${base}/.env`);
+  });
+});
+
+describe('writeLocalFile / readLocalFile / deleteLocalFile', () => {
+  it('writes, reads, and deletes a file under baseDir', () => {
+    const base = tmpDir();
+    const ok = writeLocalFile(base, 'sub/dir/file.md', 'hello');
+    expect(ok).toBe(true);
+    expect(readLocalFile(base, 'sub/dir/file.md')).toBe('hello');
+    expect(deleteLocalFile(base, 'sub/dir/file.md')).toBe(true);
+    expect(readLocalFile(base, 'sub/dir/file.md')).toBeNull();
+  });
+
+  it('refuses to write outside baseDir', () => {
+    const base = tmpDir();
+    const ok = writeLocalFile(base, '../escape.md', 'malicious');
+    expect(ok).toBe(false);
+  });
+
+  it('does not delete parent dirs that still have content', () => {
+    const base = tmpDir();
+    writeLocalFile(base, 'a/b/file1.md', '1');
+    writeLocalFile(base, 'a/b/file2.md', '2');
+    deleteLocalFile(base, 'a/b/file1.md');
+    expect(readLocalFile(base, 'a/b/file2.md')).toBe('2');
+  });
+});
+
+describe('projectPaths', () => {
+  it('builds expected layout', () => {
+    const p = projectPaths('/proj');
+    expect(p.contextDir).toBe('/proj/context');
+    expect(p.skillsDir).toBe('/proj/.claude/skills');
+    expect(p.agentsDir).toBe('/proj/.claude/agents');
+    expect(p.workflowsDir).toBe('/proj/workflows');
+    expect(p.claudeMdPath).toBe('/proj/CLAUDE.md');
+    expect(p.syncStatePath).toBe('/proj/.claude/sync-state.json');
+    expect(p.conflictsDir).toBe('/proj/.claude/sync-conflicts');
+  });
+});
+
+describe('readLocalFile error handling', () => {
+  it('returns null when file does not exist', () => {
+    const base = tmpDir();
+    expect(readLocalFile(base, 'nope.md')).toBeNull();
+  });
+
+  it('returns null for an unsafe path', () => {
+    const base = tmpDir();
+    expect(readLocalFile(base, '/etc/passwd')).toBeNull();
+  });
+});

--- a/tests/lib/npm.test.ts
+++ b/tests/lib/npm.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CommandContext } from '../../src/lib/context.js';
+import { markNpmUpdated, shouldRunNpmUpdate, TWENTY_FOUR_HOURS_MS } from '../../src/lib/npm.js';
+import type { SyncState } from '../../src/lib/sync-state.js';
+
+function ctx(overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'k',
+    rootDir: '/proj',
+    silent: false,
+    dryRun: false,
+    forceUpdate: false,
+    strategy: 'cloud-wins',
+    ...overrides,
+  };
+}
+
+function state(lastNpmUpdateAt: string | null): SyncState {
+  return {
+    files: {},
+    artifacts: {},
+    lastSyncedAt: null,
+    lastNpmUpdateAt,
+  };
+}
+
+describe('shouldRunNpmUpdate', () => {
+  it('runs on first sync (lastNpmUpdateAt = null)', () => {
+    expect(shouldRunNpmUpdate(state(null), ctx())).toBe(true);
+  });
+
+  it('skips within the 24h window', () => {
+    const recent = new Date(Date.now() - 1000).toISOString();
+    expect(shouldRunNpmUpdate(state(recent), ctx())).toBe(false);
+  });
+
+  it('runs after the 24h window expires', () => {
+    const old = new Date(Date.now() - TWENTY_FOUR_HOURS_MS - 1000).toISOString();
+    expect(shouldRunNpmUpdate(state(old), ctx())).toBe(true);
+  });
+
+  it('--force-update bypasses the gate', () => {
+    const recent = new Date(Date.now() - 1000).toISOString();
+    expect(shouldRunNpmUpdate(state(recent), ctx({ forceUpdate: true }))).toBe(true);
+  });
+
+  it('treats unparseable timestamps as "should run"', () => {
+    expect(shouldRunNpmUpdate(state('not-a-date'), ctx())).toBe(true);
+  });
+});
+
+describe('markNpmUpdated', () => {
+  it('writes a current ISO timestamp', () => {
+    const s = state(null);
+    const before = Date.now();
+    markNpmUpdated(s);
+    const after = Date.now();
+    expect(s.lastNpmUpdateAt).not.toBeNull();
+    const stored = Date.parse(s.lastNpmUpdateAt!);
+    expect(stored).toBeGreaterThanOrEqual(before);
+    expect(stored).toBeLessThanOrEqual(after);
+  });
+});

--- a/tests/lib/payload.test.ts
+++ b/tests/lib/payload.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { ARTIFACT_DIRS, classifyArtifactType } from '../../src/lib/payload.js';
+
+describe('classifyArtifactType', () => {
+  it('classifies known artifact dirs', () => {
+    expect(classifyArtifactType('specs/outputs/foo.md')).toBe('prd');
+    expect(classifyArtifactType('strategy/outputs/bar.md')).toBe('strategy');
+    expect(classifyArtifactType('discovery/outputs/baz.md')).toBe('research');
+    expect(classifyArtifactType('launch/outputs/x.md')).toBe('launch');
+    expect(classifyArtifactType('analytics/outputs/y.md')).toBe('other');
+    expect(classifyArtifactType('workflows/foo/outputs/z.md')).toBe('other');
+  });
+
+  it('returns null for paths outside artifact dirs', () => {
+    expect(classifyArtifactType('context/company.md')).toBeNull();
+    expect(classifyArtifactType('README.md')).toBeNull();
+    expect(classifyArtifactType('.claude/skills/foo/SKILL.md')).toBeNull();
+  });
+
+  it('rejects unsafe paths', () => {
+    expect(classifyArtifactType('/abs/path.md')).toBeNull();
+    expect(classifyArtifactType('../escape/specs/outputs/x.md')).toBeNull();
+  });
+
+  it('skips test outputs', () => {
+    expect(classifyArtifactType('specs/outputs/tests/x.md')).toBeNull();
+  });
+});
+
+describe('ARTIFACT_DIRS', () => {
+  it('covers the 5 known output locations', () => {
+    expect(ARTIFACT_DIRS.map((d) => d.relativeDir).sort()).toEqual([
+      'analytics/outputs',
+      'discovery/outputs',
+      'launch/outputs',
+      'specs/outputs',
+      'strategy/outputs',
+    ]);
+  });
+});

--- a/tests/lib/payload.test.ts
+++ b/tests/lib/payload.test.ts
@@ -8,7 +8,7 @@ describe('classifyArtifactType', () => {
     expect(classifyArtifactType('strategy/outputs/bar.md')).toBe('strategy');
     expect(classifyArtifactType('discovery/outputs/baz.md')).toBe('research');
     expect(classifyArtifactType('launch/outputs/x.md')).toBe('launch');
-    expect(classifyArtifactType('analytics/outputs/y.md')).toBe('other');
+    expect(classifyArtifactType('analytics/outputs/y.md')).toBe('analytics');
     expect(classifyArtifactType('workflows/foo/outputs/z.md')).toBe('other');
   });
 


### PR DESCRIPTION
## Summary

PR 4b per [EDD §5](https://github.com/yangro/pmkit.ai/blob/main/specs/EDD-solo-phase-4-pmkit-cli.md). Ports the sync + artifact-sync logic from legacy `mysecond-app/scripts/sync-context.js` into TypeScript. Real implementations — no more stubs for `mysecond sync` or `mysecond artifact-sync`. `mysecond init` stays stubbed (PR 4c).

**Status: code-ready, 52/52 tests passing, 5 reviewers PASSED, awaiting Ron final approval.**

## Three commits

1. **`8212188` — Foundation prerequisites** (CTO PR 4a forward-work items)
   - `CommandContext` interface + `parseGlobalFlags` + `buildContext` (src/lib/context.ts)
   - `MysecondError` class + `exitFromError` helper per EDD §8.1's 13 exit codes (src/lib/errors.ts)
   - `tests/integration/_helpers/tmp-home.ts` fixture scaffolding for PR 4c
   - Subcommand signature updated to `(args, ctx) => Promise<number>` throughout dispatch

2. **`2019c4c` — Sync port + tests** (PR 4b core)
   - 6 new lib modules + 2 command implementations + 41 unit tests across 5 test files

3. **`2edc008` — Review fold** (5 reviewers, 2 bugs + 1 critical UX + many cleanups)
   - 2 bugs fixed (analytics wire-format inconsistency + wasFirstSync always-true)
   - 1 CAIO-critical UX fix (stderr→stdout in --silent so SessionStart conflicts surface)
   - PostToolUse Edit + MultiEdit support
   - SessionStart-tightened cliSync timeout (8s when --silent, 30s otherwise)
   - AbortSignal.timeout + ARTIFACT_TYPES const + recordSyncedFile helper + cross-platform path handling + numerous comment/code cleanups

## Conflict UX (Ron + CXO design call, CAIO finding folded)

**Option 1 minimum safety net:** when both local and cloud diverged since last sync, write timestamped backup of the losing side to `.claude/sync-conflicts/<file>-{cloud|local}-{timestamp}.md`, apply chosen version, emit one notification line.

- `--strategy` flag: `prompt | cloud-wins | local-wins | skip`
- Default: `prompt` if interactive (TTY + not silent), else `cloud-wins`
- **CAIO catch:** notification routes to **stdout in --silent mode** (so Claude reads it as session-start context and surfaces to customer in chat) and **stderr in TTY mode** (visible directly). Closes the gap where SessionStart hook stderr is silently dropped on exit 0.

## Legacy dead code NOT ported

Per Ron + CXO Option B: legacy `ensureArtifactSync()` (sync-context.js:157-200) is deleted, not ported. That function wrote a bash script and registered a settings.json hook. Both jobs now done by the customer plugin's `plugin.json` manifest generated by the regen worker (CAIO-Y1 architectural change in [mysecond-app#78](https://github.com/mysecond-ai/mysecond-app/pull/78)). Single source of truth.

## Tests (52 total, all passing)

| File | Cases | Coverage |
|---|---|---|
| `tests/cli.test.ts` | 11 | Binary shape: version, help, unknown subcommand, init-still-stub, sync-without-key, artifact-sync hook contract (Write + Edit + MultiEdit + non-write tools + empty stdin), strategy validation |
| `tests/lib/files.test.ts` | 12 | sha256, safePath traversal guards, read/write/delete with cleanup, projectPaths layout |
| `tests/lib/payload.test.ts` | 5 | classifyArtifactType for all 5 known dirs (analytics now correctly returns 'analytics' not 'other'), rejection of unsafe paths and test-output paths |
| `tests/lib/npm.test.ts` | 6 | 24h timebox gate behavior + force-update bypass |
| `tests/lib/context.test.ts` | 11 | flag parsing happy + error paths via MysecondError.invalidFlag, .env loading, precedence, strategy defaults |
| `tests/lib/conflict.test.ts` | 7 | All 5 conflict branches × strategy options; backup writing verified |

## Build stats

- Bundle: 28.5kb (foundation 8.1kb + sync port additions; review fold was net-zero size, reorganization)
- Typecheck: clean under `strict + noUncheckedIndexedAccess + noUnusedLocals + noUnusedParameters`
- Tests: 52 pass in 1.08s

## Review stack — ALL PASSED ✅

- [x] Self-review (typecheck + build + 52/52 tests + smoke against built binary)
- [x] **`/simplify` 3-parallel-agent pass** — reuse + quality + efficiency
  - Reuse: 7 actionables folded
  - Quality: 2 bugs + many cleanups folded
  - Efficiency: 2 wins folded (1 already on reuse list); 2 deferred (parallel context reads, mtime-gated scan)
- [x] **CTO review** — pass with forward-work; 3 small comment additions folded
- [x] **CAIO spot-check** — pass with 2 yellows + 1 critical UX finding (stderr→stdout in silent mode) folded
- [ ] **`reviewer` agent** — hit prompt-too-long both attempts; coverage redundant with the 5 above; skipped after 2nd failure
- [ ] Ron final approval

## Forward-work captured (NOT in PR 4b)

- `runNpmWithRetry` + actual `npm update -g @mysecond/customer-{slug}` invocation: gate is wired, but slug isn't in local state until `mysecond init` runs (PR 4c). Gate is honored as no-op; real invocation lands in PR 4c or follow-up.
- `.claude/sync-conflicts/` → add to `.gitignore` in starter kit generator (PR 4c first-run setup or kit template).
- HTTP integration tests per EDD §5.6 — follow-up if any reviewer pushes (current coverage is unit-only).
- Legacy `/api/companion/sync` cleanup: both `/sync` and `/cli-sync` exist on mysecond-app main; CLI now uses `/cli-sync`. Can deprecate `/sync` in a separate PR.
- Parallel context-file reads via Promise.all (efficiency optimization deferred — bigger architectural change).
- mtime-gated artifact scan (efficiency optimization deferred — changes push semantics).
- Test helper extraction to `tests/_helpers.ts` (~30 lines duplicated across 3 test files; not worth the cross-file split yet).
- npm `--provenance` + Trusted Publishing OIDC migration — couples to NPM_TOKEN rotation 2026-07-21.
- Bump engines to Node 20.6+ to unlock `process.loadEnvFile` (replaces hand-rolled .env loader).

## Refs

- [EDD §5](https://github.com/yangro/pmkit.ai/blob/main/specs/EDD-solo-phase-4-pmkit-cli.md) — PR 4b scope
- [EDD §8.1](https://github.com/yangro/pmkit.ai/blob/main/specs/EDD-solo-phase-4-pmkit-cli.md) — 13 exit codes (MysecondError factories cover the most-common throw sites)
- [#1](https://github.com/mysecond-ai/mysecond-cli/pull/1) — PR 4a scaffold (merged)
- [mysecond-app#78](https://github.com/mysecond-ai/mysecond-app/pull/78) — regen worker plugin.json generator (CAIO-Y1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)