### PR TITLE
feat(sync): context-file up-sync to /api/companion/files; v1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ coverage/
 .env
 .env.local
 .vitest-cache/
+
+# Local verification scratch
+.tmp/
+mysecond-cli-*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mysecond/cli",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "UNLICENSED",
       "dependencies": {
         "proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/artifact-sync.ts
+++ b/src/commands/artifact-sync.ts
@@ -6,10 +6,17 @@
 
 import { readFileSync, statSync } from 'node:fs';
 
-import { artifactsSync } from '../lib/api.js';
+import { artifactsSync, contextFilesPush } from '../lib/api.js';
 import type { CommandContext } from '../lib/context.js';
 import { relativeFromRoot, shortHash } from '../lib/files.js';
-import { classifyArtifactType, type ArtifactPayload } from '../lib/payload.js';
+import {
+  CONTEXT_PER_FILE_LIMIT,
+  classifyArtifactType,
+  isContextFile,
+  type ArtifactPayload,
+  type ContextFilePayload,
+} from '../lib/payload.js';
+import { readSyncState, writeSyncState } from '../lib/sync-state.js';
 
 interface ToolEvent {
   tool_name?: string;
@@ -62,6 +69,44 @@ export async function runArtifactSync(
 
   const relativePath = relativeFromRoot(ctx.rootDir, filePath);
   if (relativePath === null) return 0;
+
+  // Context-file branch — checked BEFORE artifact classification so the same
+  // file can never be misrouted (context/foo.md must never be classified as
+  // an artifact, even if some future ARTIFACT_DIRS entry overlapped).
+  if (isContextFile(relativePath)) {
+    let content: string;
+    try {
+      const stat = statSync(filePath);
+      if (stat.size > CONTEXT_PER_FILE_LIMIT) return 0;
+      content = readFileSync(filePath, 'utf8');
+    } catch {
+      return 0;
+    }
+    if (content.length === 0) return 0;
+
+    const hash = shortHash(content);
+    const payload: ContextFilePayload = {
+      file_path: relativePath,
+      content,
+      current_hash: hash,
+    };
+
+    try {
+      const result = await contextFilesPush(ctx, [payload]);
+      // Persist sync-state ONLY on a confirmed push. synced > 0 means insert
+      // or update; skipped > 0 means server hash matched (already in sync —
+      // record it so SessionStart can de-dupe). Pure-error response leaves
+      // state untouched so the next SessionStart up-loop retries.
+      if (result.synced > 0 || result.skipped > 0) {
+        const state = readSyncState(ctx.rootDir);
+        state.contextFiles[relativePath] = { hash, pushedAt: new Date().toISOString() };
+        writeSyncState(ctx.rootDir, state);
+      }
+    } catch {
+      // Best-effort: TODO(telemetry) emit PostHog event when telemetry lands.
+    }
+    return 0;
+  }
 
   const artifactType = classifyArtifactType(relativePath);
   if (artifactType === null) return 0;

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -3,7 +3,13 @@
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
-import { cliSync, artifactsSync, confirmFirstSetup, emitTelemetry } from '../lib/api.js';
+import {
+  cliSync,
+  artifactsSync,
+  contextFilesPush,
+  confirmFirstSetup,
+  emitTelemetry,
+} from '../lib/api.js';
 import type { CommandContext } from '../lib/context.js';
 import { resolveConflict, type ConflictOutcome } from '../lib/conflict.js';
 import { MysecondError } from '../lib/errors.js';
@@ -16,6 +22,7 @@ import {
 import { markNpmUpdated, shouldRunNpmUpdate } from '../lib/npm.js';
 import {
   scanArtifacts,
+  scanContextFiles,
   type CompanionFile,
   type ContextFile,
 } from '../lib/payload.js';
@@ -42,6 +49,7 @@ interface SyncSummary {
   agentsUpdated: number;
   workflowsUpdated: number;
   artifactsPushed: number;
+  contextFilesPushed: number;
   claudeMdUpdated: boolean;
   npmUpdateRan: boolean;
 }
@@ -60,6 +68,7 @@ function emptySummary(): SyncSummary {
     agentsUpdated: 0,
     workflowsUpdated: 0,
     artifactsPushed: 0,
+    contextFilesPushed: 0,
     claudeMdUpdated: false,
     npmUpdateRan: false,
   };
@@ -142,6 +151,27 @@ async function upSyncArtifacts(
   return result.synced;
 }
 
+async function upSyncContextFiles(
+  ctx: CommandContext,
+  state: SyncState
+): Promise<number> {
+  const files = scanContextFiles(ctx.rootDir);
+  const toSync = files.filter((f) => {
+    const last = state.contextFiles[f.file_path];
+    return !last || last.hash !== f.current_hash;
+  });
+  if (toSync.length === 0) return 0;
+
+  const result = await contextFilesPush(ctx, toSync);
+  if (result.synced > 0 || result.skipped > 0) {
+    const now = new Date().toISOString();
+    for (const f of toSync) {
+      state.contextFiles[f.file_path] = { hash: f.current_hash, pushedAt: now };
+    }
+  }
+  return result.synced;
+}
+
 function printSummary(summary: SyncSummary, ctx: CommandContext): void {
   // CAIO finding: stderr from SessionStart hooks is silently dropped on exit 0.
   // Customer-relevant messages MUST go to stdout when ctx.silent so Claude sees
@@ -157,6 +187,7 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
     if (summary.agentsUpdated > 0) parts.push(`${summary.agentsUpdated} agents`);
     if (summary.workflowsUpdated > 0) parts.push(`${summary.workflowsUpdated} workflows`);
     if (summary.artifactsPushed > 0) parts.push(`${summary.artifactsPushed} artifacts pushed`);
+    if (summary.contextFilesPushed > 0) parts.push(`${summary.contextFilesPushed} context files pushed`);
     const conflicts =
       summary.conflictsCloudKept + summary.conflictsLocalKept + summary.conflictsSkipped;
     if (conflicts > 0) parts.push(`${conflicts} conflicts (see .claude/sync-conflicts/)`);
@@ -178,6 +209,7 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
   if (summary.agentsUpdated) parts.push(`${summary.agentsUpdated} agents`);
   if (summary.workflowsUpdated) parts.push(`${summary.workflowsUpdated} workflows`);
   if (summary.artifactsPushed) parts.push(`${summary.artifactsPushed} artifacts pushed`);
+  if (summary.contextFilesPushed) parts.push(`${summary.contextFilesPushed} context files pushed`);
   if (summary.claudeMdUpdated) parts.push('CLAUDE.md updated');
   if (parts.length === 0) parts.push('nothing changed');
 
@@ -278,6 +310,16 @@ export async function runSync(
     if (!ctx.silent) {
       process.stderr.write(
         `mysecond: artifact up-sync failed (${err instanceof Error ? err.message : String(err)}). Down-sync OK.\n`
+      );
+    }
+  }
+
+  try {
+    summary.contextFilesPushed = await upSyncContextFiles(ctx, state);
+  } catch (err) {
+    if (!ctx.silent) {
+      process.stderr.write(
+        `mysecond: context-file up-sync failed (${err instanceof Error ? err.message : String(err)}). Down-sync OK.\n`
       );
     }
   }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,8 @@ import type {
   ArtifactPayload,
   ArtifactsResponse,
   CliSyncResponse,
+  ContextFilePayload,
+  ContextFilesResponse,
 } from './payload.js';
 import type { PluginTarballMeta } from './plugin-tarball.js';
 
@@ -125,6 +127,24 @@ export async function artifactsSync(
     return { synced: 0 };
   }
   return response.body as ArtifactsResponse;
+}
+
+// POST /api/companion/files — up-sync context files (company/product/personas/
+// competitors/goals + nested under context/). Mirrors artifactsSync semantics:
+// best-effort, server returns { synced, skipped, errors }.
+export async function contextFilesPush(
+  ctx: CommandContext,
+  files: readonly ContextFilePayload[]
+): Promise<ContextFilesResponse> {
+  if (files.length === 0) return { synced: 0, skipped: 0, errors: [] };
+  const response = await companionFetch(ctx, '/api/companion/files', {
+    method: 'POST',
+    body: { files },
+  });
+  if (response.status >= 400) {
+    return { synced: 0, skipped: 0, errors: [] };
+  }
+  return response.body as ContextFilesResponse;
 }
 
 // POST /api/setup/confirm — first-sync confirmation. Best-effort; non-critical

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -1,7 +1,7 @@
 // Payload type definitions for the mysecond-app companion API.
 // Mirrors GET /api/companion/cli-sync (down-sync) and POST /api/companion/artifacts.
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, join, relative } from 'node:path';
 
 import { shortHash } from './files.js';
@@ -57,6 +57,18 @@ export interface ArtifactsResponse {
   synced: number;
 }
 
+export interface ContextFilePayload {
+  file_path: string;
+  content: string;
+  current_hash: string;
+}
+
+export interface ContextFilesResponse {
+  synced: number;
+  skipped: number;
+  errors: string[];
+}
+
 export interface ArtifactDir {
   relativeDir: string;
   type: ArtifactType;
@@ -69,6 +81,21 @@ export const ARTIFACT_DIRS: readonly ArtifactDir[] = [
   { relativeDir: 'launch/outputs', type: 'launch' },
   { relativeDir: 'analytics/outputs', type: 'analytics' },
 ];
+
+export const CONTEXT_DIR = 'context';
+
+// Server PER_FILE_LIMIT is 50KB. Pre-filter to skip wasted round-trips.
+export const CONTEXT_PER_FILE_LIMIT = 50 * 1024;
+
+// Classify a write event's file path as a context file. Same path-safety
+// gate as classifyArtifactType — leading '/', traversal, absolute paths
+// rejected. Only `.md` files under `context/` qualify; nested paths
+// (e.g. context/personas/buyer.md) are supported.
+export function isContextFile(relativePath: string): boolean {
+  if (relativePath.startsWith('/') || relativePath.includes('..')) return false;
+  if (!relativePath.startsWith(CONTEXT_DIR + '/')) return false;
+  return relativePath.endsWith('.md');
+}
 
 // Classify a write event's file path into an artifact_type for PostToolUse.
 // Single source of truth — must agree with ARTIFACT_DIRS for the same paths or
@@ -97,6 +124,52 @@ export function scanArtifacts(rootDir: string): ArtifactPayload[] {
     walkArtifactDir(rootDir, dir, entry.type, found);
   }
   return found;
+}
+
+// Walk context/ under rootDir and produce payloads for every .md file. Mirrors
+// scanArtifacts but emits ContextFilePayload (no artifact_type / pm_name /
+// skill_slug) and uses CONTEXT_DIR as the single root.
+export function scanContextFiles(rootDir: string): ContextFilePayload[] {
+  const found: ContextFilePayload[] = [];
+  const dir = join(rootDir, CONTEXT_DIR);
+  if (!existsSync(dir)) return found;
+  walkContextDir(rootDir, dir, found);
+  return found;
+}
+
+function walkContextDir(
+  rootDir: string,
+  currentDir: string,
+  results: ContextFilePayload[]
+): void {
+  for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+    // Skip dotfiles/dotdirs — `.git/`, `.DS_Store`, scratch files like
+    // `.notes.md` shouldn't leak to the server. Mirrors gitignore convention.
+    if (entry.name.startsWith('.')) continue;
+    const fullPath = join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      walkContextDir(rootDir, fullPath, results);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+
+    let content: string;
+    try {
+      // stat first — readFileSync on a 500MB file would OOM the SessionStart
+      // hook before the size check. Read only after we know the size is sane.
+      const stat = statSync(fullPath);
+      if (stat.size === 0 || stat.size > CONTEXT_PER_FILE_LIMIT) continue;
+      content = readFileSync(fullPath, 'utf8');
+    } catch {
+      continue;
+    }
+
+    results.push({
+      file_path: relative(rootDir, fullPath),
+      content,
+      current_hash: shortHash(content),
+    });
+  }
 }
 
 function walkArtifactDir(

--- a/src/lib/sync-state.ts
+++ b/src/lib/sync-state.ts
@@ -17,9 +17,15 @@ export interface SyncStateArtifactEntry {
   pushedAt: string;
 }
 
+export interface SyncStateContextEntry {
+  hash: string;
+  pushedAt: string;
+}
+
 export interface SyncState {
   files: Record<string, SyncStateFileEntry>;
   artifacts: Record<string, SyncStateArtifactEntry>;
+  contextFiles: Record<string, SyncStateContextEntry>;
   lastSyncedAt: string | null;
   // EDD §5.3 — 24h npm-update timebox cache.
   lastNpmUpdateAt: string | null;
@@ -41,17 +47,20 @@ export interface SyncState {
   customerSlug: string | null;
 }
 
-const EMPTY_STATE: SyncState = {
-  files: {},
-  artifacts: {},
-  lastSyncedAt: null,
-  lastNpmUpdateAt: null,
-  initCompletedSteps: [],
-  step9Auth401RetryCount: 0,
-  customerId: null,
-  workspaceScope: null,
-  customerSlug: null,
-};
+function freshEmptyState(): SyncState {
+  return {
+    files: {},
+    artifacts: {},
+    contextFiles: {},
+    lastSyncedAt: null,
+    lastNpmUpdateAt: null,
+    initCompletedSteps: [],
+    step9Auth401RetryCount: 0,
+    customerId: null,
+    workspaceScope: null,
+    customerSlug: null,
+  };
+}
 
 export function readSyncState(rootDir: string): SyncState {
   const path = projectPaths(rootDir).syncStatePath;
@@ -59,15 +68,16 @@ export function readSyncState(rootDir: string): SyncState {
     const raw = readFileSync(path, 'utf8');
     const parsed = JSON.parse(raw) as Partial<SyncState>;
     return {
-      ...EMPTY_STATE,
+      ...freshEmptyState(),
       ...parsed,
       files: parsed.files ?? {},
       artifacts: parsed.artifacts ?? {},
+      contextFiles: parsed.contextFiles ?? {},
       initCompletedSteps: parsed.initCompletedSteps ?? [],
       step9Auth401RetryCount: parsed.step9Auth401RetryCount ?? 0,
     };
   } catch {
-    return { ...EMPTY_STATE };
+    return freshEmptyState();
   }
 }
 

--- a/tests/commands/artifact-sync.test.ts
+++ b/tests/commands/artifact-sync.test.ts
@@ -1,0 +1,282 @@
+// PostToolUse path tests for runArtifactSync, focused on the new context-file
+// branch. Mocks the fetch transport and stubs process.stdin so the test
+// exercises the real construction path (parses the tool event, walks the
+// context-file branch, builds the payload, and calls fetch).
+
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runArtifactSync } from '../../src/commands/artifact-sync.js';
+import type { CommandContext } from '../../src/lib/context.js';
+import { readSyncState } from '../../src/lib/sync-state.js';
+
+function tmpProject(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mysecond-artifact-sync-'));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  return root;
+}
+
+function ctx(rootDir: string, overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'test-key',
+    rootDir,
+    silent: true,
+    dryRun: false,
+    forceUpdate: false,
+    fix: false,
+    strategy: 'cloud-wins',
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function stubStdin(payload: string): void {
+  const stream = Readable.from([payload]);
+  // Match the interface readStdin uses: setEncoding + async iteration.
+  (stream as unknown as { setEncoding: (e: string) => void }).setEncoding = () => {};
+  Object.defineProperty(process, 'stdin', { value: stream, configurable: true });
+}
+
+function toolEvent(toolName: string, filePath: string): string {
+  return JSON.stringify({ tool_name: toolName, tool_input: { file_path: filePath } });
+}
+
+describe('runArtifactSync — context-file branch', () => {
+  let originalFetch: typeof fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalStdin: NodeJS.ReadStream;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    originalStdin = process.stdin;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true });
+  });
+
+  it('exits 0 immediately when apiKey is empty (no fetch)', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'hello');
+    stubStdin(toolEvent('Write', join(root, 'context/company.md')));
+
+    const code = await runArtifactSync([], ctx(root, { apiKey: '' }));
+    expect(code).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('pushes a context file via POST /api/companion/files with correct wire format', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'hello world');
+    fetchMock.mockResolvedValueOnce(jsonResponse({ synced: 1, skipped: 0, errors: [] }));
+    stubStdin(toolEvent('Write', join(root, 'context/company.md')));
+
+    const code = await runArtifactSync([], ctx(root));
+    expect(code).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.toString()).toBe('https://app.mysecond.ai/api/companion/files');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer test-key');
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({
+      files: [
+        {
+          file_path: 'context/company.md',
+          content: 'hello world',
+          current_hash: expect.stringMatching(/^[0-9a-f]{12}$/),
+        },
+      ],
+    });
+  });
+
+  it('persists sync-state on successful push so SessionStart can de-dupe', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'hello');
+    fetchMock.mockResolvedValueOnce(jsonResponse({ synced: 1, skipped: 0, errors: [] }));
+    stubStdin(toolEvent('Edit', join(root, 'context/company.md')));
+
+    await runArtifactSync([], ctx(root));
+
+    const state = readSyncState(root);
+    const entry = state.contextFiles['context/company.md'];
+    expect(entry).toBeDefined();
+    expect(entry?.hash).toMatch(/^[0-9a-f]{12}$/);
+    expect(entry?.pushedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('persists sync-state when server reports skipped (hash-match) — keeps state in step', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'hello');
+    fetchMock.mockResolvedValueOnce(jsonResponse({ synced: 0, skipped: 1, errors: [] }));
+    stubStdin(toolEvent('Write', join(root, 'context/company.md')));
+
+    await runArtifactSync([], ctx(root));
+
+    const state = readSyncState(root);
+    expect(state.contextFiles['context/company.md']).toBeDefined();
+  });
+
+  it('does NOT persist sync-state when server returns 5xx', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'hello');
+    fetchMock.mockResolvedValueOnce(new Response('boom', { status: 500 }));
+    stubStdin(toolEvent('Write', join(root, 'context/company.md')));
+
+    const code = await runArtifactSync([], ctx(root));
+    expect(code).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const state = readSyncState(root);
+    expect(state.contextFiles['context/company.md']).toBeUndefined();
+  });
+
+  it('does NOT persist sync-state when network throws', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'hello');
+    fetchMock.mockRejectedValueOnce(new Error('offline'));
+    stubStdin(toolEvent('Write', join(root, 'context/company.md')));
+
+    const code = await runArtifactSync([], ctx(root));
+    expect(code).toBe(0);
+
+    const state = readSyncState(root);
+    expect(state.contextFiles['context/company.md']).toBeUndefined();
+  });
+
+  it('skips empty context files', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/empty.md'), '');
+    stubStdin(toolEvent('Write', join(root, 'context/empty.md')));
+
+    const code = await runArtifactSync([], ctx(root));
+    expect(code).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips files larger than 50KB', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/huge.md'), 'x'.repeat(50 * 1024 + 1));
+    stubStdin(toolEvent('Write', join(root, 'context/huge.md')));
+
+    await runArtifactSync([], ctx(root));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('routes nested context paths', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context/personas'), { recursive: true });
+    writeFileSync(join(root, 'context/personas/buyer.md'), 'buyer');
+    fetchMock.mockResolvedValueOnce(jsonResponse({ synced: 1, skipped: 0, errors: [] }));
+    stubStdin(toolEvent('Write', join(root, 'context/personas/buyer.md')));
+
+    await runArtifactSync([], ctx(root));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe('/api/companion/files');
+  });
+
+  it('does NOT route root-level CLAUDE.md as a context file', async () => {
+    const root = tmpProject();
+    writeFileSync(join(root, 'CLAUDE.md'), '# project');
+    stubStdin(toolEvent('Write', join(root, 'CLAUDE.md')));
+
+    await runArtifactSync([], ctx(root));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT route paths outside context/ even when .md', async () => {
+    const root = tmpProject();
+    writeFileSync(join(root, 'NOT_CONTEXT.md'), 'x');
+    stubStdin(toolEvent('Write', join(root, 'NOT_CONTEXT.md')));
+
+    await runArtifactSync([], ctx(root));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects path-traversal escapes via relativeFromRoot guard', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    // Construct an absolute path OUTSIDE root.
+    stubStdin(toolEvent('Write', '/etc/passwd'));
+
+    await runArtifactSync([], ctx(root));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT push for non-write tools (Read/Bash/etc)', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'x');
+    stubStdin(toolEvent('Read', join(root, 'context/company.md')));
+
+    await runArtifactSync([], ctx(root));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('frontmatter round-trips byte-identical in payload', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    const content = '---\ntitle: Test\nfoo: bar\n---\n\n# Body\n';
+    writeFileSync(join(root, 'context/with-fm.md'), content);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ synced: 1, skipped: 0, errors: [] }));
+    stubStdin(toolEvent('Write', join(root, 'context/with-fm.md')));
+
+    await runArtifactSync([], ctx(root));
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.files[0].content).toBe(content);
+  });
+
+  it('preserves the artifact path: PRD writes still hit /api/companion/artifacts', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'specs/outputs'), { recursive: true });
+    const prdPath = join(root, 'specs/outputs/2026-04-30-prd-generator.md');
+    writeFileSync(prdPath, '# PRD');
+    fetchMock.mockResolvedValueOnce(jsonResponse({ synced: 1 }));
+    stubStdin(toolEvent('Write', prdPath));
+
+    await runArtifactSync([], ctx(root));
+    const [url] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe('/api/companion/artifacts');
+  });
+
+  it('handles malformed sync-state.json by reinitializing fresh state on success', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'x');
+    writeFileSync(join(root, '.claude/sync-state.json'), '{not valid json');
+    fetchMock.mockResolvedValueOnce(jsonResponse({ synced: 1, skipped: 0, errors: [] }));
+    stubStdin(toolEvent('Write', join(root, 'context/company.md')));
+
+    const code = await runArtifactSync([], ctx(root));
+    expect(code).toBe(0);
+
+    // Sync-state should now contain the freshly-pushed entry.
+    const written = JSON.parse(readFileSync(join(root, '.claude/sync-state.json'), 'utf8'));
+    expect(written.contextFiles['context/company.md']).toBeDefined();
+  });
+});

