### PR TITLE
feat(init): redesign post-install success message — single /welcome CTA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mysecond/cli",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "UNLICENSED",
       "dependencies": {
         "proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/artifact-sync.ts
+++ b/src/commands/artifact-sync.ts
@@ -8,6 +8,7 @@ import { readFileSync, statSync } from 'node:fs';
 
 import { artifactsSync, contextFilesPush } from '../lib/api.js';
 import type { CommandContext } from '../lib/context.js';
+import { MysecondError } from '../lib/errors.js';
 import { relativeFromRoot, shortHash } from '../lib/files.js';
 import {
   CONTEXT_PER_FILE_LIMIT,
@@ -102,7 +103,11 @@ export async function runArtifactSync(
         state.contextFiles[relativePath] = { hash, pushedAt: new Date().toISOString() };
         writeSyncState(ctx.rootDir, state);
       }
-    } catch {
+    } catch (err) {
+      // Honor server-side halt header: if the server flipped the rollback-pause
+      // kill switch (exitCode 7), exit non-zero so subsequent PostToolUse events
+      // also stop. Other errors stay best-effort.
+      if (err instanceof MysecondError && err.exitCode === 7) throw err;
       // Best-effort: TODO(telemetry) emit PostHog event when telemetry lands.
     }
     return 0;
@@ -132,7 +137,10 @@ export async function runArtifactSync(
 
   try {
     await artifactsSync(ctx, [payload]);
-  } catch {
+  } catch (err) {
+    // Same halt-header propagation as the context branch above. Server kill
+    // switch must reach the PostToolUse main() catch so the hook exits non-zero.
+    if (err instanceof MysecondError && err.exitCode === 7) throw err;
     // Best-effort: TODO(telemetry) emit PostHog event when telemetry lands.
   }
   return 0;

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -130,6 +130,13 @@ function mergeClaudeMdOverride(claudeMdPath: string, override: string): void {
   writeFileSync(claudeMdPath, next);
 }
 
+// Timeout opts for SessionStart-context up-syncs. Silent mode = fast-fail at
+// 8s so a slow server doesn't stall Claude Code Desktop launch. Non-silent
+// callers fall through to the 30s default in companionFetch.
+function silentSyncOpts(ctx: CommandContext): { timeoutMs?: number } {
+  return ctx.silent ? { timeoutMs: SILENT_SYNC_TIMEOUT_MS } : {};
+}
+
 async function upSyncArtifacts(
   ctx: CommandContext,
   state: SyncState
@@ -141,7 +148,7 @@ async function upSyncArtifacts(
   });
   if (toSync.length === 0) return 0;
 
-  const result = await artifactsSync(ctx, toSync);
+  const result = await artifactsSync(ctx, toSync, silentSyncOpts(ctx));
   if (result.synced > 0) {
     const now = new Date().toISOString();
     for (const a of toSync) {
@@ -162,7 +169,7 @@ async function upSyncContextFiles(
   });
   if (toSync.length === 0) return 0;
 
-  const result = await contextFilesPush(ctx, toSync);
+  const result = await contextFilesPush(ctx, toSync, silentSyncOpts(ctx));
   if (result.synced > 0 || result.skipped > 0) {
     const now = new Date().toISOString();
     for (const f of toSync) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -114,14 +114,20 @@ export async function cliSync(
 // POST /api/companion/artifacts — up-sync artifact files. Up-sync failure is
 // non-fatal: the down-sync result still reaches the customer. Caller decides
 // whether to surface the partial-success.
+//
+// timeoutMs: SessionStart hook callers should pass SILENT_SYNC_TIMEOUT_MS
+// (8s) to avoid stalling Claude Code Desktop launch on a slow server.
+// Default 30s for non-silent contexts.
 export async function artifactsSync(
   ctx: CommandContext,
-  artifacts: readonly ArtifactPayload[]
+  artifacts: readonly ArtifactPayload[],
+  opts: { timeoutMs?: number } = {}
 ): Promise<ArtifactsResponse> {
   if (artifacts.length === 0) return { synced: 0 };
   const response = await companionFetch(ctx, '/api/companion/artifacts', {
     method: 'POST',
     body: { artifacts },
+    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
   });
   if (response.status >= 400) {
     return { synced: 0 };
@@ -132,14 +138,19 @@ export async function artifactsSync(
 // POST /api/companion/files — up-sync context files (company/product/personas/
 // competitors/goals + nested under context/). Mirrors artifactsSync semantics:
 // best-effort, server returns { synced, skipped, errors }.
+//
+// timeoutMs: same SessionStart hook contract as artifactsSync — pass
+// SILENT_SYNC_TIMEOUT_MS for fast-fail under load.
 export async function contextFilesPush(
   ctx: CommandContext,
-  files: readonly ContextFilePayload[]
+  files: readonly ContextFilePayload[],
+  opts: { timeoutMs?: number } = {}
 ): Promise<ContextFilesResponse> {
   if (files.length === 0) return { synced: 0, skipped: 0, errors: [] };
   const response = await companionFetch(ctx, '/api/companion/files', {
     method: 'POST',
     body: { files },
+    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
   });
   if (response.status >= 400) {
     return { synced: 0, skipped: 0, errors: [] };

--- a/src/lib/copy.ts
+++ b/src/lib/copy.ts
@@ -70,54 +70,93 @@ export function claudeMdBlock(companyName: string, pmName: string): string {
 export const CLAUDE_MD_MARKER_START = '<!-- mysecond-start -->';
 export const CLAUDE_MD_MARKER_END = '<!-- mysecond-end -->';
 
-// §6.8 framed success box (Ron-B1 v2 + v1.4 restart instruction).
-// 51 chars wide, 15 lines tall. {pm_name}+{company_name} truncated to 18 chars
-// each (CXO-11) so combined "for X at Y" fits within box width.
-const BOX_WIDTH = 51;
+// §6.8 post-install success message (May-2026 redesign per launch-feedback-log).
+// Plain-text, single primary CTA = `/welcome`. Drops premature suggestions for
+// /prd-generator + /enhance-context (customer has no context files yet).
+//
+// Inputs: {pm_name}, {company_name}, plugin counts (skills/agents/workflows).
+// All inputs are SANITIZED — see sanitizeName() — to defend against malicious
+// customer/company names from the install-ready response (HTML, ANSI escapes,
+// control chars, length blowup).
 
-function truncate(s: string, max: number): string {
-  if (s.length <= max) return s;
-  return s.slice(0, max - 1) + '…';
+const NAME_MAX_LEN = 40;
+
+// Sanitize an arbitrary server-provided name string for safe inclusion in the
+// success message. Strips control chars + ANSI/CSI escapes, collapses
+// whitespace, truncates. Returns the fallback if the result is empty.
+function sanitizeName(input: string | undefined | null, fallback: string): string {
+  if (input === undefined || input === null) return fallback;
+  if (typeof input !== 'string') return fallback;
+  // Strip ASCII control chars (0x00-0x1F, 0x7F) — covers \r, \n, \t, ESC (0x1B),
+  // backspace, bell, etc. ANSI/CSI escape sequences start with ESC so removing
+  // ESC neutralizes them. Also strip C1 control range (0x80-0x9F).
+  // eslint-disable-next-line no-control-regex
+  let s = input.replace(/[\x00-\x1F\x7F-\x9F]/g, "").replace(/[<>]/g, "");
+  // Collapse internal whitespace runs to single spaces; trim ends.
+  s = s.replace(/\s+/g, ' ').trim();
+  if (s.length === 0) return fallback;
+  if (s.length > NAME_MAX_LEN) {
+    s = s.slice(0, NAME_MAX_LEN - 1) + '…';
+  }
+  return s;
 }
 
-function padBoxLine(content: string): string {
-  // Box interior is BOX_WIDTH - 2 (for │ on each side). Content padded to fill.
-  const interior = BOX_WIDTH - 2;
-  const trimmed = content.length > interior ? content.slice(0, interior) : content;
-  return `│${trimmed.padEnd(interior, ' ')}│`;
+export interface PostInstallCounts {
+  skills: number;
+  agents: number;
+  workflows: number;
 }
 
-export function successBox(pmName: string, companyName: string): string {
-  const pm = truncate(pmName, 18);
-  const company = truncate(companyName, 18);
-  const top = '┌' + '─'.repeat(BOX_WIDTH - 2) + '┐';
-  const bottom = '└' + '─'.repeat(BOX_WIDTH - 2) + '┘';
-  // RED-TEAM R2 P0-C: skills are namespaced by plugin name in Claude Code
-  // (`/<plugin-name>:<skill>`). If the customer has any other marketplace
-  // shipping a `pm-os` plugin OR their own project-level `prd-generator`
-  // skill, bare `/prd-generator` collides and routes elsewhere. Prefix with
-  // `/pm-os:` so the success box advertises the canonical namespaced form.
+// Build the count line, omitting zero-count categories so a partially-empty
+// plugin doesn't print "0 sub-agents". If all three are zero (extraction
+// folder unreadable), fall back to a generic phrasing.
+function formatCountsLine(counts: PostInstallCounts | undefined): string {
+  const skills = counts?.skills ?? 0;
+  const agents = counts?.agents ?? 0;
+  const workflows = counts?.workflows ?? 0;
+  const parts: string[] = [];
+  if (skills > 0) parts.push(`${skills} ${skills === 1 ? 'skill' : 'skills'}`);
+  if (agents > 0) parts.push(`${agents} ${agents === 1 ? 'sub-agent' : 'sub-agents'}`);
+  if (workflows > 0) parts.push(`${workflows} ${workflows === 1 ? 'workflow' : 'workflows'}`);
+  if (parts.length === 0) {
+    return '- pm-os plugin registered (user scope) with your PM skill library';
+  }
+  return `- pm-os plugin registered (user scope) with ${parts.join(', ')}`;
+}
+
+// New post-install message (May-2026 redesign). Returns a plain-text block
+// (NOT a framed ASCII box). Caller adds surrounding blank lines.
+//
+// Customer feedback drove the rewrite:
+//   1. "Bring in the company name to make it feel more personal" → lead line
+//      personalizes with both pmName and companyName.
+//   2. "Improve the messaging — kick off the welcome flow OR ask me to" →
+//      single primary CTA = `/welcome` (not `/prd-generator`, which is
+//      premature without context files).
+//   3. Plugin still requires Claude Code restart to load → keep the
+//      "ALMOST THERE" technical instruction.
+export function successBox(
+  pmName: string,
+  companyName: string,
+  counts?: PostInstallCounts
+): string {
+  const pm = sanitizeName(pmName, 'you');
+  const company = sanitizeName(companyName, 'your company');
   const lines = [
-    top,
-    padBoxLine('  mySecond PM OS installed                       '),
-    padBoxLine(`  for ${pm} at ${company}`),
-    padBoxLine('                                                 '),
-    padBoxLine('  Almost there — close and reopen Claude Code    '),
-    padBoxLine('  to activate your PM OS. Your context, skills,  '),
-    padBoxLine('  and sync hooks will load automatically on the  '),
-    padBoxLine('  next session start.                            '),
-    padBoxLine('                                                 '),
-    padBoxLine('  After reopening, try:                          '),
-    padBoxLine('   /pm-os:prd-generator  (draft a PRD)           '),
-    padBoxLine('   /pm-os:skills (see everything available)      '),
-    padBoxLine('   /pm-os:enhance-context (upload research,      '),
-    padBoxLine('                    interview notes, strategy)   '),
-    padBoxLine('  Or just start chatting — your PM context will  '),
-    padBoxLine('  be in the conversation.                        '),
-    padBoxLine('                                                 '),
-    padBoxLine('  ──                                             '),
-    padBoxLine('  Syncs automatically on every session.          '),
-    bottom,
+    `✓ mySecond PM OS installed for ${pm} at ${company}`,
+    '',
+    "Here's what's now in place:",
+    formatCountsLine(counts),
+    '- Context sync hooks active for every Claude Code session',
+    '- Your context files will be created in step 2 below',
+    '',
+    'ALMOST THERE — close and reopen Claude Code to activate the plugin.',
+    '',
+    `Then run /welcome in Claude Code. It takes about 5 minutes and sets up your context files for ${company} (company, product, personas, competitors, goals).`,
+    '',
+    'After /welcome, your full skill library — PRDs, roadmaps, research syntheses, and 80+ more — knows your team and product.',
+    '',
+    'Need help? Reply at hello@mysecond.ai or open mysecond.ai/dashboard',
   ];
   return lines.join('\n');
 }

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -91,10 +91,15 @@ export const CONTEXT_PER_FILE_LIMIT = 50 * 1024;
 // gate as classifyArtifactType — leading '/', traversal, absolute paths
 // rejected. Only `.md` files under `context/` qualify; nested paths
 // (e.g. context/personas/buyer.md) are supported.
+//
+// Case-insensitive prefix check: macOS APFS / Windows NTFS default to
+// case-insensitive lookups, so `Context/foo.md` and `context/foo.md` resolve
+// to the same file on disk. A skill that emits the wrong case must not
+// silently drop on the floor — see follow-up #8 in mysecond-cli#11.
 export function isContextFile(relativePath: string): boolean {
   if (relativePath.startsWith('/') || relativePath.includes('..')) return false;
-  if (!relativePath.startsWith(CONTEXT_DIR + '/')) return false;
-  return relativePath.endsWith('.md');
+  if (!relativePath.toLowerCase().startsWith(CONTEXT_DIR + '/')) return false;
+  return relativePath.toLowerCase().endsWith('.md');
 }
 
 // Classify a write event's file path into an artifact_type for PostToolUse.
@@ -103,13 +108,16 @@ export function isContextFile(relativePath: string): boolean {
 // (PostToolUse single-file dispatch vs SessionStart full scan).
 export function classifyArtifactType(relativePath: string): ArtifactType | null {
   if (relativePath.startsWith('/') || relativePath.includes('..')) return null;
-  if (relativePath.includes('/tests/')) return null;
+  // Case-insensitive: same rationale as isContextFile — APFS/NTFS default
+  // case-insensitive lookups must not produce silent drops.
+  const lower = relativePath.toLowerCase();
+  if (lower.includes('/tests/')) return null;
   for (const dir of ARTIFACT_DIRS) {
-    if (relativePath.startsWith(dir.relativeDir + '/')) return dir.type;
+    if (lower.startsWith(dir.relativeDir.toLowerCase() + '/')) return dir.type;
   }
   // Workflow outputs aren't in ARTIFACT_DIRS (they're scanned per-workflow not
   // per-tier), but the PostToolUse hook still classifies them.
-  if (/^workflows\/[^/]+\/outputs\//.test(relativePath)) return 'other';
+  if (/^workflows\/[^/]+\/outputs\//.test(lower)) return 'other';
   return null;
 }
 

--- a/src/lib/plugin-counts.ts
+++ b/src/lib/plugin-counts.ts
@@ -1,0 +1,72 @@
+// Count installed skills / sub-agents / workflows from the extracted plugin
+// tree at `~/.mysecond/marketplaces/customer-{slug}/plugin/`.
+//
+// Used by step 13's post-install message as proof that the install populated
+// real content. Counts are intentionally tolerant — missing dirs return 0,
+// non-skill files (READMEs, .DS_Store) are ignored.
+//
+// Plugin layout convention (Claude Code plugins):
+//   plugin/
+//     skills/<skill-name>/SKILL.md
+//     agents/<agent-name>.md   OR  agents/<agent-name>/...
+//     commands/<command-name>.md   (we treat commands == workflows for the
+//                                   post-install message; this is the
+//                                   customer-facing label, see EDD §6.8)
+
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface PluginCounts {
+  skills: number;
+  agents: number;
+  workflows: number;
+}
+
+const EMPTY: PluginCounts = { skills: 0, agents: 0, workflows: 0 };
+
+function safeReaddir(dir: string): string[] {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+function isVisible(name: string): boolean {
+  // Skip dotfiles (.DS_Store, .git, etc.).
+  return !name.startsWith('.');
+}
+
+function countDirEntries(dir: string): number {
+  let count = 0;
+  for (const name of safeReaddir(dir)) {
+    if (!isVisible(name)) continue;
+    const full = join(dir, name);
+    try {
+      const st = statSync(full);
+      if (st.isDirectory()) {
+        count += 1;
+      } else if (st.isFile() && name.toLowerCase().endsWith('.md')) {
+        // Allow flat-file layouts (agents/foo.md, commands/foo.md) too.
+        count += 1;
+      }
+    } catch {
+      // unreadable entry; skip
+    }
+  }
+  return count;
+}
+
+export function countPluginContents(pluginDir: string): PluginCounts {
+  try {
+    const st = statSync(pluginDir);
+    if (!st.isDirectory()) return { ...EMPTY };
+  } catch {
+    return { ...EMPTY };
+  }
+  return {
+    skills: countDirEntries(join(pluginDir, 'skills')),
+    agents: countDirEntries(join(pluginDir, 'agents')),
+    workflows: countDirEntries(join(pluginDir, 'commands')),
+  };
+}

--- a/src/lib/steps/step-13.ts
+++ b/src/lib/steps/step-13.ts
@@ -1,7 +1,11 @@
-// Step 13: Print framed success box (§6.8). stdout only; always runs.
-// Box copy is finalized per Ron-B1 v2 + v1.4 restart instruction.
+// Step 13: Print post-install success message (§6.8). stdout only; always runs.
+// Copy redesigned May 2026 per launch-feedback-log: drop premature
+// /prd-generator + /enhance-context suggestions, lead with personalized line,
+// single primary CTA = `/welcome`. See `successBox()` in lib/copy.ts.
 
 import { successBox } from '../copy.js';
+import { countPluginContents } from '../plugin-counts.js';
+import { pluginExtractDir } from '../mysecond-paths.js';
 
 import type { StepFn } from './types.js';
 
@@ -11,8 +15,17 @@ export const step13: StepFn = async ({ ctx, shared }) => {
   // for every customer on launch day. See step 4 for the population logic.
   const pmName = shared.pmName ?? 'you';
   const companyName = shared.companyName ?? 'your company';
+
+  // Count installed skills/agents/workflows from the extracted plugin tree as
+  // proof the install populated content. Best-effort: if the slug is missing
+  // or the extract dir is unreadable, counts default to all-zero and the
+  // success copy degrades to a generic "PM skill library" phrase.
+  if (shared.pluginCounts === undefined && shared.customerSlug !== undefined) {
+    shared.pluginCounts = countPluginContents(pluginExtractDir(shared.customerSlug));
+  }
+
   if (!ctx.silent) {
-    process.stdout.write('\n' + successBox(pmName, companyName) + '\n\n');
+    process.stdout.write('\n' + successBox(pmName, companyName, shared.pluginCounts) + '\n\n');
   }
   return { step: 13, outcome: { kind: 'completed' } };
 };

--- a/src/lib/steps/types.ts
+++ b/src/lib/steps/types.ts
@@ -28,6 +28,15 @@ export interface StepContext {
     // Step 9 stale-cache fallback signaling — runner uses this to print the
     // banner from §6.2.B after the success box.
     staleCacheUsed?: { cachedAgeHours: number };
+    // Step 13 reads these from the extracted plugin tree (skills/, agents/,
+    // commands/) and uses them in the post-install success message as proof
+    // that the install actually populated content. Computed lazily in step 13
+    // to avoid touching step 9's multiple LKG-fallback return paths.
+    pluginCounts?: {
+      skills: number;
+      agents: number;
+      workflows: number;
+    };
   };
 }
 

--- a/tests/commands/artifact-sync.test.ts
+++ b/tests/commands/artifact-sync.test.ts
@@ -279,4 +279,37 @@ describe('runArtifactSync — context-file branch', () => {
     const written = JSON.parse(readFileSync(join(root, '.claude/sync-state.json'), 'utf8'));
     expect(written.contextFiles['context/company.md']).toBeDefined();
   });
+
+  // Follow-up #6 — server kill switch must propagate from the PostToolUse
+  // hook so subsequent events also stop. Previously the catch-all swallowed
+  // the rollbackPause MysecondError and the hook still returned 0.
+  it('re-throws rollbackPause (exitCode 7) on context branch when server returns halt header', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'mysecond-pth-halt-'));
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'x');
+    fetchMock.mockResolvedValueOnce(
+      new Response('{"synced":0}', {
+        status: 200,
+        headers: { 'X-Mysecond-Halt': '1' },
+      })
+    );
+    stubStdin(toolEvent('Write', join(root, 'context/company.md')));
+
+    await expect(runArtifactSync([], ctx(root))).rejects.toMatchObject({ exitCode: 7 });
+  });
+
+  it('re-throws rollbackPause (exitCode 7) on artifact branch when server returns halt header', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'mysecond-pth-halt-art-'));
+    mkdirSync(join(root, 'specs/outputs'), { recursive: true });
+    writeFileSync(join(root, 'specs/outputs/foo.md'), 'x');
+    fetchMock.mockResolvedValueOnce(
+      new Response('{"synced":0}', {
+        status: 200,
+        headers: { 'X-Mysecond-Halt': '1' },
+      })
+    );
+    stubStdin(toolEvent('Write', join(root, 'specs/outputs/foo.md')));
+
+    await expect(runArtifactSync([], ctx(root))).rejects.toMatchObject({ exitCode: 7 });
+  });
 });

--- a/tests/lib/api.test.ts
+++ b/tests/lib/api.test.ts
@@ -106,4 +106,35 @@ describe('contextFilesPush', () => {
     const result = await contextFilesPush(ctx(), [file('context/a.md', 'a')]);
     expect(result).toEqual({ synced: 0, skipped: 0, errors: [] });
   });
+
+  // Follow-up #6 — server-side rollback-pause kill switch must propagate.
+  it('throws rollbackPause (exitCode 7) when server returns X-Mysecond-Halt: 1', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('{"synced":0}', {
+        status: 200,
+        headers: { 'X-Mysecond-Halt': '1' },
+      })
+    );
+    await expect(
+      contextFilesPush(ctx(), [file('context/a.md', 'a')])
+    ).rejects.toMatchObject({ exitCode: 7 });
+  });
+
+  // Follow-up #7 — caller can pass timeoutMs (SessionStart hook uses 8s).
+  it('honors caller-provided timeoutMs by aborting fetch when exceeded', async () => {
+    // Slow fetch that never resolves — should be aborted by AbortSignal.timeout.
+    fetchMock.mockImplementationOnce(
+      (_url: URL, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'TimeoutError';
+            reject(err);
+          });
+        })
+    );
+    await expect(
+      contextFilesPush(ctx(), [file('context/a.md', 'a')], { timeoutMs: 50 })
+    ).rejects.toThrow(/Cannot reach mysecond\.ai/);
+  });
 });

--- a/tests/lib/payload.test.ts
+++ b/tests/lib/payload.test.ts
@@ -35,6 +35,13 @@ describe('classifyArtifactType', () => {
   it('skips test outputs', () => {
     expect(classifyArtifactType('specs/outputs/tests/x.md')).toBeNull();
   });
+
+  // Follow-up #8 — case-insensitive prefix match.
+  it('classifies case-variant artifact prefixes on case-insensitive filesystems', () => {
+    expect(classifyArtifactType('Specs/Outputs/foo.md')).toBe('prd');
+    expect(classifyArtifactType('STRATEGY/OUTPUTS/bar.md')).toBe('strategy');
+    expect(classifyArtifactType('Workflows/Foo/Outputs/z.md')).toBe('other');
+  });
 });
 
 describe('ARTIFACT_DIRS', () => {
@@ -77,6 +84,20 @@ describe('isContextFile', () => {
     expect(isContextFile('/abs/context/foo.md')).toBe(false);
     expect(isContextFile('../escape/context/foo.md')).toBe(false);
     expect(isContextFile('context/../etc/passwd')).toBe(false);
+  });
+
+  // Follow-up #8 — case-insensitive filesystems (macOS APFS, Windows NTFS
+  // default) resolve `Context/foo.md` and `context/foo.md` to the same disk
+  // file. A skill that emits the wrong case must not silently drop.
+  it('accepts case-variant context prefix on case-insensitive filesystems', () => {
+    expect(isContextFile('Context/company.md')).toBe(true);
+    expect(isContextFile('CONTEXT/personas.md')).toBe(true);
+    expect(isContextFile('CoNtExT/goals.md')).toBe(true);
+  });
+
+  it('accepts case-variant .md suffix', () => {
+    expect(isContextFile('context/company.MD')).toBe(true);
+    expect(isContextFile('context/product.Md')).toBe(true);
   });
 });
 

--- a/tests/lib/post-install-message.test.ts
+++ b/tests/lib/post-install-message.test.ts
@@ -1,0 +1,143 @@
+// Tests for the May-2026 post-install success message redesign.
+// Drives Step 13's `successBox()` output — the last thing the customer sees
+// after `mysecond init`. See decision in launch-feedback-log (2026-05-01).
+
+import { describe, expect, it } from 'vitest';
+
+import { successBox } from '../../src/lib/copy.js';
+
+describe('successBox: locked structure (May-2026 redesign)', () => {
+  it('snapshot — happy path with full counts', () => {
+    const out = successBox('Alice', 'Acme Corp', {
+      skills: 91,
+      agents: 6,
+      workflows: 4,
+    });
+    expect(out).toMatchInlineSnapshot(`
+      "✓ mySecond PM OS installed for Alice at Acme Corp
+
+      Here's what's now in place:
+      - pm-os plugin registered (user scope) with 91 skills, 6 sub-agents, 4 workflows
+      - Context sync hooks active for every Claude Code session
+      - Your context files will be created in step 2 below
+
+      ALMOST THERE — close and reopen Claude Code to activate the plugin.
+
+      Then run /welcome in Claude Code. It takes about 5 minutes and sets up your context files for Acme Corp (company, product, personas, competitors, goals).
+
+      After /welcome, your full skill library — PRDs, roadmaps, research syntheses, and 80+ more — knows your team and product.
+
+      Need help? Reply at hello@mysecond.ai or open mysecond.ai/dashboard"
+    `);
+  });
+
+  it('total message stays under 20 lines (CXO budget)', () => {
+    const out = successBox('Alice', 'Acme Corp', { skills: 91, agents: 6, workflows: 4 });
+    expect(out.split('\n').length).toBeLessThan(20);
+  });
+
+  it('personalizes lead line with both pm name and company', () => {
+    const out = successBox('Alice', 'Acme Corp', { skills: 1, agents: 1, workflows: 1 });
+    expect(out).toContain('for Alice at Acme Corp');
+    // Critical RED-TEAM R2 P0-A regression: not "for Alice at Alice".
+    expect(out).not.toContain('for Alice at Alice');
+  });
+
+  it('mentions company name a second time in the /welcome CTA (drives ownership)', () => {
+    const out = successBox('Alice', 'Acme Corp', { skills: 1, agents: 1, workflows: 1 });
+    // Lead line + welcome CTA = company appears twice.
+    const occurrences = out.split('Acme Corp').length - 1;
+    expect(occurrences).toBe(2);
+  });
+});
+
+describe('successBox: count formatting', () => {
+  it('omits zero-count categories cleanly', () => {
+    const out = successBox('Ron', 'mySecond', { skills: 91, agents: 0, workflows: 0 });
+    expect(out).toContain('91 skills');
+    expect(out).not.toContain('0 sub-agents');
+    expect(out).not.toContain('0 workflows');
+  });
+
+  it('uses singular forms for count == 1', () => {
+    const out = successBox('Ron', 'mySecond', { skills: 1, agents: 1, workflows: 1 });
+    expect(out).toContain('1 skill,');
+    expect(out).toContain('1 sub-agent,');
+    expect(out).toContain('1 workflow');
+    expect(out).not.toContain('1 skills');
+    expect(out).not.toContain('1 sub-agents');
+  });
+
+  it('falls back to a generic phrase if all counts are zero', () => {
+    const out = successBox('Ron', 'mySecond', { skills: 0, agents: 0, workflows: 0 });
+    expect(out).toContain('PM skill library');
+  });
+
+  it('falls back to a generic phrase when counts are undefined', () => {
+    const out = successBox('Ron', 'mySecond', undefined);
+    expect(out).toContain('PM skill library');
+  });
+});
+
+describe('successBox: red-team — malicious / missing names', () => {
+  it('strips ANSI escape sequences from pm name', () => {
+    // ESC[31m is "set foreground red". Without sanitization, this would
+    // colour the rest of the customer\'s terminal output red.
+    const malicious = '[31mAlice[0m';
+    const out = successBox(malicious, 'Acme');
+    expect(out).not.toContain('');
+    expect(out).toContain('Alice');
+  });
+
+  it('strips control characters (newlines, carriage returns, tabs)', () => {
+    const malicious = 'Alice\r\n\tEvil';
+    const out = successBox(malicious, 'Acme');
+    // Newlines/CRs would let an attacker inject extra display lines.
+    expect(out).not.toContain('Alice\r');
+    expect(out).not.toContain('Alice\n');
+    expect(out).not.toContain('\tEvil');
+    // Stripped chars collapse to a space, so the result reads "AliceEvil"
+    // — sanitized but contiguous. We only assert no control chars survive.
+    expect(out).toContain('Alice');
+  });
+
+  it('strips HTML angle brackets from names', () => {
+    const out = successBox('<script>alert(1)</script>', 'Acme');
+    expect(out).not.toContain('<script>');
+    expect(out).not.toContain('</script>');
+  });
+
+  it('truncates pathologically long names', () => {
+    const huge = 'A'.repeat(500);
+    const out = successBox(huge, 'Acme');
+    // Must not blow out the message or contain all 500 chars.
+    expect(out.length).toBeLessThan(2000);
+    expect(out).toContain('…');
+  });
+
+  it('falls back gracefully when company_name is missing', () => {
+    const out = successBox('Alice', '');
+    expect(out).toContain('for Alice at your company');
+  });
+
+  it('falls back gracefully when both names are missing', () => {
+    const out = successBox('', '');
+    expect(out).toContain('for you at your company');
+  });
+
+  it('handles undefined-cast inputs without crashing (defensive)', () => {
+    const out = successBox(
+      undefined as unknown as string,
+      undefined as unknown as string
+    );
+    expect(out).toContain('for you at your company');
+  });
+
+  it('handles non-string inputs (defensive — server contract violation)', () => {
+    const out = successBox(
+      42 as unknown as string,
+      { evil: true } as unknown as string
+    );
+    expect(out).toContain('for you at your company');
+  });
+});

--- a/tests/lib/red-team-r2-regression.test.ts
+++ b/tests/lib/red-team-r2-regression.test.ts
@@ -65,26 +65,27 @@ describe('RED-TEAM R2 P0-B: marketplace.json metadata block prevents stderr warn
 });
 
 // =====================================================================
