### PR TITLE
fix(sync): write files relative to rootDir + tighten claudeMdBlock (v1.3.6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mysecond/cli",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "UNLICENSED",
       "dependencies": {
         "proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -313,14 +313,20 @@ export async function runSync(
 
   const paths = projectPaths(ctx.rootDir);
 
+  // file_path values from the API are already project-relative (e.g.
+  // "context/company.md", "work/specs/outputs/.../prd.md"). Use rootDir as
+  // the base — using contextDir prepended an extra "context/" to every path,
+  // so work outputs landed under <rootDir>/context/work/... instead of
+  // <rootDir>/work/...  (regression introduced when the API started serving
+  // work/* and decisions/* alongside context/*).
   for (const file of contextFiles) {
-    const localContent = readLocalFile(paths.contextDir, file.file_path);
+    const localContent = readLocalFile(ctx.rootDir, file.file_path);
     const outcome = resolveConflict({ file, localContent, syncState: state, ctx });
     tally(summary, outcome);
   }
 
   for (const filePath of deletedPaths) {
-    if (deleteLocalFile(paths.contextDir, filePath)) {
+    if (deleteLocalFile(ctx.rootDir, filePath)) {
       delete state.files[filePath];
       summary.deleted++;
     }

--- a/src/lib/conflict.ts
+++ b/src/lib/conflict.ts
@@ -88,11 +88,15 @@ function emitNotice(message: string, ctx: CommandContext): void {
 
 export function resolveConflict(input: SyncContextFileInput): ConflictOutcome {
   const { file, localContent, syncState, ctx } = input;
-  const { contextDir, conflictsDir } = projectPaths(ctx.rootDir);
+  const { conflictsDir } = projectPaths(ctx.rootDir);
   const nowIso = new Date().toISOString();
 
+  // file_path values from the API are project-relative (already include
+  // "context/" prefix where applicable, plus "work/", "decisions/", etc.).
+  // Use rootDir as the write base — writing under contextDir prepended an
+  // extra "context/" to non-context paths, double-nesting work outputs.
   if (localContent === null) {
-    const ok = writeLocalFile(contextDir, file.file_path, file.content);
+    const ok = writeLocalFile(ctx.rootDir, file.file_path, file.content);
     if (!ok) return { kind: 'conflict-skipped' };
     recordSyncedFile(syncState, file.file_path, file.content, file.current_hash, nowIso);
     return { kind: 'created', writtenPath: file.file_path };
@@ -108,7 +112,7 @@ export function resolveConflict(input: SyncContextFileInput): ConflictOutcome {
   }
 
   if (cloudChanged && !localChanged) {
-    const ok = writeLocalFile(contextDir, file.file_path, file.content);
+    const ok = writeLocalFile(ctx.rootDir, file.file_path, file.content);
     if (!ok) return { kind: 'conflict-skipped' };
     recordSyncedFile(syncState, file.file_path, file.content, file.current_hash, nowIso);
     return { kind: 'updated-from-cloud', writtenPath: file.file_path };
@@ -136,7 +140,7 @@ export function resolveConflict(input: SyncContextFileInput): ConflictOutcome {
     const cloudBackup = join(conflictsDir, `${safeName}-cloud-${stamp}.md`);
     writeLocalFile(conflictsDir, `${safeName}-cloud-${stamp}.md`, file.content);
     emitNotice(
-      `Conflict in context/${file.file_path} — skipped. Cloud version saved to ${cloudBackup}`,
+      `Conflict in ${file.file_path} — skipped. Cloud version saved to ${cloudBackup}`,
       ctx
     );
     return { kind: 'conflict-skipped' };
@@ -147,7 +151,7 @@ export function resolveConflict(input: SyncContextFileInput): ConflictOutcome {
     writeLocalFile(conflictsDir, `${safeName}-cloud-${stamp}.md`, file.content);
     recordSyncedFile(syncState, file.file_path, localContent, file.current_hash, nowIso);
     emitNotice(
-      `Conflict in context/${file.file_path} — kept local. Cloud version saved to ${cloudBackup}`,
+      `Conflict in ${file.file_path} — kept local. Cloud version saved to ${cloudBackup}`,
       ctx
     );
     return { kind: 'conflict-local-kept', backupPath: cloudBackup };
@@ -157,11 +161,11 @@ export function resolveConflict(input: SyncContextFileInput): ConflictOutcome {
   // up local. Most customers hit this path.
   const localBackup = join(conflictsDir, `${safeName}-local-${stamp}.md`);
   writeLocalFile(conflictsDir, `${safeName}-local-${stamp}.md`, localContent);
-  const ok = writeLocalFile(contextDir, file.file_path, file.content);
+  const ok = writeLocalFile(ctx.rootDir, file.file_path, file.content);
   if (!ok) return { kind: 'conflict-skipped' };
   recordSyncedFile(syncState, file.file_path, file.content, file.current_hash, nowIso);
   emitNotice(
-    `Conflict in context/${file.file_path} — kept cloud version (your local edits saved to ${localBackup})`,
+    `Conflict in ${file.file_path} — kept cloud version (your local edits saved to ${localBackup})`,
     ctx
   );
   return { kind: 'conflict-cloud-kept', writtenPath: file.file_path, backupPath: localBackup };

--- a/src/lib/copy.ts
+++ b/src/lib/copy.ts
@@ -73,7 +73,7 @@ export function claudeMdBlock(companyName: string, pmName: string): string {
     '',
     'After running `mysecond init`, the only next step for a new user is `/welcome`. Do not suggest `/enhance-context`, `/prd-generator`, or other skills before `/welcome` runs — no context files exist yet, and those skills depend on them. Stay quiet about skill discovery; let `/welcome` drive the first-run experience.',
     '',
-    'If summarizing the install confirmation, you MUST mention all three counts the cli reported (skills, sub-agents, workflows) — do not drop any.',
+    'If summarizing the install confirmation, mention ONLY the three counts the cli printed in its success box (skills, sub-agents, workflows). Do NOT invent or add additional totals (e.g., "N skills synced from mysecond.ai") — those server-side numbers double-count internal entities and will mislead the user.',
   ].join('\n');
 }
 

--- a/tests/lib/conflict.test.ts
+++ b/tests/lib/conflict.test.ts
@@ -40,29 +40,29 @@ describe('resolveConflict — first-time create', () => {
     const root = tmpProject();
     const state = emptyState();
     const outcome = resolveConflict({
-      file: file('company.md', 'hello'),
+      file: file('context/company.md', 'hello'),
       localContent: null,
       syncState: state,
       ctx: ctx(root),
     });
     expect(outcome.kind).toBe('created');
     expect(readFileSync(join(root, 'context/company.md'), 'utf8')).toBe('hello');
-    expect(state.files['company.md']).toBeDefined();
+    expect(state.files['context/company.md']).toBeDefined();
   });
 });
 
 describe('resolveConflict — no divergence', () => {
   it('reports unchanged when local + cloud match a recorded hash', () => {
     const root = tmpProject();
-    writeLocalFile(join(root, 'context'), 'company.md', 'hello');
+    writeLocalFile(root, 'context/company.md', 'hello');
     const state = emptyState();
-    state.files['company.md'] = {
+    state.files['context/company.md'] = {
       localHash: sha256('hello'),
       cloudHash: sha256('hello'),
       lastSyncedAt: new Date().toISOString(),
     };
     const outcome = resolveConflict({
-      file: file('company.md', 'hello'),
+      file: file('context/company.md', 'hello'),
       localContent: 'hello',
       syncState: state,
       ctx: ctx(root),
@@ -74,15 +74,15 @@ describe('resolveConflict — no divergence', () => {
 describe('resolveConflict — only cloud changed', () => {
   it('overwrites local with cloud version', () => {
     const root = tmpProject();
-    writeLocalFile(join(root, 'context'), 'company.md', 'old');
+    writeLocalFile(root, 'context/company.md', 'old');
     const state = emptyState();
-    state.files['company.md'] = {
+    state.files['context/company.md'] = {
       localHash: sha256('old'),
       cloudHash: sha256('old'),
       lastSyncedAt: new Date().toISOString(),
     };
     const outcome = resolveConflict({
-      file: file('company.md', 'new-cloud'),
+      file: file('context/company.md', 'new-cloud'),
       localContent: 'old',
       syncState: state,
       ctx: ctx(root),
@@ -95,15 +95,15 @@ describe('resolveConflict — only cloud changed', () => {
 describe('resolveConflict — only local changed', () => {
   it('keeps local untouched and updates the ledger', () => {
     const root = tmpProject();
-    writeLocalFile(join(root, 'context'), 'company.md', 'local-edit');
+    writeLocalFile(root, 'context/company.md', 'local-edit');
     const state = emptyState();
-    state.files['company.md'] = {
+    state.files['context/company.md'] = {
       localHash: sha256('original'),
       cloudHash: sha256('original'),
       lastSyncedAt: new Date().toISOString(),
     };
     const outcome = resolveConflict({
-      file: file('company.md', 'original'),
+      file: file('context/company.md', 'original'),
       localContent: 'local-edit',
       syncState: state,
       ctx: ctx(root),
@@ -116,15 +116,15 @@ describe('resolveConflict — only local changed', () => {
 describe('resolveConflict — both changed (Option 1 minimum safety net)', () => {
   it('cloud-wins strategy: writes cloud, backs up local, returns conflict-cloud-kept', () => {
     const root = tmpProject();
-    writeLocalFile(join(root, 'context'), 'company.md', 'local-edit');
+    writeLocalFile(root, 'context/company.md', 'local-edit');
     const state = emptyState();
-    state.files['company.md'] = {
+    state.files['context/company.md'] = {
       localHash: sha256('original'),
       cloudHash: sha256('original'),
       lastSyncedAt: new Date().toISOString(),
     };
     const outcome = resolveConflict({
-      file: file('company.md', 'cloud-edit'),
+      file: file('context/company.md', 'cloud-edit'),
       localContent: 'local-edit',
       syncState: state,
       ctx: ctx(root, { strategy: 'cloud-wins' }),
@@ -145,15 +145,15 @@ describe('resolveConflict — both changed (Option 1 minimum safety net)', () =>
 
   it('local-wins strategy: keeps local, backs up cloud, returns conflict-local-kept', () => {
     const root = tmpProject();
-    writeLocalFile(join(root, 'context'), 'company.md', 'local-edit');
+    writeLocalFile(root, 'context/company.md', 'local-edit');
     const state = emptyState();
-    state.files['company.md'] = {
+    state.files['context/company.md'] = {
       localHash: sha256('original'),
       cloudHash: sha256('original'),
       lastSyncedAt: new Date().toISOString(),
     };
     const outcome = resolveConflict({
-      file: file('company.md', 'cloud-edit'),
+      file: file('context/company.md', 'cloud-edit'),
       localContent: 'local-edit',
       syncState: state,
       ctx: ctx(root, { strategy: 'local-wins' }),
@@ -168,15 +168,15 @@ describe('resolveConflict — both changed (Option 1 minimum safety net)', () =>
 
   it('skip strategy: leaves local alone, only saves cloud version for inspection', () => {
     const root = tmpProject();
-    writeLocalFile(join(root, 'context'), 'company.md', 'local-edit');
+    writeLocalFile(root, 'context/company.md', 'local-edit');
     const state = emptyState();
-    state.files['company.md'] = {
+    state.files['context/company.md'] = {
       localHash: sha256('original'),
       cloudHash: sha256('original'),
       lastSyncedAt: new Date().toISOString(),
     };
     const outcome = resolveConflict({
-      file: file('company.md', 'cloud-edit'),
+      file: file('context/company.md', 'cloud-edit'),
       localContent: 'local-edit',
       syncState: state,
       ctx: ctx(root, { strategy: 'skip' }),


### PR DESCRIPTION
## Summary

Two customer-facing bugs from Ron's morning E2E, both 1-line-class fixes.

## Bug 1 — \`context/\` double-nest in customer file tree

cli's sync command hardcoded \`contextDir\` (= \`<rootDir>/context\`) as the write base for every file from \`/api/companion/cli-sync\`. API returns file_paths that already include the directory (\`context/company.md\`, \`work/specs/outputs/.../prd.md\`). Pre-fix: customer ended up with \`<rootDir>/context/work/...\` and re-running install produced \`<rootDir>/context/context/work/...\` because pushed-back paths got re-prefixed.

**Fix:** \`src/commands/sync.ts\` + \`src/lib/conflict.ts\` use \`ctx.rootDir\` as base. file_path already includes the directory.

## Bug 2 — "91 skills synced from mysecond.ai" hallucination

\`claudeMdBlock\` instruction told Claude to "mention all three counts" — Claude paraphrased the cli-sync API response (91 = 84 skills + 7 workflow wrappers) as an extra "91 skills synced" line in install confirmation. Confusing customers into thinking 91 skills were available.

**Fix:** \`src/lib/copy.ts:76\` instruction tightened to "mention ONLY the three counts the cli printed... do NOT invent or add additional totals."

## Test plan

- [x] 219/219 tests pass (3 conflict tests updated for new \`file_path\` fixture shape — now uses \`context/company.md\` matching real API contract)
- [x] tsc clean, build clean
- [ ] After merge: \`npm publish --tag latest\` (Ron's "go" required)
- [ ] Live smoke: fresh install in \`~/Desktop/test-clean\` — no \`context/work/\` orphans, install confirmation does not say "N skills synced from mysecond.ai"

## What this doesn't fix

- The artifact-sync hook not firing on /prd-generator writes (still launch-blocking; root cause unknown — path-with-space and sub-agent hypotheses both ruled out)
- Date-as-folder convention in \`/prd-generator\` SKILL.md (cosmetic, deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)