--- a/tests/commands/up-sync-context.test.ts
+++ b/tests/commands/up-sync-context.test.ts
@@ -1,0 +1,196 @@
+// SessionStart up-loop tests for the context-file branch of runSync.
+// Mocks the fetch transport — exercises the real construction path of
+// scanContextFiles → state filter → contextFilesPush → state mutation.
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runSync } from '../../src/commands/sync.js';
+import type { CommandContext } from '../../src/lib/context.js';
+import { writeSyncState, readSyncState, type SyncState } from '../../src/lib/sync-state.js';
+
+function tmpProject(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mysecond-up-sync-context-'));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  return root;
+}
+
+function ctx(rootDir: string, overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'test-key',
+    rootDir,
+    silent: true,
+    dryRun: false,
+    forceUpdate: false,
+    fix: false,
+    strategy: 'cloud-wins',
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function emptyDownSync(): unknown {
+  return {
+    context_files: [],
+    custom_skills: [],
+    custom_agents: [],
+    custom_workflows: [],
+    claude_md_override: null,
+    deleted_paths: [],
+    syncedAt: new Date().toISOString(),
+  };
+}
+
+function seedState(rootDir: string, partial: Partial<SyncState> = {}): void {
+  const base: SyncState = {
+    files: {},
+    artifacts: {},
+    contextFiles: {},
+    lastSyncedAt: '2026-04-29T00:00:00.000Z',
+    lastNpmUpdateAt: new Date().toISOString(),
+    initCompletedSteps: [],
+    step9Auth401RetryCount: 0,
+    customerId: null,
+    workspaceScope: null,
+    customerSlug: null,
+  };
+  writeSyncState(rootDir, { ...base, ...partial });
+}
+
+describe('upSyncContextFiles via runSync', () => {
+  let originalFetch: typeof fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('pushes new context files, recording state on success', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context/personas'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'company-content');
+    writeFileSync(join(root, 'context/personas/buyer.md'), 'buyer-content');
+    seedState(root);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(emptyDownSync())) // cli-sync GET
+      .mockResolvedValueOnce(jsonResponse({ synced: 2, skipped: 0, errors: [] })); // files POST
+
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+
+    const filesCall = fetchMock.mock.calls[1] as [URL, RequestInit];
+    expect(filesCall[0].pathname).toBe('/api/companion/files');
+    const body = JSON.parse(filesCall[1].body as string);
+    expect(body.files.map((f: { file_path: string }) => f.file_path).sort()).toEqual([
+      'context/company.md',
+      'context/personas/buyer.md',
+    ]);
+
+    const state = readSyncState(root);
+    expect(state.contextFiles['context/company.md']).toBeDefined();
+    expect(state.contextFiles['context/personas/buyer.md']).toBeDefined();
+  });
+
+  it('skips files whose hash matches the recorded state (idempotent)', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    const content = 'unchanged';
+    writeFileSync(join(root, 'context/company.md'), content);
+
+    // shortHash of "unchanged" — capture by running once and reading state, but
+    // we just need the matching value. Compute it here to seed state.
+    const { shortHash } = await import('../../src/lib/files.js');
+    seedState(root, {
+      contextFiles: {
+        'context/company.md': { hash: shortHash(content), pushedAt: new Date().toISOString() },
+      },
+    });
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(emptyDownSync()));
+
+    await runSync([], ctx(root));
+
+    // Only one fetch (the cli-sync GET). No files POST because everything matched state.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('records state on skipped (server-side hash match) just like synced', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'hello');
+    seedState(root);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(emptyDownSync()))
+      .mockResolvedValueOnce(jsonResponse({ synced: 0, skipped: 1, errors: [] }));
+
+    await runSync([], ctx(root));
+
+    const state = readSyncState(root);
+    expect(state.contextFiles['context/company.md']).toBeDefined();
+  });
+
+  it('does NOT block down-sync when context-file push fails', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'hello');
+    seedState(root);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(emptyDownSync()))
+      .mockResolvedValueOnce(new Response('boom', { status: 500 }));
+
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+
+    const state = readSyncState(root);
+    expect(state.contextFiles['context/company.md']).toBeUndefined();
+  });
+
+  it('handles missing context/ dir cleanly (no scan = no push)', async () => {
+    const root = tmpProject();
+    seedState(root);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(emptyDownSync()));
+
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('artifact failure does not prevent context-file push', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    mkdirSync(join(root, 'specs/outputs'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'hello');
+    writeFileSync(join(root, 'specs/outputs/foo.md'), '# PRD');
+    seedState(root);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(emptyDownSync())) // cli-sync
+      .mockResolvedValueOnce(new Response('boom', { status: 500 })) // artifacts POST fails
+      .mockResolvedValueOnce(jsonResponse({ synced: 1, skipped: 0, errors: [] })); // files POST
+
+    await runSync([], ctx(root));
+
+    const state = readSyncState(root);
+    expect(state.contextFiles['context/company.md']).toBeDefined();
+  });
+});

