### PR TITLE
feat(copy): suppress post-install skill suggestions + drop technical phrasing

### DIFF
--- a/src/lib/copy.ts
+++ b/src/lib/copy.ts
@@ -64,6 +64,10 @@ export function claudeMdBlock(companyName: string, pmName: string): string {
     '@context/competitors.md',
     '',
     'For skill usage, type `/skills` in Claude Code. Sync runs automatically on every SessionStart.',
+    '',
+    '## After Installation',
+    '',
+    'After running `mysecond init`, the only next step for a new user is `/welcome`. Do not suggest `/enhance-context`, `/prd-generator`, or other skills before `/welcome` runs — no context files exist yet, and those skills depend on them. Stay quiet about skill discovery; let `/welcome` drive the first-run experience.',
   ].join('\n');
 }
 
@@ -119,9 +123,9 @@ function formatCountsLine(counts: PostInstallCounts | undefined): string {
   if (agents > 0) parts.push(`${agents} ${agents === 1 ? 'sub-agent' : 'sub-agents'}`);
   if (workflows > 0) parts.push(`${workflows} ${workflows === 1 ? 'workflow' : 'workflows'}`);
   if (parts.length === 0) {
-    return '- pm-os plugin registered (user scope) with your PM skill library';
+    return '- pm-os plugin registered with your PM skill library';
   }
-  return `- pm-os plugin registered (user scope) with ${parts.join(', ')}`;
+  return `- pm-os plugin registered with ${parts.join(', ')}`;
 }
 
 // New post-install message (May-2026 redesign). Returns a plain-text block

--- a/tests/lib/post-install-message.test.ts
+++ b/tests/lib/post-install-message.test.ts
@@ -17,7 +17,7 @@ describe('successBox: locked structure (May-2026 redesign)', () => {
       "✓ mySecond PM OS installed for Alice at Acme Corp
 
       Here's what's now in place:
-      - pm-os plugin registered (user scope) with 91 skills, 6 sub-agents, 4 workflows
+      - pm-os plugin registered with 91 skills, 6 sub-agents, 4 workflows
       - Context sync hooks active for every Claude Code session
       - Your context files will be created in step 2 below
 


### PR DESCRIPTION
## Summary

Two changes from Ron's 3rd review feedback (`launch-feedback-log.md` "may 1 2026 - 3rd review", items A and B):

### 1. `claudeMdBlock()` — post-install skill-suppression instruction (feedback A)

After `mysecond init`, Claude Code Desktop auto-suggests `/enhance-context` and `/prd-generator` and links to context-health. Those suggestions distract from `/welcome` — the actual next step.

Per CTO research, the most reliable lever is an explicit instruction in the installed `CLAUDE.md` (~85% effective; behavioral guidance, not hard constraint, but reliable in practice). Sentinel markers in stdout don't reliably suppress anything.

New section appended to `claudeMdBlock()`:

> ## After Installation
>
> After running `mysecond init`, the only next step for a new user is `/welcome`. Do not suggest `/enhance-context`, `/prd-generator`, or other skills before `/welcome` runs — no context files exist yet, and those skills depend on them. Stay quiet about skill discovery; let `/welcome` drive the first-run experience.

### 2. `successBox()` — drop "(user scope)" technical phrasing (feedback B)

Light tightening. Ron called out the install message as "too technical" — `(user scope)` was noise that doesn't matter to the customer. Plan-of-record specifies this is light surgical work; the bigger lever is the CLAUDE.md instruction above.

Before: \`pm-os plugin registered (user scope) with 91 skills…\`
After:  \`pm-os plugin registered with 91 skills…\`

## Files changed

- `src/lib/copy.ts` — `claudeMdBlock()` append, `formatCountsLine()` strip
- `tests/lib/post-install-message.test.ts` — inline snapshot updated

## Pre-push checks

- `tsc --noEmit` ✓
- `npm test` ✓ — 190 tests pass (1 snapshot updated)
- `npm run build` ✓ — 84.9kb dist

## What's NOT in this PR

- `successBox()` further restructuring beyond stripping "(user scope)" — held per plan ("the bigger lever is the CLAUDE.md instruction")
- npm publish / version bump — separate step after merge + Ron's verbal approval

## Verification path

After merge:
1. Bump version (1.3.0 → 1.3.1) and publish to npm `next` tag for safer rollout
2. Fresh customer E2E: `npx -y @mysecond/cli@next init` → confirm Claude does NOT suggest /enhance-context or /prd-generator after install message; only /welcome surfaces as the next step
3. Promote `next` → `latest` once verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)