### PR TITLE
chore(release): v1.1.0 — bump from 1.1.0-rc.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -820,7 +820,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.1.0-rc.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mysecond/cli",
-      "version": "1.1.0-rc.0",
+      "version": "1.1.0",
       "license": "UNLICENSED",
       "dependencies": {
         "proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.1.0-rc.0",
+  "version": "1.1.0",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -89,6 +89,22 @@ export class MysecondError extends Error {
     );
   }
 
+  static claudeCodeTooOld(actualVersion: string, requiredVersion: string): MysecondError {
+    return new MysecondError(
+      5,
+      `mysecond requires Claude Code ${requiredVersion} or newer — you're on ${actualVersion}. Update Claude Code (Claude Code → About → Check for Updates), restart, then re-run mysecond init.`,
+      { subCode: 'claude_code_too_old' }
+    );
+  }
+
+  static claudeCodeNotDetected(): MysecondError {
+    return new MysecondError(
+      5,
+      `mysecond could not run 'claude --version'. Make sure Claude Code is installed + current, then quit + relaunch Claude Code so the paste command runs inside its bash tool (not a plain terminal).`,
+      { subCode: 'claude_code_too_old' }
+    );
+  }
+
   static authThrashCircuit(retryCount: number): MysecondError {
     return new MysecondError(
       8,

--- a/src/lib/steps/step-1.ts
+++ b/src/lib/steps/step-1.ts
@@ -1,6 +1,7 @@
-// Step 1: Validate --project-dir + Node version pre-check.
+// Step 1: Validate --project-dir + Node version + Claude Code version pre-check.
 // Fails fast (no writes, no network). Always re-runs (cheap).
 
+import { spawnSync } from 'node:child_process';
 import { isAbsolute, resolve } from 'node:path';
 
 import { MysecondError } from '../errors.js';
@@ -10,7 +11,14 @@ import type { StepFn } from './types.js';
 
 const MIN_NODE_MAJOR = 18;
 
-function parseNodeMajor(version: string): number | null {
+// CAIO Y-CC-Floor (EDD v1.5 §4.3 + §6.2) — mysecond init relies on
+// `claude plugin marketplace add` + `claude plugin install` which require this
+// minimum Claude Code version. Older versions emit "unknown command: marketplace"
+// which leads to a confusing customer-facing error during step 9. Pin explicitly
+// here so we fail early with an actionable message instead of mid-install.
+export const MIN_CLAUDE_CODE_VERSION = '2.1.118';
+
+export function parseNodeMajor(version: string): number | null {
   // process.versions.node looks like "20.11.1" — no leading "v".
   const match = /^(\d+)\./.exec(version);
   if (match === null || match[1] === undefined) return null;
@@ -18,7 +26,86 @@ function parseNodeMajor(version: string): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+/**
+ * Parse a Claude Code version string into a comparable `[major, minor, patch]` tuple.
+ *
+ * Handles observed output shapes of `claude --version`:
+ *   - "2.1.118"
+ *   - "2.1.118 (Claude Code)"
+ *   - "Claude Code 2.1.118"
+ *   - "claude 2.1.118"
+ */
+export function parseClaudeVersion(raw: string): [number, number, number] | null {
+  const match = /\b(\d+)\.(\d+)\.(\d+)\b/.exec(raw);
+  if (!match || !match[1] || !match[2] || !match[3]) return null;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+  if (!Number.isFinite(major) || !Number.isFinite(minor) || !Number.isFinite(patch)) {
+    return null;
+  }
+  return [major, minor, patch];
+}
+
+export function compareVersions(
+  a: [number, number, number],
+  b: [number, number, number]
+): number {
+  if (a[0] !== b[0]) return a[0] - b[0];
+  if (a[1] !== b[1]) return a[1] - b[1];
+  return a[2] - b[2];
+}
+
+export type ClaudeProbeResult =
+  | { kind: 'ok'; version: [number, number, number]; raw: string }
+  | { kind: 'not_detected' }
+  | { kind: 'unparseable'; raw: string };
+
+export type ClaudeVersionProbe = () => ClaudeProbeResult;
+
+/**
+ * Default probe — spawns `claude --version` with a 5s timeout. Returns
+ * `not_detected` on ENOENT / non-zero exit / spawn error; `unparseable` when
+ * output exists but no semver triple is present. Split out from step1 so
+ * tests can inject a fake probe without needing a real claude binary.
+ */
+export const defaultClaudeVersionProbe: ClaudeVersionProbe = () => {
+  let result: ReturnType<typeof spawnSync>;
+  try {
+    result = spawnSync('claude', ['--version'], {
+      encoding: 'utf8',
+      timeout: 5_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch {
+    return { kind: 'not_detected' };
+  }
+
+  if (result.error || result.status === null || result.status !== 0) {
+    return { kind: 'not_detected' };
+  }
+
+  const raw = (result.stdout ?? '').toString().trim();
+  const parsed = parseClaudeVersion(raw);
+  if (!parsed) {
+    return { kind: 'unparseable', raw };
+  }
+  return { kind: 'ok', version: parsed, raw };
+};
+
+// Test seam — swap the probe without touching step1's StepFn signature.
+// Tests call `__setClaudeVersionProbe(fakeProbe)` in beforeEach, then
+// `__resetClaudeVersionProbe()` in afterEach.
+let activeProbe: ClaudeVersionProbe = defaultClaudeVersionProbe;
+export function __setClaudeVersionProbe(probe: ClaudeVersionProbe): void {
+  activeProbe = probe;
+}
+export function __resetClaudeVersionProbe(): void {
+  activeProbe = defaultClaudeVersionProbe;
+}
+
 export const step1: StepFn = async ({ ctx }) => {
+  // ── Node version check ────────────────────────────────────────────────────
   const major = parseNodeMajor(process.versions.node);
   if (major === null || major < MIN_NODE_MAJOR) {
     // CTO-6 / HoD-4b: exit BEFORE any network/IO. bin/mysecond.cjs has its own
@@ -27,11 +114,38 @@ export const step1: StepFn = async ({ ctx }) => {
     throw MysecondError.nodeTooOld(process.versions.node);
   }
 
+  // ── --project-dir safety check ────────────────────────────────────────────
   const root = isAbsolute(ctx.rootDir) ? ctx.rootDir : resolve(process.cwd(), ctx.rootDir);
   if (isForbiddenProjectDir(root)) {
     throw MysecondError.localStateConflict(
       `--project-dir=${root} refused (path traversal / system dir guard)`
     );
+  }
+
+  // ── Claude Code version floor (CAIO Y-CC-Floor) ──────────────────────────
+  const probed = activeProbe();
+
+  switch (probed.kind) {
+    case 'ok': {
+      const required = parseClaudeVersion(MIN_CLAUDE_CODE_VERSION);
+      if (!required) {
+        // Dev-time assertion — MIN_CLAUDE_CODE_VERSION is a constant we control.
+        throw new Error(
+          `MIN_CLAUDE_CODE_VERSION='${MIN_CLAUDE_CODE_VERSION}' failed to parse. Build broken.`
+        );
+      }
+      if (compareVersions(probed.version, required) < 0) {
+        throw MysecondError.claudeCodeTooOld(probed.raw, MIN_CLAUDE_CODE_VERSION);
+      }
+      break;
+    }
+    case 'not_detected':
+      throw MysecondError.claudeCodeNotDetected();
+    case 'unparseable':
+      // Conservative: unparseable output (e.g., a future Claude Code release
+      // changes the version format) shouldn't block install. If the actual
+      // marketplace command fails later, step 9's telemetry surfaces it.
+      break;
   }
 
   return { step: 1, outcome: { kind: 'completed' } };

--- a/tests/lib/step-1.test.ts
+++ b/tests/lib/step-1.test.ts
@@ -1,0 +1,198 @@
+// Tests for step-1 claude-version floor (CAIO Y-CC-Floor).
+//
+// Strategy: inject a fake ClaudeVersionProbe so we don't need a real claude
+// binary. Verifies the Node check still fires + the new Claude Code version
+// gate rejects old versions / missing binary / passes current + future versions.
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  compareVersions,
+  MIN_CLAUDE_CODE_VERSION,
+  parseClaudeVersion,
+  step1,
+  __setClaudeVersionProbe,
+  __resetClaudeVersionProbe,
+  type ClaudeProbeResult,
+} from '../../src/lib/steps/step-1.js';
+import { MysecondError } from '../../src/lib/errors.js';
+import type { StepContext } from '../../src/lib/steps/types.js';
+
+const originalEnv = { ...process.env };
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'mysecond-step1-test-'));
+  __resetClaudeVersionProbe();
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { force: true, recursive: true });
+  process.env = { ...originalEnv };
+  __resetClaudeVersionProbe();
+});
+
+function fakeCtx(rootDir = tmpRoot): StepContext {
+  return {
+    ctx: {
+      rootDir,
+      apiKey: 'msk_test',
+      baseUrl: 'https://app.mysecond.ai',
+      silent: true,
+      dryRun: false,
+      fix: false,
+    },
+    state: {},
+    shared: {},
+  } as unknown as StepContext;
+}
+
+function fakeProbe(result: ClaudeProbeResult) {
+  return () => result;
+}
+
+describe('parseClaudeVersion', () => {
+  it('parses bare semver', () => {
+    expect(parseClaudeVersion('2.1.118')).toEqual([2, 1, 118]);
+  });
+
+  it('parses "claude 2.1.118" form', () => {
+    expect(parseClaudeVersion('claude 2.1.118')).toEqual([2, 1, 118]);
+  });
+
+  it('parses "Claude Code 2.1.118" form', () => {
+    expect(parseClaudeVersion('Claude Code 2.1.118')).toEqual([2, 1, 118]);
+  });
+
+  it('parses "2.1.118 (Claude Code)" form', () => {
+    expect(parseClaudeVersion('2.1.118 (Claude Code)')).toEqual([2, 1, 118]);
+  });
+
+  it('handles double-digit minor/patch', () => {
+    expect(parseClaudeVersion('10.20.30')).toEqual([10, 20, 30]);
+  });
+
+  it('returns null on unparseable strings', () => {
+    expect(parseClaudeVersion('some other string')).toBeNull();
+    expect(parseClaudeVersion('2.1')).toBeNull(); // missing patch
+    expect(parseClaudeVersion('')).toBeNull();
+  });
+});
+
+describe('compareVersions', () => {
+  it('returns zero on equal', () => {
+    expect(compareVersions([2, 1, 118], [2, 1, 118])).toBe(0);
+  });
+
+  it('returns negative when first is older', () => {
+    expect(compareVersions([2, 1, 117], [2, 1, 118])).toBeLessThan(0);
+    expect(compareVersions([2, 0, 999], [2, 1, 0])).toBeLessThan(0);
+    expect(compareVersions([1, 99, 99], [2, 0, 0])).toBeLessThan(0);
+  });
+
+  it('returns positive when first is newer', () => {
+    expect(compareVersions([2, 1, 119], [2, 1, 118])).toBeGreaterThan(0);
+    expect(compareVersions([3, 0, 0], [2, 99, 99])).toBeGreaterThan(0);
+  });
+});
+
+describe('step1 — Claude Code version gate', () => {
+  it('passes on exact floor version', async () => {
+    __setClaudeVersionProbe(
+      fakeProbe({ kind: 'ok', version: [2, 1, 118], raw: '2.1.118' })
+    );
+    const result = await step1(fakeCtx());
+    expect(result.outcome.kind).toBe('completed');
+  });
+
+  it('passes on newer version', async () => {
+    __setClaudeVersionProbe(
+      fakeProbe({ kind: 'ok', version: [2, 1, 200], raw: '2.1.200' })
+    );
+    const result = await step1(fakeCtx());
+    expect(result.outcome.kind).toBe('completed');
+  });
+
+  it('passes on much newer version', async () => {
+    __setClaudeVersionProbe(
+      fakeProbe({ kind: 'ok', version: [3, 0, 0], raw: '3.0.0' })
+    );
+    const result = await step1(fakeCtx());
+    expect(result.outcome.kind).toBe('completed');
+  });
+
+  it('rejects older patch version with claudeCodeTooOld (exit 5)', async () => {
+    __setClaudeVersionProbe(
+      fakeProbe({ kind: 'ok', version: [2, 1, 117], raw: '2.1.117' })
+    );
+    await expect(step1(fakeCtx())).rejects.toMatchObject({
+      exitCode: 5,
+      subCode: 'claude_code_too_old',
+    });
+  });
+
+  it('rejects older minor version', async () => {
+    __setClaudeVersionProbe(
+      fakeProbe({ kind: 'ok', version: [2, 0, 500], raw: '2.0.500' })
+    );
+    await expect(step1(fakeCtx())).rejects.toMatchObject({
+      exitCode: 5,
+      subCode: 'claude_code_too_old',
+    });
+  });
+
+  it('rejects older major version', async () => {
+    __setClaudeVersionProbe(
+      fakeProbe({ kind: 'ok', version: [1, 99, 999], raw: '1.99.999' })
+    );
+    await expect(step1(fakeCtx())).rejects.toMatchObject({
+      exitCode: 5,
+      subCode: 'claude_code_too_old',
+    });
+  });
+
+  it('error message cites the required version so customer knows what to upgrade to', async () => {
+    __setClaudeVersionProbe(
+      fakeProbe({ kind: 'ok', version: [2, 1, 100], raw: '2.1.100' })
+    );
+    try {
+      await step1(fakeCtx());
+      throw new Error('expected throw');
+    } catch (err) {
+      const e = err as MysecondError;
+      expect(e.message).toContain(MIN_CLAUDE_CODE_VERSION);
+      expect(e.message).toContain('2.1.100');
+    }
+  });
+
+  it('rejects when claude binary not detected (ENOENT / non-zero)', async () => {
+    __setClaudeVersionProbe(fakeProbe({ kind: 'not_detected' }));
+    await expect(step1(fakeCtx())).rejects.toMatchObject({
+      exitCode: 5,
+      subCode: 'claude_code_too_old',
+    });
+  });
+
+  it('not-detected error copy guides customer to Claude Code bash tool', async () => {
+    __setClaudeVersionProbe(fakeProbe({ kind: 'not_detected' }));
+    try {
+      await step1(fakeCtx());
+      throw new Error('expected throw');
+    } catch (err) {
+      const e = err as MysecondError;
+      expect(e.message).toContain('Claude Code');
+      expect(e.message.toLowerCase()).toContain('bash');
+    }
+  });
+
+  it('passes through when version output is unparseable (forward-compat for future CC releases)', async () => {
+    __setClaudeVersionProbe(
+      fakeProbe({ kind: 'unparseable', raw: 'ClaudeCode-NEXT-GA 2026-q3' })
+    );
+    const result = await step1(fakeCtx());
+    expect(result.outcome.kind).toBe('completed');
+  });
+});


### PR DESCRIPTION
## Summary

- Bumps `package.json` version from `1.1.0-rc.0` → `1.1.0`
- Regenerates `package-lock.json`
- All 137 tests pass (`npm run test`)
- TypeScript clean (`npm run typecheck`)
- Binary smoke: `node bin/mysecond.cjs --version` → `1.1.0`
- Pack smoke: tarball contains `bin/mysecond.cjs` + `dist/mysecond.mjs`

## Claude Code version floor

`MIN_CLAUDE_CODE_VERSION = '2.1.118'` (in `src/lib/steps/step-1.ts`). Ron's current CC Desktop is `2.1.122` — floor will not block.

## Publish step (requires Ron's 2FA)

```bash
cd /Users/ronyang/dev/mysecond-cli
npm publish --access public --otp=<6-digit-npm-otp>
git tag v1.1.0 && git push --tags
```

After publish: verify with `npm view @mysecond/cli version` → `1.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)