--- a/tests/lib/api.test.ts
+++ b/tests/lib/api.test.ts
@@ -1,0 +1,109 @@
+// Mocks the fetch transport — NOT contextFilesPush itself. Tests assert the
+// outgoing wire format (URL, method, Authorization header, body shape) so a
+// regression that breaks the server contract surfaces here. Mirrors the PR
+// #107 regression-test template referenced in CLAUDE.md.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { contextFilesPush } from '../../src/lib/api.js';
+import type { CommandContext } from '../../src/lib/context.js';
+import type { ContextFilePayload } from '../../src/lib/payload.js';
+
+function ctx(overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'test-key-123',
+    rootDir: '/tmp/x',
+    silent: false,
+    dryRun: false,
+    forceUpdate: false,
+    fix: false,
+    strategy: 'cloud-wins',
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function file(path: string, content: string): ContextFilePayload {
+  return { file_path: path, content, current_hash: 'h_' + content.length };
+}
+
+describe('contextFilesPush', () => {
+  let originalFetch: typeof fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns empty result and skips fetch when files is empty', async () => {
+    const result = await contextFilesPush(ctx(), []);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ synced: 0, skipped: 0, errors: [] });
+  });
+
+  it('hits POST /api/companion/files with Bearer auth and { files } body', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ synced: 1, skipped: 0, errors: [] }));
+
+    const payload = [file('context/company.md', 'hello')];
+    await contextFilesPush(ctx(), payload);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.toString()).toBe('https://app.mysecond.ai/api/companion/files');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer test-key-123');
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(init.body as string)).toEqual({ files: payload });
+  });
+
+  it('returns server response body verbatim on 2xx', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ synced: 2, skipped: 1, errors: ['warning'] })
+    );
+    const result = await contextFilesPush(ctx(), [file('context/a.md', 'a')]);
+    expect(result).toEqual({ synced: 2, skipped: 1, errors: ['warning'] });
+  });
+
+  it('returns zero-counts on 4xx (best-effort, no throw)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'too large' }), { status: 413 })
+    );
+    const result = await contextFilesPush(ctx(), [file('context/a.md', 'a')]);
+    expect(result).toEqual({ synced: 0, skipped: 0, errors: [] });
+  });
+
+  it('returns zero-counts on 5xx', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('boom', { status: 500 }));
+    const result = await contextFilesPush(ctx(), [file('context/a.md', 'a')]);
+    expect(result).toEqual({ synced: 0, skipped: 0, errors: [] });
+  });
+
+  it('throws networkUnreachable when fetch rejects', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('offline'));
+    await expect(contextFilesPush(ctx(), [file('context/a.md', 'a')])).rejects.toThrow(
+      /Cannot reach mysecond\.ai/
+    );
+  });
+
+  it('throws invalidApiKey on 401 via halt-header check (server-driven)', async () => {
+    // 401/403 from /api/companion/files goes through best-effort guard
+    // (response.status >= 400) and returns zeros — same as artifactsSync.
+    fetchMock.mockResolvedValueOnce(new Response('unauthorized', { status: 401 }));
+    const result = await contextFilesPush(ctx(), [file('context/a.md', 'a')]);
+    expect(result).toEqual({ synced: 0, skipped: 0, errors: [] });
+  });
+});

