### PR TITLE
fix(artifact-sync): add work/ prefix to ARTIFACT_DIRS — closes launch-blocking sync bug (v1.3.7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mysecond/cli",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "UNLICENSED",
       "dependencies": {
         "proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -74,7 +74,22 @@ export interface ArtifactDir {
   type: ArtifactType;
 }
 
+// Skills under content/skills/*/SKILL.md write outputs to `work/<area>/outputs/…`
+// (work/specs, work/discovery, work/strategy, work/launches). The `work/`
+// prefix is canonical — skills that wrote to bare `specs/outputs/…` were the
+// legacy pattern before the work/ activity-tree convention landed. Both
+// prefixed and unprefixed variants are accepted so any legacy customer
+// artifacts on disk keep syncing; canonical location is the work/ form.
+//
+// Note `work/launches/outputs` (plural) matches what skills emit. The legacy
+// `launch/outputs` entry is a back-compat synonym.
 export const ARTIFACT_DIRS: readonly ArtifactDir[] = [
+  // Canonical work/ activity-tree paths (what every skill writes today)
+  { relativeDir: 'work/specs/outputs', type: 'prd' },
+  { relativeDir: 'work/discovery/outputs', type: 'research' },
+  { relativeDir: 'work/strategy/outputs', type: 'strategy' },
+  { relativeDir: 'work/launches/outputs', type: 'launch' },
+  // Legacy un-prefixed paths (back-compat)
   { relativeDir: 'specs/outputs', type: 'prd' },
   { relativeDir: 'discovery/outputs', type: 'research' },
   { relativeDir: 'strategy/outputs', type: 'strategy' },

--- a/tests/lib/payload.test.ts
+++ b/tests/lib/payload.test.ts
@@ -45,14 +45,31 @@ describe('classifyArtifactType', () => {
 });
 
 describe('ARTIFACT_DIRS', () => {
-  it('covers the 5 known output locations', () => {
+  it('covers the canonical work/* output locations + legacy unprefixed', () => {
+    // Canonical: every skill writes to work/<area>/outputs/...
+    // Legacy: pre-work/ tree convention, kept as back-compat synonyms.
     expect(ARTIFACT_DIRS.map((d) => d.relativeDir).sort()).toEqual([
       'analytics/outputs',
       'discovery/outputs',
       'launch/outputs',
       'specs/outputs',
       'strategy/outputs',
+      'work/discovery/outputs',
+      'work/launches/outputs',
+      'work/specs/outputs',
+      'work/strategy/outputs',
     ]);
+  });
+
+  it('classifies a real skill output path (work/specs/outputs/...) as prd', () => {
+    // Regression: 2026-05-02 customer E2E — /prd-generator wrote to
+    // work/specs/outputs/2026-05-02-1622/prd-dashboard.md, but the cli's
+    // PostToolUse handler returned null because ARTIFACT_DIRS didn't include
+    // the work/ prefix. Lock that path.
+    expect(classifyArtifactType('work/specs/outputs/2026-05-02-1622/prd-dashboard.md')).toBe('prd');
+    expect(classifyArtifactType('work/strategy/outputs/2026-05-01/competitive-profile.md')).toBe('strategy');
+    expect(classifyArtifactType('work/discovery/outputs/2026-05-01/research.md')).toBe('research');
+    expect(classifyArtifactType('work/launches/outputs/2026-05-01/launch-plan.md')).toBe('launch');
   });
 });
 


### PR DESCRIPTION
## CRITICAL launch blocker — customer skill outputs were silently dropped

Every skill (\`/prd-generator\`, \`/competitive-profile-builder\`, etc.) writes outputs to \`work/<area>/outputs/<timestamp>/...\` per the SKILL.md convention. The customer plugin's PostToolUse hook calls \`mysecond artifact-sync --silent\`, which uses \`classifyArtifactType()\` to decide if a write event is a syncable artifact.

\`ARTIFACT_DIRS\` was missing the \`work/\` prefix:

\`\`\`
specs/outputs, discovery/outputs, strategy/outputs, launch/outputs, analytics/outputs
\`\`\`

So \`work/specs/outputs/.../prd-dashboard.md\` → \`null\` → cli exit 0 → no sync. **Every customer's skill output silently dropped.**

## Why this took a week to find

The \`companion-sync/hooks/post-tool-use-sync.sh\` bash script that I (Claude) and CTO+CISO have been investigating all session is **dead code**. The active PostToolUse hook is \`mysecond artifact-sync --silent\`, declared in \`pm-os/.claude-plugin/plugin.json\`. CAIO's earlier callout to verify against primary sources was prescient — we kept investigating the wrong path.

## Fix

Add \`work/\` prefixed paths to \`ARTIFACT_DIRS\` as canonical. Keep legacy unprefixed paths as back-compat synonyms.

## Test plan

- [x] 220/220 tests pass (1 updated, 1 new)
- [x] Live smoke against ron+0502a@mysecond.ai (t0502a-z2cb) — pre-fix: cli-sync \`[]\`. Post-fix: PRD now in cli-sync response.
- [ ] After merge: \`npm publish --tag latest\` (Ron's "go" required)
- [ ] Ron re-runs \`/prd-generator\` in fresh folder → output appears in /files automatically

## What this unblocks

Combined with v1.3.6 (sync rootDir-base) and v1.3.5 (project-scoped creds): customer install → run skills → outputs auto-sync to mySecond. The full Solo flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)