### PR TITLE
feat(sync): hardening — halt-header, timeout, case-folding (v1.2.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mysecond/cli",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "UNLICENSED",
       "dependencies": {
         "proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/artifact-sync.ts
+++ b/src/commands/artifact-sync.ts
@@ -8,6 +8,7 @@ import { readFileSync, statSync } from 'node:fs';
 
 import { artifactsSync, contextFilesPush } from '../lib/api.js';
 import type { CommandContext } from '../lib/context.js';
+import { MysecondError } from '../lib/errors.js';
 import { relativeFromRoot, shortHash } from '../lib/files.js';
 import {
   CONTEXT_PER_FILE_LIMIT,
@@ -102,7 +103,11 @@ export async function runArtifactSync(
         state.contextFiles[relativePath] = { hash, pushedAt: new Date().toISOString() };
         writeSyncState(ctx.rootDir, state);
       }
-    } catch {
+    } catch (err) {
+      // Honor server-side halt header: if the server flipped the rollback-pause
+      // kill switch (exitCode 7), exit non-zero so subsequent PostToolUse events
+      // also stop. Other errors stay best-effort.
+      if (err instanceof MysecondError && err.exitCode === 7) throw err;
       // Best-effort: TODO(telemetry) emit PostHog event when telemetry lands.
     }
     return 0;
@@ -132,7 +137,10 @@ export async function runArtifactSync(
 
   try {
     await artifactsSync(ctx, [payload]);
-  } catch {
+  } catch (err) {
+    // Same halt-header propagation as the context branch above. Server kill
+    // switch must reach the PostToolUse main() catch so the hook exits non-zero.
+    if (err instanceof MysecondError && err.exitCode === 7) throw err;
     // Best-effort: TODO(telemetry) emit PostHog event when telemetry lands.
   }
   return 0;

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -130,6 +130,13 @@ function mergeClaudeMdOverride(claudeMdPath: string, override: string): void {
   writeFileSync(claudeMdPath, next);
 }
 
+// Timeout opts for SessionStart-context up-syncs. Silent mode = fast-fail at
+// 8s so a slow server doesn't stall Claude Code Desktop launch. Non-silent
+// callers fall through to the 30s default in companionFetch.
+function silentSyncOpts(ctx: CommandContext): { timeoutMs?: number } {
+  return ctx.silent ? { timeoutMs: SILENT_SYNC_TIMEOUT_MS } : {};
+}
+
 async function upSyncArtifacts(
   ctx: CommandContext,
   state: SyncState
@@ -141,7 +148,7 @@ async function upSyncArtifacts(
   });
   if (toSync.length === 0) return 0;
 
-  const result = await artifactsSync(ctx, toSync);
+  const result = await artifactsSync(ctx, toSync, silentSyncOpts(ctx));
   if (result.synced > 0) {
     const now = new Date().toISOString();
     for (const a of toSync) {
@@ -162,7 +169,7 @@ async function upSyncContextFiles(
   });
   if (toSync.length === 0) return 0;
 
-  const result = await contextFilesPush(ctx, toSync);
+  const result = await contextFilesPush(ctx, toSync, silentSyncOpts(ctx));
   if (result.synced > 0 || result.skipped > 0) {
     const now = new Date().toISOString();
     for (const f of toSync) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -114,14 +114,20 @@ export async function cliSync(
 // POST /api/companion/artifacts — up-sync artifact files. Up-sync failure is
 // non-fatal: the down-sync result still reaches the customer. Caller decides
 // whether to surface the partial-success.
+//
+// timeoutMs: SessionStart hook callers should pass SILENT_SYNC_TIMEOUT_MS
+// (8s) to avoid stalling Claude Code Desktop launch on a slow server.
+// Default 30s for non-silent contexts.
 export async function artifactsSync(
   ctx: CommandContext,
-  artifacts: readonly ArtifactPayload[]
+  artifacts: readonly ArtifactPayload[],
+  opts: { timeoutMs?: number } = {}
 ): Promise<ArtifactsResponse> {
   if (artifacts.length === 0) return { synced: 0 };
   const response = await companionFetch(ctx, '/api/companion/artifacts', {
     method: 'POST',
     body: { artifacts },
+    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
   });
   if (response.status >= 400) {
     return { synced: 0 };
@@ -132,14 +138,19 @@ export async function artifactsSync(
 // POST /api/companion/files — up-sync context files (company/product/personas/
 // competitors/goals + nested under context/). Mirrors artifactsSync semantics:
 // best-effort, server returns { synced, skipped, errors }.
+//
+// timeoutMs: same SessionStart hook contract as artifactsSync — pass
+// SILENT_SYNC_TIMEOUT_MS for fast-fail under load.
 export async function contextFilesPush(
   ctx: CommandContext,
-  files: readonly ContextFilePayload[]
+  files: readonly ContextFilePayload[],
+  opts: { timeoutMs?: number } = {}
 ): Promise<ContextFilesResponse> {
   if (files.length === 0) return { synced: 0, skipped: 0, errors: [] };
   const response = await companionFetch(ctx, '/api/companion/files', {
     method: 'POST',
     body: { files },
+    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
   });
   if (response.status >= 400) {
     return { synced: 0, skipped: 0, errors: [] };

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -91,10 +91,15 @@ export const CONTEXT_PER_FILE_LIMIT = 50 * 1024;
 // gate as classifyArtifactType — leading '/', traversal, absolute paths
 // rejected. Only `.md` files under `context/` qualify; nested paths
 // (e.g. context/personas/buyer.md) are supported.
+//
+// Case-insensitive prefix check: macOS APFS / Windows NTFS default to
+// case-insensitive lookups, so `Context/foo.md` and `context/foo.md` resolve
+// to the same file on disk. A skill that emits the wrong case must not
+// silently drop on the floor — see follow-up #8 in mysecond-cli#11.
 export function isContextFile(relativePath: string): boolean {
   if (relativePath.startsWith('/') || relativePath.includes('..')) return false;
-  if (!relativePath.startsWith(CONTEXT_DIR + '/')) return false;
-  return relativePath.endsWith('.md');
+  if (!relativePath.toLowerCase().startsWith(CONTEXT_DIR + '/')) return false;
+  return relativePath.toLowerCase().endsWith('.md');
 }
 
 // Classify a write event's file path into an artifact_type for PostToolUse.
@@ -103,13 +108,16 @@ export function isContextFile(relativePath: string): boolean {
 // (PostToolUse single-file dispatch vs SessionStart full scan).
 export function classifyArtifactType(relativePath: string): ArtifactType | null {
   if (relativePath.startsWith('/') || relativePath.includes('..')) return null;
-  if (relativePath.includes('/tests/')) return null;
+  // Case-insensitive: same rationale as isContextFile — APFS/NTFS default
+  // case-insensitive lookups must not produce silent drops.
+  const lower = relativePath.toLowerCase();
+  if (lower.includes('/tests/')) return null;
   for (const dir of ARTIFACT_DIRS) {
-    if (relativePath.startsWith(dir.relativeDir + '/')) return dir.type;
+    if (lower.startsWith(dir.relativeDir.toLowerCase() + '/')) return dir.type;
   }
   // Workflow outputs aren't in ARTIFACT_DIRS (they're scanned per-workflow not
   // per-tier), but the PostToolUse hook still classifies them.
-  if (/^workflows\/[^/]+\/outputs\//.test(relativePath)) return 'other';
+  if (/^workflows\/[^/]+\/outputs\//.test(lower)) return 'other';
   return null;
 }
 

--- a/tests/commands/artifact-sync.test.ts
+++ b/tests/commands/artifact-sync.test.ts
@@ -279,4 +279,37 @@ describe('runArtifactSync — context-file branch', () => {
     const written = JSON.parse(readFileSync(join(root, '.claude/sync-state.json'), 'utf8'));
     expect(written.contextFiles['context/company.md']).toBeDefined();
   });
+
+  // Follow-up #6 — server kill switch must propagate from the PostToolUse
+  // hook so subsequent events also stop. Previously the catch-all swallowed
+  // the rollbackPause MysecondError and the hook still returned 0.
+  it('re-throws rollbackPause (exitCode 7) on context branch when server returns halt header', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'mysecond-pth-halt-'));
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'x');
+    fetchMock.mockResolvedValueOnce(
+      new Response('{"synced":0}', {
+        status: 200,
+        headers: { 'X-Mysecond-Halt': '1' },
+      })
+    );
+    stubStdin(toolEvent('Write', join(root, 'context/company.md')));
+
+    await expect(runArtifactSync([], ctx(root))).rejects.toMatchObject({ exitCode: 7 });
+  });
+
+  it('re-throws rollbackPause (exitCode 7) on artifact branch when server returns halt header', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'mysecond-pth-halt-art-'));
+    mkdirSync(join(root, 'specs/outputs'), { recursive: true });
+    writeFileSync(join(root, 'specs/outputs/foo.md'), 'x');
+    fetchMock.mockResolvedValueOnce(
+      new Response('{"synced":0}', {
+        status: 200,
+        headers: { 'X-Mysecond-Halt': '1' },
+      })
+    );
+    stubStdin(toolEvent('Write', join(root, 'specs/outputs/foo.md')));
+
+    await expect(runArtifactSync([], ctx(root))).rejects.toMatchObject({ exitCode: 7 });
+  });
 });

--- a/tests/lib/api.test.ts
+++ b/tests/lib/api.test.ts
@@ -106,4 +106,35 @@ describe('contextFilesPush', () => {
     const result = await contextFilesPush(ctx(), [file('context/a.md', 'a')]);
     expect(result).toEqual({ synced: 0, skipped: 0, errors: [] });
   });
+
+  // Follow-up #6 — server-side rollback-pause kill switch must propagate.
+  it('throws rollbackPause (exitCode 7) when server returns X-Mysecond-Halt: 1', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('{"synced":0}', {
+        status: 200,
+        headers: { 'X-Mysecond-Halt': '1' },
+      })
+    );
+    await expect(
+      contextFilesPush(ctx(), [file('context/a.md', 'a')])
+    ).rejects.toMatchObject({ exitCode: 7 });
+  });
+
+  // Follow-up #7 — caller can pass timeoutMs (SessionStart hook uses 8s).
+  it('honors caller-provided timeoutMs by aborting fetch when exceeded', async () => {
+    // Slow fetch that never resolves — should be aborted by AbortSignal.timeout.
+    fetchMock.mockImplementationOnce(
+      (_url: URL, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'TimeoutError';
+            reject(err);
+          });
+        })
+    );
+    await expect(
+      contextFilesPush(ctx(), [file('context/a.md', 'a')], { timeoutMs: 50 })
+    ).rejects.toThrow(/Cannot reach mysecond\.ai/);
+  });
 });