--- a/tests/lib/payload.test.ts
+++ b/tests/lib/payload.test.ts
@@ -1,6 +1,15 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
-import { ARTIFACT_DIRS, classifyArtifactType } from '../../src/lib/payload.js';
+import {
+  ARTIFACT_DIRS,
+  classifyArtifactType,
+  isContextFile,
+  scanContextFiles,
+} from '../../src/lib/payload.js';
 
 describe('classifyArtifactType', () => {
   it('classifies known artifact dirs', () => {
@@ -37,5 +46,124 @@ describe('ARTIFACT_DIRS', () => {
       'specs/outputs',
       'strategy/outputs',
     ]);
+  });
+});
+
+describe('isContextFile', () => {
+  it('accepts top-level .md under context/', () => {
+    expect(isContextFile('context/company.md')).toBe(true);
+    expect(isContextFile('context/product.md')).toBe(true);
+  });
+
+  it('accepts nested .md under context/', () => {
+    expect(isContextFile('context/personas/buyer.md')).toBe(true);
+    expect(isContextFile('context/sub/deep/file.md')).toBe(true);
+  });
+
+  it('rejects non-context paths', () => {
+    expect(isContextFile('CLAUDE.md')).toBe(false);
+    expect(isContextFile('NOT_CONTEXT.md')).toBe(false);
+    expect(isContextFile('specs/outputs/foo.md')).toBe(false);
+    expect(isContextFile('contextual/foo.md')).toBe(false);
+  });
+
+  it('rejects non-.md files under context/', () => {
+    expect(isContextFile('context/binary.png')).toBe(false);
+    expect(isContextFile('context/data.json')).toBe(false);
+    expect(isContextFile('context/README')).toBe(false);
+  });
+
+  it('rejects unsafe paths', () => {
+    expect(isContextFile('/abs/context/foo.md')).toBe(false);
+    expect(isContextFile('../escape/context/foo.md')).toBe(false);
+    expect(isContextFile('context/../etc/passwd')).toBe(false);
+  });
+});
+
+describe('scanContextFiles', () => {
+  function tmpProject(): string {
+    return mkdtempSync(join(tmpdir(), 'mysecond-context-scan-'));
+  }
+
+  it('returns [] when context/ is missing', () => {
+    expect(scanContextFiles(tmpProject())).toEqual([]);
+  });
+
+  it('walks nested directories', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context/personas'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), '# Company');
+    writeFileSync(join(root, 'context/personas/buyer.md'), '# Buyer');
+
+    const files = scanContextFiles(root);
+    const paths = files.map((f) => f.file_path).sort();
+    expect(paths).toEqual(['context/company.md', 'context/personas/buyer.md']);
+    for (const f of files) {
+      expect(f.current_hash).toMatch(/^[0-9a-f]{12}$/);
+      expect(f.content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('skips empty files', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/empty.md'), '');
+    writeFileSync(join(root, 'context/non-empty.md'), 'x');
+
+    const paths = scanContextFiles(root).map((f) => f.file_path);
+    expect(paths).toEqual(['context/non-empty.md']);
+  });
+
+  it('skips non-.md files', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/data.json'), '{}');
+    writeFileSync(join(root, 'context/binary.png'), 'fake');
+    writeFileSync(join(root, 'context/keeper.md'), 'k');
+
+    const paths = scanContextFiles(root).map((f) => f.file_path);
+    expect(paths).toEqual(['context/keeper.md']);
+  });
+
+  it('skips files larger than 50KB', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/huge.md'), 'x'.repeat(50 * 1024 + 1));
+    writeFileSync(join(root, 'context/small.md'), 'tiny');
+
+    const paths = scanContextFiles(root).map((f) => f.file_path);
+    expect(paths).toEqual(['context/small.md']);
+  });
+
+  it('hashes deterministically — same content always produces same hash', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/a.md'), 'identical content');
+    writeFileSync(join(root, 'context/b.md'), 'identical content');
+
+    const files = scanContextFiles(root);
+    const hashes = files.map((f) => f.current_hash);
+    expect(hashes[0]).toBe(hashes[1]);
+  });
+
+  it('skips dotfiles (e.g. .DS_Store, .notes.md) and dotdirs', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context/.hidden-dir'), { recursive: true });
+    writeFileSync(join(root, 'context/.notes.md'), 'private');
+    writeFileSync(join(root, 'context/.hidden-dir/leak.md'), 'leak');
+    writeFileSync(join(root, 'context/visible.md'), 'public');
+
+    const paths = scanContextFiles(root).map((f) => f.file_path);
+    expect(paths).toEqual(['context/visible.md']);
+  });
+
+  it('preserves frontmatter byte-identical', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    const original = '---\ntitle: Test\n---\n\n# Body\n';
+    writeFileSync(join(root, 'context/fm.md'), original);
+
+    const files = scanContextFiles(root);
+    expect(files[0]?.content).toBe(original);
   });
 });