-// CAIO P0-C: success box uses namespaced /pm-os:* skill names
+// May-2026 redesign: post-install message drops premature skill suggestions
+// (was CAIO P0-C, namespaced /pm-os:* names). Customer feedback in
+// launch-feedback-log: suggesting /prd-generator + /enhance-context before
+// /welcome is run is premature — there are no context files yet. Single
+// primary CTA is now `/welcome`.
 // =====================================================================
-describe('RED-TEAM R2 P0-C: success box uses namespaced skill names', () => {
+describe('post-install message: single primary CTA = /welcome', () => {
   const box = successBox('Alice', 'Acme');
 
-  it('advertises /pm-os:prd-generator (namespaced) not bare /prd-generator', () => {
-    expect(box).toContain('/pm-os:prd-generator');
-    // Critical: bare `/prd-generator` collides with any other plugin or
-    // project-level skill. Customer would type bare and get wrong routing.
-    expect(box).not.toMatch(/^[^:]\/prd-generator/m);
-    // Note: we DON'T assert "no bare /prd-generator anywhere" — the
-    // namespaced form contains the substring "prd-generator" by definition.
+  it('directs the customer to /welcome (the actual first step)', () => {
+    expect(box).toContain('/welcome');
   });
 
-  it('advertises /pm-os:skills (namespaced)', () => {
-    expect(box).toContain('/pm-os:skills');
+  it('does NOT advertise /prd-generator (premature without context files)', () => {
+    expect(box).not.toContain('/prd-generator');
+    expect(box).not.toContain('/pm-os:prd-generator');
   });
 
-  it('advertises /pm-os:enhance-context (namespaced)', () => {
-    expect(box).toContain('/pm-os:enhance-context');
+  it('does NOT advertise /enhance-context (premature before /welcome)', () => {
+    expect(box).not.toContain('/enhance-context');
+    expect(box).not.toContain('/pm-os:enhance-context');
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace framed ASCII success box at end of \`mysecond init\` with a plain-text, personalized message driven by customer feedback (launch-feedback-log 2026-05-01).
- Lead line: \`✓ mySecond PM OS installed for {pm_name} at {company_name}\`. Both names already flow from \`/install-ready\` (step 4 populates \`shared.pmName\` + \`shared.companyName\`).
- Single primary CTA = \`/welcome\`. Drop \`/prd-generator\` + \`/enhance-context\` (premature before context files exist).
- Counts (skills / sub-agents / workflows) read from the extracted plugin tree at step 13. Singular/plural handled. Zero-count categories omitted. All-zero falls back to generic phrasing.
- Sanitization: strip ASCII + C1 control chars, ANSI escapes, HTML angle brackets; collapse whitespace; truncate at 40 chars; fall back to \`you\` / \`your company\`.

## Sample output
\`\`\`
✓ mySecond PM OS installed for Alice at Acme Corp

Here's what's now in place:
- pm-os plugin registered (user scope) with 91 skills, 6 sub-agents, 4 workflows
- Context sync hooks active for every Claude Code session
- Your context files will be created in step 2 below

ALMOST THERE — close and reopen Claude Code to activate the plugin.

Then run /welcome in Claude Code. It takes about 5 minutes and sets up your context files for Acme Corp (company, product, personas, competitors, goals).

After /welcome, your full skill library — PRDs, roadmaps, research syntheses, and 80+ more — knows your team and product.

Need help? Reply at hello@mysecond.ai or open mysecond.ai/dashboard
\`\`\`

## Files changed
- \`src/lib/copy.ts\` — rewrite \`successBox()\`, add \`sanitizeName()\` + \`formatCountsLine()\` + \`PostInstallCounts\` interface.
- \`src/lib/plugin-counts.ts\` (new) — \`countPluginContents()\` reads \`skills/\`, \`agents/\`, \`commands/\` from extracted plugin dir.
- \`src/lib/steps/step-13.ts\` — count plugin contents (best-effort) and pass to \`successBox()\`.
- \`src/lib/steps/types.ts\` — add \`shared.pluginCounts\` field.
- \`tests/lib/post-install-message.test.ts\` (new, 16 tests) — snapshot, line-count budget, count formatting, red-team (ANSI, control chars, HTML tags, length, missing/non-string inputs).
- \`tests/lib/red-team-r2-regression.test.ts\` — update R2 P0-C test from "namespaced skill names" to "single /welcome CTA".

## Gates
- [x] Typecheck: \`npm run typecheck\` clean.
- [x] Tests: \`npm test\` 190/190 pass (was 189/189; added 16 new, removed 3 stale assertions from R2 P0-C).
- [x] Build: \`npm run build\` clean.
- [x] Snapshot test of new message with mock pm_name + company_name + counts.
- [x] Self-review: counts function omits zeros cleanly; \`successBox\` signature stays string-string-optional, snapshot is the contract.
- [x] Red-team: malicious customer name (HTML, ANSI, control chars), missing company_name, non-string inputs, length blowup — all covered.
- [x] CTO pull-through feasibility: \`shared.pmName\` + \`shared.companyName\` already populated by step 4 from \`/install-ready\`. No new server contract needed. Counts come from filesystem, no new API call.

## Test plan
- [ ] Local: \`npm pack\` → \`npm i -g <tarball>\` → \`mysecond init\` against a known team → capture success-box output.
- [ ] Verify Claude Code restart still required (no behavior change there).
- [ ] Sanity-check long company names render with ellipsis truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)