### PR TITLE
fix(security): step-5 throw no longer leaves .env un-gitignored (v1.3.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mysecond/cli",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "UNLICENSED",
       "dependencies": {
         "proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/lib/init-runner.ts
+++ b/src/lib/init-runner.ts
@@ -17,6 +17,7 @@ import {
 } from './sync-state.js';
 
 import { STEPS, type StepEntry } from './steps/index.js';
+import { runGitignoreGuard } from './steps/step-5b.js';
 import type { StepContext } from './steps/types.js';
 
 export async function runInit(ctx: CommandContext): Promise<number> {
@@ -98,7 +99,26 @@ export async function runInit(ctx: CommandContext): Promise<number> {
       }
       // RED-TEAM R2 P1-D: track current step for SIGINT telemetry above.
       currentStepNumber = entry.number;
-      const result = await entry.fn(sctx);
+      let result;
+      try {
+        result = await entry.fn(sctx);
+      } catch (err) {
+        // Orphan-migration safety: if step-5 (.env write) throws — most
+        // commonly an env conflict the customer didn't pass --fix for —
+        // the gitignore guard from step-5b would otherwise never run, and
+        // the customer's existing .env sits un-protected. Run the guard
+        // here on the failure path so the security mitigation always lands.
+        // No-op on success (step-5b runs the guard normally) and no-op
+        // outside step 5 (other steps don't touch credentials).
+        if (entry.number === 5) {
+          try {
+            runGitignoreGuard(ctx.rootDir, ctx.silent);
+          } catch {
+            // Guard itself failed — don't mask the original error.
+          }
+        }
+        throw err;
+      }
 
       if (result.message !== undefined && !ctx.silent) {
         process.stdout.write(result.message + '\n');

--- a/src/lib/steps/step-5b.ts
+++ b/src/lib/steps/step-5b.ts
@@ -77,6 +77,55 @@ function emitWarning(_silent: boolean, message: string): void {
   process.stderr.write(`${message}\n`);
 }
 
+/**
+ * Runs the `.env`-gitignore security guard. Exported separately from `step5b`
+ * so init-runner can call it from step-5's catch handler — if step-5 throws
+ * (e.g. .env conflict before --fix), the customer's existing un-gitignored
+ * .env is the security risk this PR was scoped to fix. Without this, an
+ * orphan .env sits in the repo with the key un-protected.
+ *
+ * Behavior matches the inline version in step5b's happy path:
+ *  • Skipped if not a git repo (no point creating a stray .gitignore)
+ *  • LOUD warning if .env is already git-tracked (gitignore is a no-op then)
+ *  • Otherwise: pre-write notice + atomic append to .gitignore
+ *  • Idempotent — safe to call multiple times in one init run
+ */
+export function runGitignoreGuard(rootDir: string, silent: boolean): void {
+  if (!isGitRepo(rootDir)) return;
+
+  if (isFileTracked(rootDir, '.env')) {
+    emitWarning(
+      silent,
+      '[mysecond] ⚠️ SECURITY: .env is tracked by git in this repo. Your COMPANION_API_KEY is in your git history right now. Remediate:\n' +
+        '  1. git rm --cached .env\n' +
+        '  2. git commit -m "stop tracking .env"\n' +
+        '  3. Rotate your key at app.mysecond.ai (the old key is in git history forever).\n' +
+        '  4. Re-run `mysecond init` with the new key.'
+    );
+    return;
+  }
+
+  // Pre-write notice + ensure entry. Customer-empathy: print BEFORE mutating.
+  const path = join(rootDir, '.gitignore');
+  const willMutate =
+    !existsSync(path) ||
+    !readFileSync(path, 'utf8')
+      .split('\n')
+      .map((l) => l.trim())
+      .includes('.env');
+  if (willMutate) {
+    emit(silent, '[mysecond] Adding `.env` to .gitignore as a safety net.');
+  }
+  try {
+    ensureGitignoreEntry(rootDir, '.env');
+  } catch (err) {
+    emitWarning(
+      silent,
+      `[mysecond] ⚠️ Could not update .gitignore (${(err as Error).message}). Add \`.env\` manually so your API key isn't committed.`
+    );
+  }
+}
+
 export const step5b: StepFn = async ({ ctx }) => {
   // Windows guard — explicit skip + log per CTO review.
   if (process.platform === 'win32') {
@@ -180,44 +229,7 @@ export const step5b: StepFn = async ({ ctx }) => {
   }
 
   // ── Gitignore guard ─────────────────────────────────────────────────────
-  // Gate on .git existence — non-repo folders shouldn't get a stray .gitignore.
-  if (isGitRepo(ctx.rootDir)) {
-    // Check tracked-status FIRST. If `.env` is already in git's index,
-    // appending to .gitignore is a security-theatre no-op — the key is
-    // already in committed history. Surface a loud warning so the customer
-    // knows to remediate (git rm --cached + commit + key rotation).
-    if (isFileTracked(ctx.rootDir, '.env')) {
-      emitWarning(
-        ctx.silent,
-        '[mysecond] ⚠️ SECURITY: .env is tracked by git in this repo. Your COMPANION_API_KEY is in your git history right now. Remediate:\n' +
-          '  1. git rm --cached .env\n' +
-          '  2. git commit -m "stop tracking .env"\n' +
-          '  3. Rotate your key at app.mysecond.ai (the old key is in git history forever).\n' +
-          '  4. Re-run `mysecond init` with the new key.'
-      );
-    } else {
-      // Pre-write notice + ensure entry. Customer-empathy per CAIO review:
-      // print BEFORE mutating, not after.
-      const path = join(ctx.rootDir, '.gitignore');
-      const willMutate =
-        !existsSync(path) ||
-        !readFileSync(path, 'utf8')
-          .split('\n')
-          .map((l) => l.trim())
-          .includes('.env');
-      if (willMutate) {
-        emit(ctx.silent, '[mysecond] Adding `.env` to .gitignore as a safety net.');
-      }
-      try {
-        ensureGitignoreEntry(ctx.rootDir, '.env');
-      } catch (err) {
-        emitWarning(
-          ctx.silent,
-          `[mysecond] ⚠️ Could not update .gitignore (${(err as Error).message}). Add \`.env\` manually so your API key isn't committed.`
-        );
-      }
-    }
-  }
+  runGitignoreGuard(ctx.rootDir, ctx.silent);
 
   return { step: 14, outcome: { kind: 'completed' } };
 };

--- a/tests/lib/step-5b.test.ts
+++ b/tests/lib/step-5b.test.ts
@@ -10,7 +10,7 @@ import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { step5b } from '../../src/lib/steps/step-5b.js';
+import { runGitignoreGuard, step5b } from '../../src/lib/steps/step-5b.js';
 import { projectHash } from '../../src/lib/project-hash.js';
 import type { CommandContext } from '../../src/lib/context.js';
 import type { SyncState } from '../../src/lib/sync-state.js';
@@ -265,5 +265,45 @@ describe('step-5b — clean install (no .env present)', () => {
     );
     expect(existsSync(credsPath)).toBe(true);
     expect(readFileSync(credsPath, 'utf8')).toContain(TEST_KEY);
+  });
+});
+
+describe('runGitignoreGuard — orphan-migration safety (called from init-runner on step-5 throw)', () => {
+  it('exported for init-runner to call independently', () => {
+    expect(typeof runGitignoreGuard).toBe('function');
+  });
+
+  it('appends .env to .gitignore when called standalone in a git repo', () => {
+    if (process.platform === 'win32') return;
+    mkdirSync(join(projectDir, '.git'), { recursive: true });
+    runGitignoreGuard(projectDir, false);
+    expect(readFileSync(join(projectDir, '.gitignore'), 'utf8')).toContain('.env');
+  });
+
+  it('skips silently if not a git repo (no orphan .gitignore created)', () => {
+    if (process.platform === 'win32') return;
+    runGitignoreGuard(projectDir, false);
+    expect(existsSync(join(projectDir, '.gitignore'))).toBe(false);
+  });
+
+  it('still emits SECURITY warning when .env is git-tracked, even on orphan path', () => {
+    if (process.platform === 'win32') return;
+    try {
+      execFileSync('git', ['--version'], { stdio: 'pipe' });
+    } catch {
+      return;
+    }
+    execFileSync('git', ['init', '-q'], { cwd: projectDir });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: projectDir });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: projectDir });
+    writeFileSync(join(projectDir, '.env'), `COMPANION_API_KEY=${TEST_KEY}\n`);
+    execFileSync('git', ['add', '.env'], { cwd: projectDir });
+    execFileSync('git', ['commit', '-q', '-m', 'oops'], { cwd: projectDir });
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    runGitignoreGuard(projectDir, false);
+    const warnings = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(warnings).toContain('SECURITY');
+    expect(warnings).toContain('.env is tracked by git');
   });
 });