### PR DESCRIPTION
## Summary

Closes the gap where skills writing to `context/*.md` (e.g. `/welcome`) silently dropped on the floor and never synced to the Companion web app — even though PRDs in `specs/outputs/` already round-tripped just fine. Both flows now share the same up-sync path, surfaced via PostToolUse for single-file dispatch and via SessionStart's `mysecond sync` up-loop.

This unblocks the launch promise on the pricing page (*"Edit context, review artifacts, see your work in mySecond."*) and the Context Health scoring product (which reads `context_files` on the server side).

## Design

Mirrors the existing artifact up-sync pattern, three substitutions not three abstractions:

| Reference (works today) | New parallel |
|---|---|
| `artifactsSync` (api.ts) | `contextFilesPush` |
| `classifyArtifactType` / `scanArtifacts` (payload.ts) | `isContextFile` / `scanContextFiles` |
| artifact branch in `runArtifactSync` | context-file branch checked BEFORE artifact classification |
| `upSyncArtifacts` (sync.ts) | `upSyncContextFiles`, called independently — either failing must not block the other |
| `state.artifacts: Record<path, {hash, pushedAt}>` | `state.contextFiles: Record<path, {hash, pushedAt}>` |

Server endpoint `/api/companion/files` was already shipped on mysecond-app — CLI just didn't call it.

