### PR TITLE
fix(p0): CLAUDECODE=1 primary CC env signal + telemetry + sync warn-not-throw; v1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.1.0-rc.0",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mysecond/cli",
-      "version": "1.1.0-rc.0",
+      "version": "1.1.3",
       "license": "UNLICENSED",
       "dependencies": {
         "proper-lockfile": "^4.1.2",
@@ -24,7 +24,7 @@
         "vitest": "^1.6.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -820,7 +820,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.1.0-rc.0",
+  "version": "1.1.3",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {
@@ -11,7 +11,7 @@
     "bin/"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "build": "node esbuild.config.mjs",

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -3,7 +3,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
-import { cliSync, artifactsSync, confirmFirstSetup } from '../lib/api.js';
+import { cliSync, artifactsSync, confirmFirstSetup, emitTelemetry } from '../lib/api.js';
 import type { CommandContext } from '../lib/context.js';
 import { resolveConflict, type ConflictOutcome } from '../lib/conflict.js';
 import { MysecondError } from '../lib/errors.js';
@@ -207,7 +207,31 @@ export async function runSync(
   const cliSyncOpts: { timeoutMs?: number } = ctx.silent
     ? { timeoutMs: SILENT_SYNC_TIMEOUT_MS }
     : {};
-  const response = await cliSync(ctx, previousPaths, cliSyncOpts);
+
+  // CTO P1: context sync failure is partial-success, not a hard install failure.
+  // Plugin install already succeeded at this point. Warn loudly + exit 0 so
+  // the customer has a working PM OS (minus the context files), and knows to retry.
+  // CTO BLOCKING-1: emit sync_failed telemetry with HTTP status for funnel analysis.
+  let response: Awaited<ReturnType<typeof cliSync>>;
+  try {
+    response = await cliSync(ctx, previousPaths, cliSyncOpts);
+  } catch (err) {
+    const httpCode = err instanceof MysecondError ? err.exitCode : -1;
+    const errMsg = err instanceof Error ? err.message : String(err);
+    void emitTelemetry(ctx, 'mysecond.install.sync_failed', {
+      slug: state.customerSlug ?? 'unknown',
+      http_code: httpCode,
+      error: errMsg,
+    });
+    process.stderr.write(
+      `mysecond: Context sync incomplete (${errMsg}).\n` +
+      `  Your PM OS is installed but context files are not downloaded yet.\n` +
+      `  Run \`mysecond sync\` to retry. If this persists, email hello@mysecond.ai with slug: ${state.customerSlug ?? 'unknown'}.\n`
+    );
+    // Exit 0 — partial success. Plugin is installed; only context files missing.
+    return 0;
+  }
+
   const contextFiles: ContextFile[] = response.context_files ?? response.files ?? [];
   const customSkills = response.custom_skills ?? [];
   const customAgents = response.custom_agents ?? [];

--- a/src/lib/init-runner.ts
+++ b/src/lib/init-runner.ts
@@ -31,6 +31,15 @@ export async function runInit(ctx: CommandContext): Promise<number> {
   // Load state (or empty defaults).
   const state = readSyncState(ctx.rootDir);
 
+  // CTO BLOCKING-1: install funnel telemetry. Fire-and-forget — never block
+  // install on telemetry. Slug may not be known yet (comes from env or step 4),
+  // so send what we have. Completed event fires after all 13 steps succeed.
+  const telemetrySlug = process.env.MYSECOND_CUSTOMER_SLUG ?? state.customerSlug ?? 'unknown';
+  void emitTelemetry(ctx, 'mysecond.install.started', {
+    slug: telemetrySlug,
+    resuming: state.initCompletedSteps !== undefined && state.initCompletedSteps.length > 0,
+  });
+
   // Stale-tmp cleanup on resume (CTO-2 + RT-1 lock-scoped — §6.2).
   // Scan ~/.mysecond/marketplaces/, .claude/sync-state.json parent dir,
   // .env parent, .claude/settings.json parent, CLAUDE.md parent for *.tmp-{pid}
@@ -112,6 +121,12 @@ export async function runInit(ctx: CommandContext): Promise<number> {
       if (!ctx.silent) {
         process.stdout.write('\nDRY-RUN PASSED — would exit 0 on real run.\n');
       }
+    } else {
+      // CTO BLOCKING-1: emit install.completed on first-time success.
+      // Re-runs (resume from partial) still emit — server can deduplicate on slug.
+      void emitTelemetry(ctx, 'mysecond.install.completed', {
+        slug: sctx.shared.customerId ?? telemetrySlug,
+      });
     }
 
     return 0;

--- a/src/lib/paste-detect.ts
+++ b/src/lib/paste-detect.ts
@@ -1,14 +1,46 @@
 // Wrong-window paste detection per EDD §6.9.
-// Detection: $CLAUDE_PROJECT_DIR env unset AND no `.claude/` dir in CWD or any
+// Detection: no Claude Code env signals AND no `.claude/` dir in CWD or any
 // parent up to $HOME. Customer pasted the install command into a regular
 // terminal instead of Claude Code's terminal.
+//
+// Claude Code bash sandbox env signals (empirically verified 2026-04-29):
+//   CLAUDECODE=1               — reliably set; PRIMARY signal
+//   CLAUDE_PROJECT_DIR=""      — set but to EMPTY STRING (not undefined) — do NOT use as primary
+//   CLAUDE_CODE_ACCOUNT_UUID   — documented but NOT set in bash sandbox in current CC versions
+//   CLAUDE_CODE_ENTRYPOINT     — set to "claude-desktop" in Desktop, varies in CLI
+//
+// Decision: CLAUDECODE=1 is the primary gate. The others are belt-and-suspenders.
+// CLAUDE_CODE_ACCOUNT_UUID added as a future-proof check in case Anthropic starts
+// setting it in the bash sandbox (per context/anthropic-tools.md it is documented
+// as a valid CC env var).
 
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 export function isInClaudeCodeContext(cwd: string = process.cwd()): boolean {
-  // Fast path: env var set means we're already inside Claude Code.
+  // Primary: CLAUDECODE=1 — reliably set in CC's bash sandbox across all versions.
+  // This is the only signal that is (a) non-empty and (b) consistently present.
+  if (process.env.CLAUDECODE === '1') {
+    return true;
+  }
+
+  // Belt-and-suspenders: CLAUDE_CODE_ACCOUNT_UUID — documented as a CC env var
+  // (context/anthropic-tools.md). Not currently set in bash sandbox but may be
+  // in future CC versions or in non-bash execution contexts.
+  if (process.env.CLAUDE_CODE_ACCOUNT_UUID !== undefined && process.env.CLAUDE_CODE_ACCOUNT_UUID !== '') {
+    return true;
+  }
+
+  // Belt-and-suspenders: CLAUDE_CODE_ENTRYPOINT — set by CC Desktop/CLI to
+  // "claude-desktop" or similar. Not set in regular terminals.
+  if (process.env.CLAUDE_CODE_ENTRYPOINT !== undefined && process.env.CLAUDE_CODE_ENTRYPOINT !== '') {
+    return true;
+  }
+
+  // Secondary: CLAUDE_PROJECT_DIR set to a non-empty path.
+  // Note: CC sandbox sets this to "" (empty string), so empty string is NOT
+  // a valid signal — must check for non-empty explicitly.
   if (process.env.CLAUDE_PROJECT_DIR !== undefined && process.env.CLAUDE_PROJECT_DIR !== '') {
     return true;
   }

--- a/tests/lib/paste-detect.test.ts
+++ b/tests/lib/paste-detect.test.ts
@@ -6,27 +6,82 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { isInClaudeCodeContext, WRONG_WINDOW_COPY } from '../../src/lib/paste-detect.js';
 
+const CC_ENV_VARS = ['CLAUDECODE', 'CLAUDE_PROJECT_DIR', 'CLAUDE_CODE_ACCOUNT_UUID', 'CLAUDE_CODE_ENTRYPOINT'];
+
 let workDir: string;
-let originalEnv: string | undefined;
+let savedEnv: Record<string, string | undefined> = {};
 
 beforeEach(() => {
   workDir = mkdtempSync(join(tmpdir(), 'mysecond-paste-'));
-  originalEnv = process.env.CLAUDE_PROJECT_DIR;
-  delete process.env.CLAUDE_PROJECT_DIR;
+  // Save and clear ALL CC env signals so tests don't cross-contaminate
+  // (especially important when running inside the CC bash sandbox itself
+  // where CLAUDECODE=1 is always present).
+  savedEnv = {};
+  for (const key of CC_ENV_VARS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
 });
 
 afterEach(() => {
-  if (originalEnv !== undefined) process.env.CLAUDE_PROJECT_DIR = originalEnv;
-  else delete process.env.CLAUDE_PROJECT_DIR;
+  for (const key of CC_ENV_VARS) {
+    if (savedEnv[key] !== undefined) process.env[key] = savedEnv[key];
+    else delete process.env[key];
+  }
   rmSync(workDir, { recursive: true, force: true });
 });
 
 describe('paste-detect (§6.9 wrong-window detection)', () => {
-  it('returns true when CLAUDE_PROJECT_DIR is set (fast path)', () => {
+  // Primary signal: CLAUDECODE=1
+  it('returns true when CLAUDECODE=1 (primary fast path)', () => {
+    process.env.CLAUDECODE = '1';
+    expect(isInClaudeCodeContext('/anywhere')).toBe(true);
+  });
+
+  it('returns false when CLAUDECODE is set to something other than "1"', () => {
+    process.env.CLAUDECODE = 'true';
+    expect(isInClaudeCodeContext(workDir)).toBe(false);
+  });
+
+  it('CLAUDECODE=1 rescues fresh project with no .claude/ dir yet (P0 regression)', () => {
+    // Real P0 scenario: customer pastes into CC on a fresh empty folder.
+    // No .claude/ exists yet. CLAUDECODE=1 is the only reliable signal.
+    process.env.CLAUDECODE = '1';
+    expect(isInClaudeCodeContext(workDir)).toBe(true);
+  });
+
+  // Belt-and-suspenders: CLAUDE_CODE_ACCOUNT_UUID (documented CC env var per anthropic-tools.md)
+  it('returns true when CLAUDE_CODE_ACCOUNT_UUID is non-empty', () => {
+    process.env.CLAUDE_CODE_ACCOUNT_UUID = 'some-uuid-1234';
+    expect(isInClaudeCodeContext('/anywhere')).toBe(true);
+  });
+
+  it('does NOT treat CLAUDE_CODE_ACCOUNT_UUID="" as a valid CC signal', () => {
+    process.env.CLAUDE_CODE_ACCOUNT_UUID = '';
+    expect(isInClaudeCodeContext(workDir)).toBe(false);
+  });
+
+  // Belt-and-suspenders: CLAUDE_CODE_ENTRYPOINT (set by CC Desktop/CLI)
+  it('returns true when CLAUDE_CODE_ENTRYPOINT is non-empty', () => {
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'claude-desktop';
+    expect(isInClaudeCodeContext('/anywhere')).toBe(true);
+  });
+
+  // Secondary signal: CLAUDE_PROJECT_DIR (non-empty path)
+  it('returns true when CLAUDE_PROJECT_DIR is set to a non-empty path', () => {
     process.env.CLAUDE_PROJECT_DIR = '/some/path';
     expect(isInClaudeCodeContext('/anywhere')).toBe(true);
   });
 
+  // Regression: CC bash sandbox sets CLAUDE_PROJECT_DIR="" (empty string).
+  // Previously this caused false-negative: init errored with WRONG_WINDOW_COPY
+  // even when running inside Claude Code on a fresh project folder.
+  it('does NOT treat CLAUDE_PROJECT_DIR="" as a valid CC signal (falls through to walk)', () => {
+    process.env.CLAUDE_PROJECT_DIR = '';
+    expect(isInClaudeCodeContext(workDir)).toBe(false);
+  });
+
+  // Filesystem walk fallback
   it('returns true when .claude/ dir exists in cwd', () => {
     mkdirSync(join(workDir, '.claude'));
     expect(isInClaudeCodeContext(workDir)).toBe(true);
@@ -39,7 +94,7 @@ describe('paste-detect (§6.9 wrong-window detection)', () => {
     expect(isInClaudeCodeContext(child)).toBe(true);
   });
 
-  it('returns false when no .claude/ in cwd or parents up to HOME', () => {
+  it('returns false when no CC env signals and no .claude/ in cwd or parents up to HOME', () => {
     // workDir is under $TMPDIR which is NOT under $HOME on macOS — perfect.
     expect(isInClaudeCodeContext(workDir)).toBe(false);
   });

--- a/tests/lib/red-team-regression.test.ts
+++ b/tests/lib/red-team-regression.test.ts
@@ -7,22 +7,34 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const CC_ENV_VARS = ['CLAUDECODE', 'CLAUDE_PROJECT_DIR', 'CLAUDE_CODE_ACCOUNT_UUID', 'CLAUDE_CODE_ENTRYPOINT'];
+
 let fakeHome: string;
 let originalHome: string | undefined;
-let originalProjectDir: string | undefined;
+let savedCcEnv: Record<string, string | undefined> = {};
 
 beforeEach(() => {
   fakeHome = mkdtempSync(join(tmpdir(), 'mysecond-redteam-'));
   originalHome = process.env.HOME;
-  originalProjectDir = process.env.CLAUDE_PROJECT_DIR;
   process.env.HOME = fakeHome;
-  delete process.env.CLAUDE_PROJECT_DIR;
+  // Clear ALL Claude Code env signals so filesystem-walk tests aren't
+  // short-circuited by ambient CC env (e.g. CLAUDECODE=1 when running
+  // inside the CC bash sandbox). Also clears new belt-and-suspenders
+  // signals added in v1.1.1: CLAUDE_CODE_ACCOUNT_UUID, CLAUDE_CODE_ENTRYPOINT.
+  savedCcEnv = {};
+  for (const key of CC_ENV_VARS) {
+    savedCcEnv[key] = process.env[key];
+    delete process.env[key];
+  }
   vi.resetModules();
 });
 
 afterEach(() => {
   if (originalHome !== undefined) process.env.HOME = originalHome;
-  if (originalProjectDir !== undefined) process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
+  for (const key of CC_ENV_VARS) {
+    if (savedCcEnv[key] !== undefined) process.env[key] = savedCcEnv[key];
+    else delete process.env[key];
+  }
   rmSync(fakeHome, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

**P0 install friction fix — CLI side.** Closes the two-part customer blocker:

1. **Permission denied on global install** → fixed by paste-message switching to `npx` (companion PR: mysecond-app commit 8f502a0 on design/impeccable)
2. **mysecond init errors even when running inside Claude Code** → this PR. Root cause: `CLAUDE_PROJECT_DIR` is set to `""` (empty string, not undefined) in CC's bash sandbox. The old check `!== undefined && !== ''` failed, fell through to `.claude/` directory walk, which also fails for fresh empty project folders. Fix: `CLAUDECODE=1` is now the primary detection signal (empirically confirmed present in CC bash sandbox).

## Changes

### paste-detect.ts — env check order
```
CLAUDECODE=1             (primary — reliably set in CC bash sandbox)
CLAUDE_CODE_ACCOUNT_UUID (belt-and-suspenders — documented, not yet set but future-proof)  
CLAUDE_CODE_ENTRYPOINT   (belt-and-suspenders — set by CC Desktop/CLI)
CLAUDE_PROJECT_DIR≠""    (secondary — was the only check before; broken by empty string)
.claude/ dir walk        (fallback for terminal users in existing CC workspaces)
```

### install telemetry (BLOCKING-1)
Fire-and-forget events added to init funnel:
- `mysecond.install.started` — with slug + resuming flag
- `mysecond.install.completed` — with slug
- `mysecond.install.sync_failed` — with slug + http_code + error (in sync.ts)

### sync failure semantics (P1)
`cliSync` HTTP failure now warns loudly + exits 0. Plugin install already succeeded at this point; only context files are missing. Customer gets: _"Context sync incomplete. Your PM OS is installed but context files are not downloaded yet. Run `mysecond sync` to retry."_

### Node engines (P1)
`>=18.0.0` → `>=20.0.0` (Node 18 EOL April 2025)

## Test plan

- [x] `npx vitest run` — 125/125 tests pass (3 new tests for CLAUDE_CODE_ACCOUNT_UUID, CLAUDE_CODE_ENTRYPOINT, and the fresh-folder P0 scenario)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — 79.0kb
- [x] Playwright smoke test on preview — confirmed `npx` in deployed JS bundle, `npm install -g` absent
- [ ] Ron manual paste-test on fresh Claude Code session (canonical gate — Ron's call)

## Rollback

```bash
npm dist-tag add @mysecond/cli@1.1.2 latest
```
Rolls `@latest` back to 1.1.2 in ~30 seconds. Both 1.1.1 and 1.1.2 also available as rollback targets.

## Version history
- 1.1.1 — first env-marker attempt (published 20h ago — had correct CLAUDECODE=1 logic but published before full review stack)
- 1.1.2 — CAIO amendments (CLAUDE_CODE_ACCOUNT_UUID, CLAUDE_CODE_ENTRYPOINT, test cleanup)
- **1.1.3 — this PR** (CTO amendments: telemetry, sync warn-not-throw, Node 20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)