### PR DESCRIPTION
## Summary

Closes the orphan-migration security gap CTO flagged in PR #17 heavy review (#10). When step-5 (.env write) throws — typically an env conflict the customer didn't pass \`--fix\` for — step-5b never runs and the customer's existing \`.env\` sits without \`.gitignore\` protection. The whole point of v1.3.4's gitignore guard was to prevent exactly this leakage path.

## Changes

- **\`src/lib/steps/step-5b.ts\`** — extract \`.gitignore\` guard logic into exported \`runGitignoreGuard(rootDir, silent)\` helper. Step-5b's happy path is unchanged; it now calls the helper internally.
- **\`src/lib/init-runner.ts\`** — wrap each step invocation in try/catch. When \`entry.number === 5\` throws, run \`runGitignoreGuard()\` before re-throwing the original error. Guard's own throws are swallowed so we never mask the upstream error.
- **\`tests/lib/step-5b.test.ts\`** — 4 new tests for \`runGitignoreGuard\` standalone (exported, appends in git repo, skips non-repo, SECURITY warning when tracked).
- **\`package.json\`** — bump to v1.3.5.

## Test plan

- [x] 219/219 tests pass (\`npm test\`) — was 215 in v1.3.4, +4 new
- [x] \`tsc --noEmit\` clean
- [x] \`npm run build\` clean (98.6kb dist)
- [ ] After merge: \`npm publish --tag latest\` (Ron's "go" required)
- [ ] **Live smoke after publish:** seed a project with a conflicting \`.env\` key, run \`init\` (no \`--fix\`). Step-5 throws. Verify \`.gitignore\` got the \`.env\` line anyway.

## What this enables

Pairs with PR #167 (mysecond-app server side) + PR #14 (product-manager-os hook side) for the v1.4.0 telemetry-gated cutover. Together: customers' security mitigation is bulletproof regardless of which init step succeeds, AND we have data to know when it's safe to drop the \`.env\` write entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)