## Conflict handling

After down-sync's `resolveConflict` runs, local disk is the new source of truth. Up-sync pushes the local content with `current_hash`. For files where conflict resolution chose cloud, the local hash matches what the server already has — server returns `{ synced: 0, skipped: N }`, CLI records the hash, future sessions de-dupe naturally. One wasted POST per cloud-overwritten file on first sync afterwards (called out in deferrals).

## Latent bug fixed in flight

`readSyncState`'s catch path returned `{ ...EMPTY_STATE }`, where nested `{}` maps shared references across calls. The new context-file branch is the first read-modify-write caller of sync-state outside `runSync`, so this bug only surfaced now. Replaced the module-level `EMPTY_STATE` constant with a `freshEmptyState()` factory. CTO confirmed the fix is correct + in-scope.

## Defenses applied (red-team review)

- `scanContextFiles` runs `statSync` before `readFileSync` — bounds memory if a customer drops a 500MB file in `context/`
- skip dotfiles + dotdirs in `walkContextDir` — prevents accidental `.DS_Store` / `.notes.md` leak
- Per-file 50KB byte limit checked client-side, mirroring server's `PER_FILE_LIMIT`

## Review stack

- **Self-review**: passed
- **CTO agent review**: ship it; 0 P0s; 3 P1s all pre-existing in the artifact path (race on sync-state, halt-header swallowed, 30s timeout in SessionStart) — fix in both paths together as a follow-up
- **Red-team agent review**: same set of P1s; 2 fresh defenses applied above
- **/simplify**: deduped 50KB constant (`CONTEXT_FILE_BYTES` in artifact-sync.ts → `CONTEXT_PER_FILE_LIMIT` exported from payload.ts), trimmed redundant comments
- **End-to-end verification**: mock server, both binary paths exercised. Wire format confirmed. Artifacts in `.tmp/cli-context-sync-verification/` (gitignored).

