### PR TITLE
fix(plugin-counts): traverse subplugins for accurate install counts

### DIFF
--- a/src/lib/copy.ts
+++ b/src/lib/copy.ts
@@ -72,6 +72,8 @@ export function claudeMdBlock(companyName: string, pmName: string): string {
     '## After Installation',
     '',
     'After running `mysecond init`, the only next step for a new user is `/welcome`. Do not suggest `/enhance-context`, `/prd-generator`, or other skills before `/welcome` runs — no context files exist yet, and those skills depend on them. Stay quiet about skill discovery; let `/welcome` drive the first-run experience.',
+    '',
+    'If summarizing the install confirmation, you MUST mention all three counts the cli reported (skills, sub-agents, workflows) — do not drop any.',
   ].join('\n');
 }
 

--- a/src/lib/plugin-counts.ts
+++ b/src/lib/plugin-counts.ts
@@ -5,15 +5,25 @@
 // real content. Counts are intentionally tolerant — missing dirs return 0,
 // non-skill files (READMEs, .DS_Store) are ignored.
 //
-// Plugin layout convention (Claude Code plugins):
+// Plugin layout (multi-subplugin — what product-manager-os actually emits):
 //   plugin/
-//     skills/<skill-name>/SKILL.md
-//     agents/<agent-name>.md   OR  agents/<agent-name>/...
-//     commands/<command-name>.md   (we treat commands == workflows for the
-//                                   post-install message; this is the
-//                                   customer-facing label, see EDD §6.8)
+//     <subplugin>/
+//       .claude-plugin/plugin.json    (presence marks a real subplugin)
+//       skills/<skill-name>/SKILL.md  (counted as a skill)
+//       agents/<agent-name>.md        (counted as a sub-agent)
+//       workflows/<workflow>.md       (counted as a workflow — workflows-pack)
+//       commands/<wrapper>.md         (NOT counted — slash-command wrappers
+//                                     around skills, 1:1 with the skills/ dir)
+//
+// Subdirs without `.claude-plugin/plugin.json` (e.g. `context-templates/`,
+// `work/`) are skipped silently so they neither contribute nor break counting.
+//
+// If no subplugins are detected, returns zeros — there is no flat-layout
+// fallback. The cli only ever installs product-manager-os, which is always
+// multi-subplugin. Returning zeros triggers the existing fallback string in
+// `successBox` ("pm-os plugin registered with your PM skill library").
 