--- a/tests/lib/payload.test.ts
+++ b/tests/lib/payload.test.ts
@@ -35,6 +35,13 @@ describe('classifyArtifactType', () => {
   it('skips test outputs', () => {
     expect(classifyArtifactType('specs/outputs/tests/x.md')).toBeNull();
   });
+
+  // Follow-up #8 — case-insensitive prefix match.
+  it('classifies case-variant artifact prefixes on case-insensitive filesystems', () => {
+    expect(classifyArtifactType('Specs/Outputs/foo.md')).toBe('prd');
+    expect(classifyArtifactType('STRATEGY/OUTPUTS/bar.md')).toBe('strategy');
+    expect(classifyArtifactType('Workflows/Foo/Outputs/z.md')).toBe('other');
+  });
 });
 
 describe('ARTIFACT_DIRS', () => {
@@ -77,6 +84,20 @@ describe('isContextFile', () => {
     expect(isContextFile('/abs/context/foo.md')).toBe(false);
     expect(isContextFile('../escape/context/foo.md')).toBe(false);
     expect(isContextFile('context/../etc/passwd')).toBe(false);
+  });
+
+  // Follow-up #8 — case-insensitive filesystems (macOS APFS, Windows NTFS
+  // default) resolve `Context/foo.md` and `context/foo.md` to the same disk
+  // file. A skill that emits the wrong case must not silently drop.
+  it('accepts case-variant context prefix on case-insensitive filesystems', () => {
+    expect(isContextFile('Context/company.md')).toBe(true);
+    expect(isContextFile('CONTEXT/personas.md')).toBe(true);
+    expect(isContextFile('CoNtExT/goals.md')).toBe(true);
+  });
+
+  it('accepts case-variant .md suffix', () => {
+    expect(isContextFile('context/company.MD')).toBe(true);
+    expect(isContextFile('context/product.Md')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Three pre-existing pattern bugs from the sync subsystem, fixed in both the artifact path and the new context-file path simultaneously. Mirrors discipline: same fix shape, applied at every callsite.

Closes [#11](https://github.com/mysecond-ai/mysecond-cli/issues/11) items **#6**, **#7**, **#8**.

## Why these three together

The other session that audited follow-ups ranked these as the highest-impact pre-existing items for solo launch:

| # | Customer-visible | Severity |
|---|---|---|
| #6 Halt-header kill switch swallowed | Visible during a launch crisis (kill switch doesn't fully work for PostToolUse) | High during incident |
| #7 30s timeout in SessionStart | Visible to every user under slow-server conditions (Claude Code Desktop hangs ~1 min on launch) | High first-impression |
| #8 Case-folding bypass | Silent data loss when a skill writes `Context/foo.md` (capital C) on macOS/Windows | High but rare-trigger |

Cheap surgical fixes, ride-along value across both sync surfaces, no scope creep.

## Changes

### `src/commands/artifact-sync.ts`
- Both catch blocks (context branch + artifact branch) now re-throw `MysecondError` when `exitCode === 7` (rollback-pause). Other errors stay best-effort.
- Imports `MysecondError` from `../lib/errors.js`.

### `src/lib/api.ts`
- `artifactsSync` and `contextFilesPush` accept `opts.timeoutMs` (mirror of `cliSync`'s existing pattern).
- Pass-through to `companionFetch` so `AbortSignal.timeout` honors the caller's deadline.

### `src/commands/sync.ts`
- New `silentSyncOpts(ctx)` helper — returns `{ timeoutMs: SILENT_SYNC_TIMEOUT_MS }` when `ctx.silent`, else `{}`.
- `upSyncArtifacts` and `upSyncContextFiles` both pass it through.

### `src/lib/payload.ts`
- `isContextFile`: lowercase the prefix and suffix checks.
- `classifyArtifactType`: lowercase the prefix check (artifact dirs, workflow regex, tests guard).
- Path-traversal guards (`startsWith('/')`, `includes('..')`) unchanged — case-folding doesn't affect those.

## Tests (7 new, 174 total)

- `tests/lib/payload.test.ts` — 5 case-folding cases (`Context/`, `CONTEXT/`, `CoNtExT/`, `.MD`, `.Md`; same for artifact dirs)
- `tests/lib/api.test.ts` — 1 halt-header propagation test (`X-Mysecond-Halt: 1` → exitCode 7), 1 timeout-honored test (caller-provided `timeoutMs` aborts the fetch)
- `tests/commands/artifact-sync.test.ts` — 2 halt-header re-throw tests (one for context branch, one for artifact branch)

All tests mock `globalThis.fetch` (transport), assert outgoing wire format. No abstractions added.

## Verification

- `npm test` — 174/174 ✓
- `npm run build` — 83.1kb (+0.6kb vs main)
- Manual review: each diff hunk maps to a specific item in #11

## What's NOT in this PR

Other items from #11 — **deferred per the audit's severity ranking:**

- #1 deletion up-sync — not solo-blocking
- #2 multi-product routing — Team-tier only
- #3 Team approval gate — Team-tier only
- #4 PostHog telemetry — operational, blocked on telemetry infra
- #5 sync-state RMW race — needs proper-lockfile, scope expansion
- #9 cloud→local→server echo — pure efficiency, not visible

## Rollout plan

After Ron's review:
1. Merge into `main`
2. `npm publish --tag next` (same safer pattern as v1.2.0)
3. Run an E2E with a real test team to confirm the live preview server still works
4. Promote `next` → `latest` once verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)