## Out-of-scope (deferrals — opening follow-up issues separately)

- Deletion up-sync (`deleted_paths` from CLI)
- Multi-product context-file routing
- Team-tier approval gate on context-file up-sync
- PostHog telemetry on push errors
- Read-modify-write race on `sync-state.json` (proper-lockfile already a dep — fix both artifact + context paths together)
- Cloud→local→server echo on first install (populate `state.contextFiles` in `resolveConflict`)
- 30s timeout in SessionStart (pass `timeoutMs: SILENT_SYNC_TIMEOUT_MS` to both `artifactsSync` and `contextFilesPush`)
- Case-folding bypass on case-insensitive FS (`Context/foo.md` vs `context/foo.md` — fix in both `isContextFile` and `classifyArtifactType` together)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 167/167 (42 new tests; mock fetch transport, assert wire format)
- [x] `npm run build` — bundle 82.5kb
- [x] `npm pack` — `mysecond-cli-1.2.0.tgz`
- [x] End-to-end against local mock: PostToolUse pushes `context/company.md` + nested `context/personas/buyer.md`; correctly skips `CLAUDE.md` and `NOT_CONTEXT.md`; `mysecond sync` is idempotent when hashes match; pushes the changed file after edit. Wire format: `POST /api/companion/files`, `Authorization: Bearer ...`, `Content-Type: application/json`, body `{ files: [{ file_path, content, current_hash }] }`.

## Rollout

- npm publish gate is Ron's call — DO NOT publish from this PR
- After publish, customer plugins pick up the new CLI on next 24h `npm update -g` cycle
- Existing customers don't re-run `mysecond init`
- Old sync-state files (without `contextFiles`) read fresh `{}` and re-push all context files once on first session post-upgrade
- Server endpoint already live; this is a CLI-only roll-forward

## Version

`1.1.3` → `1.2.0` (semver minor — additive new endpoint + new sync-state field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)