-import { readdirSync, statSync } from 'node:fs';
+import { readdirSync, statSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 export interface PluginCounts {
@@ -37,6 +47,14 @@ function isVisible(name: string): boolean {
   return !name.startsWith('.');
 }
 
+function isDir(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 function countDirEntries(dir: string): number {
   let count = 0;
   for (const name of safeReaddir(dir)) {
@@ -47,7 +65,7 @@ function countDirEntries(dir: string): number {
       if (st.isDirectory()) {
         count += 1;
       } else if (st.isFile() && name.toLowerCase().endsWith('.md')) {
-        // Allow flat-file layouts (agents/foo.md, commands/foo.md) too.
+        // Allow flat-file layouts (agents/foo.md, workflows/foo.md) too.
         count += 1;
       }
     } catch {
@@ -58,15 +76,23 @@ function countDirEntries(dir: string): number {
 }
 
 export function countPluginContents(pluginDir: string): PluginCounts {
-  try {
-    const st = statSync(pluginDir);
-    if (!st.isDirectory()) return { ...EMPTY };
-  } catch {
-    return { ...EMPTY };
+  if (!isDir(pluginDir)) return { ...EMPTY };
+
+  const totals: PluginCounts = { skills: 0, agents: 0, workflows: 0 };
+  let foundAnySubplugin = false;
+
+  for (const name of safeReaddir(pluginDir)) {
+    if (!isVisible(name)) continue;
+    const subDir = join(pluginDir, name);
+    if (!isDir(subDir)) continue;
+    if (!existsSync(join(subDir, '.claude-plugin', 'plugin.json'))) continue;
+
+    foundAnySubplugin = true;
+    totals.skills += countDirEntries(join(subDir, 'skills'));
+    totals.agents += countDirEntries(join(subDir, 'agents'));
+    totals.workflows += countDirEntries(join(subDir, 'workflows'));
   }
-  return {
-    skills: countDirEntries(join(pluginDir, 'skills')),
-    agents: countDirEntries(join(pluginDir, 'agents')),
-    workflows: countDirEntries(join(pluginDir, 'commands')),
-  };
+
+  if (!foundAnySubplugin) return { ...EMPTY };
+  return totals;
 }

--- a/tests/lib/plugin-counts.test.ts
+++ b/tests/lib/plugin-counts.test.ts
@@ -1,0 +1,165 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { countPluginContents } from '../../src/lib/plugin-counts.js';
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'mysecond-plugin-counts-'));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+// Make a subplugin dir with .claude-plugin/plugin.json marker.
+function makeSubplugin(root: string, name: string): string {
+  const sub = join(root, name);
+  mkdirSync(join(sub, '.claude-plugin'), { recursive: true });
+  writeFileSync(join(sub, '.claude-plugin', 'plugin.json'), '{}');
+  return sub;
+}
+
+// Add N skill subdirs (each with a SKILL.md file) under <sub>/skills/.
+function addSkills(sub: string, count: number): void {
+  for (let i = 0; i < count; i++) {
+    const skill = join(sub, 'skills', `skill-${i}`);
+    mkdirSync(skill, { recursive: true });
+    writeFileSync(join(skill, 'SKILL.md'), '# skill');
+  }
+}
+
+// Add N agent .md files under <sub>/agents/.
+function addAgents(sub: string, count: number): void {
+  mkdirSync(join(sub, 'agents'), { recursive: true });
+  for (let i = 0; i < count; i++) {
+    writeFileSync(join(sub, 'agents', `agent-${i}.md`), '# agent');
+  }
+}
+
+// Add N workflow .md files under <sub>/workflows/.
+function addWorkflows(sub: string, count: number): void {
+  mkdirSync(join(sub, 'workflows'), { recursive: true });
+  for (let i = 0; i < count; i++) {
+    writeFileSync(join(sub, 'workflows', `wf-${i}.md`), '# wf');
+  }
+}
+
+// Add N command wrappers under <sub>/commands/. These should NOT be counted
+// as workflows — they're slash-command wrappers around skills (1:1).
+function addCommands(sub: string, count: number): void {
+  mkdirSync(join(sub, 'commands'), { recursive: true });
+  for (let i = 0; i < count; i++) {
+    writeFileSync(join(sub, 'commands', `cmd-${i}.md`), '# cmd');
+  }
+}
+
+// Build the verified production layout: 79 skills + 12 agents + 7 workflows.
+function buildProductionLayout(root: string): void {
+  const skillSubplugins: Array<[string, number]> = [
+    ['communication', 9],
+    ['competitive', 6],
+    ['data', 7],
+    ['discovery', 13],
+    ['launch', 3],
+    ['operations', 6],
+    ['planning', 7],
+    ['specs', 9],
+    ['strategy', 19],
+  ];
+  for (const [name, n] of skillSubplugins) {
+    const sub = makeSubplugin(root, name);
+    addSkills(sub, n);
+    // Each skill subplugin also has commands/ wrappers (1:1) — must NOT be
+    // counted as workflows. Add them so the test catches a regression that
+    // would re-count them.
+    addCommands(sub, n);
+  }
+
+  // personas/ subplugin: agents only.
+  addAgents(makeSubplugin(root, 'personas'), 12);
+
+  // workflows-pack/ subplugin: workflows only.
+  addWorkflows(makeSubplugin(root, 'workflows-pack'), 7);
+
+  // companion-sync/ subplugin: hooks only, no countable content.
+  const sync = makeSubplugin(root, 'companion-sync');
+  mkdirSync(join(sync, 'hooks'), { recursive: true });
+  writeFileSync(join(sync, 'hooks', 'pre-tool-use.sh'), '#!/bin/sh');
+}
+
+describe('countPluginContents', () => {
+  it('multi-subplugin happy path returns 79 skills, 12 agents, 7 workflows', () => {
+    buildProductionLayout(workDir);
+    expect(countPluginContents(workDir)).toEqual({
+      skills: 79,
+      agents: 12,
+      workflows: 7,
+    });
+  });
+
+  it('non-subplugin root (no .claude-plugin/plugin.json anywhere) returns zeros — no flat-layout fallback', () => {
+    // Build a flat layout that the OLD code would have counted.
+    mkdirSync(join(workDir, 'skills', 'a'), { recursive: true });
+    writeFileSync(join(workDir, 'skills', 'a', 'SKILL.md'), '# s');
+    mkdirSync(join(workDir, 'agents'), { recursive: true });
+    writeFileSync(join(workDir, 'agents', 'a.md'), '# a');
+    mkdirSync(join(workDir, 'commands'), { recursive: true });
+    writeFileSync(join(workDir, 'commands', 'c.md'), '# c');
+
+    expect(countPluginContents(workDir)).toEqual({
+      skills: 0,
+      agents: 0,
+      workflows: 0,
+    });
+  });
+
+  it('missing pluginDir returns zeros', () => {
+    expect(countPluginContents(join(workDir, 'does-not-exist'))).toEqual({
+      skills: 0,
+      agents: 0,
+      workflows: 0,
+    });
+  });
+
+  it('subdirs without .claude-plugin/plugin.json are skipped without subtracting from totals', () => {
+    buildProductionLayout(workDir);
+
+    // Add the real-layout decoys: context-templates/ has stray .md files,
+    // work/ has subdirs. Neither has plugin.json — both must be ignored.
+    const ct = join(workDir, 'context-templates');
+    mkdirSync(ct, { recursive: true });
+    writeFileSync(join(ct, 'company.md'), '# stray');
+    writeFileSync(join(ct, 'product.md'), '# stray');
+
+    const work = join(workDir, 'work');
+    mkdirSync(join(work, 'discovery'), { recursive: true });
+    mkdirSync(join(work, 'specs'), { recursive: true });
+
+    // Even with these decoys, totals must be unchanged.
+    expect(countPluginContents(workDir)).toEqual({
+      skills: 79,
+      agents: 12,
+      workflows: 7,
+    });
+  });
+
+  it('subplugin commands/ dirs are NOT counted as workflows (regression guard)', () => {
+    // One subplugin with both commands/ (10) and workflows/ (3). Workflows
+    // count = 3, NOT 13.
+    const sub = makeSubplugin(workDir, 'mixed');
+    addCommands(sub, 10);
+    addWorkflows(sub, 3);
+
+    expect(countPluginContents(workDir).workflows).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Rewrites `countPluginContents()` to walk multi-subplugin layouts (specs/, discovery/, personas/, workflows-pack/, etc.) instead of looking at flat `pluginDir/{skills,agents,commands}` — which returned 0/0/0 for every real customer install
- Sums skills from `<sub>/skills/`, agents from `<sub>/agents/`, workflows from `<sub>/workflows/`. Subplugin `commands/` dirs are explicitly excluded — they're 1:1 slash-command wrappers around the skills in the same subplugin and would double-count
- Tightens \`claudeMdBlock\` so when Claude paraphrases the install confirmation, it must mention all three counts (skills, sub-agents, workflows) — addresses the editorialization that originally lost the agents/workflows numbers
- Verified production layout (\`mysecond-customer-t0501g-nbzl\`) sums to **79 skills, 12 agents, 7 workflows**

## Why
Tonight's E2E install hit: \"pm-os plugin registered with 91 PM skills synced\" — wrong number, missing agents and workflows entirely. Root cause: cli plugin-counts looked at flat layout but the customer plugin is multi-subplugin.

## Test plan
- [x] \`npm test\` — 195 tests pass (5 new in \`tests/lib/plugin-counts.test.ts\`)
- [x] \`npm run typecheck\` clean
- [ ] After merge + v1.3.3 publish: live cli init against test customer should print \"79 skills, 12 sub-agents, 7 workflows\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)