### PR TITLE
feat(sync): base plugin skill/agent/workflow updates with customization detection (v1.3.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -17,13 +17,20 @@ import { MysecondError } from '../lib/errors.js';
 import {
   projectPaths,
   readLocalFile,
+  shortHash,
   writeLocalFile,
   deleteLocalFile,
 } from '../lib/files.js';
+import {
+  readInstallState,
+  writeInstallState,
+  type InstallState,
+} from '../lib/install-state.js';
 import { markNpmUpdated, shouldRunNpmUpdate } from '../lib/npm.js';
 import {
   scanArtifacts,
   scanContextFiles,
+  type BasePluginFile,
   type CompanionFile,
   type ContextFile,
 } from '../lib/payload.js';
@@ -53,6 +60,13 @@ interface SyncSummary {
   contextFilesPushed: number;
   claudeMdUpdated: boolean;
   npmUpdateRan: boolean;
+  // Workstream H — base plugin update counters. baseSkippedDueToCustomization
+  // is telemetry-only; never surfaced to the customer per locked product
+  // decision (customizations are invisible to mySecond).
+  baseSkillsUpdated: number;
+  baseAgentsUpdated: number;
+  baseWorkflowsUpdated: number;
+  baseSkippedDueToCustomization: number;
 }
 
 function emptySummary(): SyncSummary {
@@ -72,6 +86,10 @@ function emptySummary(): SyncSummary {
     contextFilesPushed: 0,
     claudeMdUpdated: false,
     npmUpdateRan: false,
+    baseSkillsUpdated: 0,
+    baseAgentsUpdated: 0,
+    baseWorkflowsUpdated: 0,
+    baseSkippedDueToCustomization: 0,
   };
 }
 
@@ -105,6 +123,75 @@ function syncCompanionFile(baseDir: string, file: CompanionFile): boolean {
   const local = readLocalFile(baseDir, file.file_path);
   if (local === file.content) return false;
   return writeLocalFile(baseDir, file.file_path, file.content);
+}
+
+// Workstream H: write a single base plugin file (skill/agent/workflow) into
+// the project, but ONLY if the customer hasn't customized it. Customization
+// detection: compare the local SHA to the SHA we recorded in install-state
+// the last time WE wrote the file. If they match → safe overwrite. If they
+// differ → SILENTLY skip per locked product decision; bump telemetry counter
+// for ops visibility.
+//
+// Returns 'updated' if we wrote, 'skipped-customized' if the local file
+// diverged from our last write, or 'unchanged' if local already matches the
+// new content.
+function syncBasePluginFile(
+  ctx: CommandContext,
+  file: BasePluginFile,
+  installState: InstallState
+): 'updated' | 'skipped-customized' | 'unchanged' {
+  const local = readLocalFile(ctx.rootDir, file.file_path);
+  const installTimeHash = installState.files[file.file_path];
+
+  // Fresh install OR file we've never seen — always write. The first time we
+  // touch a file, install-time hash IS the cloud hash (no customization
+  // possible yet). Same path serves the new-customer "no install-state.json
+  // yet" graceful initialization.
+  if (local === null || installTimeHash === undefined) {
+    if (local === file.content) {
+      installState.files[file.file_path] = file.current_hash;
+      return 'unchanged';
+    }
+    if (writeLocalFile(ctx.rootDir, file.file_path, file.content)) {
+      installState.files[file.file_path] = file.current_hash;
+      return 'updated';
+    }
+    return 'unchanged';
+  }
+
+  // Customization detection: did the customer edit our last-written copy?
+  const localHash = shortHash(local);
+  if (localHash !== installTimeHash) {
+    // Customer forked this skill — leave their edits alone. No notification,
+    // no log surfaced, no mention in printSummary. Bump the telemetry-only
+    // counter so we can see drift in aggregate without exposing it to
+    // individual customers.
+    return 'skipped-customized';
+  }
+
+  // Customer hasn't touched it. Safe to overwrite.
+  if (local === file.content) return 'unchanged';
+  if (writeLocalFile(ctx.rootDir, file.file_path, file.content)) {
+    installState.files[file.file_path] = file.current_hash;
+    return 'updated';
+  }
+  return 'unchanged';
+}
+
+function syncBaseTree(
+  ctx: CommandContext,
+  files: readonly BasePluginFile[] | undefined,
+  installState: InstallState
+): { updated: number; skipped: number } {
+  if (!files || files.length === 0) return { updated: 0, skipped: 0 };
+  let updated = 0;
+  let skipped = 0;
+  for (const f of files) {
+    const outcome = syncBasePluginFile(ctx, f, installState);
+    if (outcome === 'updated') updated++;
+    else if (outcome === 'skipped-customized') skipped++;
+  }
+  return { updated, skipped };
 }
 
 function mergeClaudeMdOverride(claudeMdPath: string, override: string): void {
@@ -202,6 +289,21 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
     if (parts.length > 0) {
       out.write(`mysecond: ${parts.join(', ')}\n`);
     }
+    // Workstream H: separate one-liner for base plugin updates so Claude (which
+    // reads this as session-start context) clearly distinguishes "your customs
+    // synced" from "mySecond shipped improvements." Customizations skipped
+    // silently — never mentioned. Link to /changelog so the customer can dig in.
+    const baseTotal =
+      summary.baseSkillsUpdated + summary.baseAgentsUpdated + summary.baseWorkflowsUpdated;
+    if (baseTotal > 0) {
+      const baseParts: string[] = [];
+      if (summary.baseSkillsUpdated > 0) baseParts.push(`${summary.baseSkillsUpdated} skills`);
+      if (summary.baseAgentsUpdated > 0) baseParts.push(`${summary.baseAgentsUpdated} agents`);
+      if (summary.baseWorkflowsUpdated > 0) baseParts.push(`${summary.baseWorkflowsUpdated} workflows`);
+      out.write(
+        `mysecond: ${baseParts.join(', ')} updated — see https://app.mysecond.ai/changelog\n`,
+      );
+    }
     return;
   }
 
@@ -219,11 +321,24 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
   if (summary.artifactsPushed) parts.push(`${summary.artifactsPushed} artifacts pushed`);
   if (summary.contextFilesPushed) parts.push(`${summary.contextFilesPushed} context files pushed`);
   if (summary.claudeMdUpdated) parts.push('CLAUDE.md updated');
+  if (summary.baseSkillsUpdated)
+    parts.push(`${summary.baseSkillsUpdated} skills updated from mysecond.ai`);
+  if (summary.baseAgentsUpdated)
+    parts.push(`${summary.baseAgentsUpdated} agents updated from mysecond.ai`);
+  if (summary.baseWorkflowsUpdated)
+    parts.push(`${summary.baseWorkflowsUpdated} workflows updated from mysecond.ai`);
   if (parts.length === 0) parts.push('nothing changed');
 
   out.write(`✓ Sync complete: ${parts.join(', ')}.\n`);
   if (summary.conflictsCloudKept > 0 || summary.conflictsLocalKept > 0) {
     out.write(`  Recover backed-up versions from .claude/sync-conflicts/ if needed.\n`);
+  }
+  if (
+    summary.baseSkillsUpdated > 0 ||
+    summary.baseAgentsUpdated > 0 ||
+    summary.baseWorkflowsUpdated > 0
+  ) {
+    out.write(`  See what changed: https://app.mysecond.ai/changelog\n`);
   }
 }
 
@@ -280,13 +395,21 @@ export async function runSync(
     ? { timeoutMs: SILENT_SYNC_TIMEOUT_MS }
     : {};
 
+  // Workstream H: read install-state BEFORE the cliSync call so we can send
+  // the recorded base_plugin_version. Server uses it to decide whether to
+  // include base_skills/agents/workflows in the response.
+  const installState = readInstallState(ctx.rootDir);
+
   // CTO P1: context sync failure is partial-success, not a hard install failure.
   // Plugin install already succeeded at this point. Warn loudly + exit 0 so
   // the customer has a working PM OS (minus the context files), and knows to retry.
   // CTO BLOCKING-1: emit sync_failed telemetry with HTTP status for funnel analysis.
   let response: Awaited<ReturnType<typeof cliSync>>;
   try {
-    response = await cliSync(ctx, previousPaths, cliSyncOpts);
+    response = await cliSync(ctx, previousPaths, {
+      ...cliSyncOpts,
+      clientBasePluginVersion: installState.base_plugin_version,
+    });
   } catch (err) {
     const httpCode = err instanceof MysecondError ? err.exitCode : -1;
     const errMsg = err instanceof Error ? err.message : String(err);
@@ -340,6 +463,47 @@ export async function runSync(
   }
   for (const file of customWorkflows) {
     if (syncCompanionFile(paths.workflowsDir, file)) summary.workflowsUpdated++;
+  }
+
+  // Workstream H: pull base plugin updates (skills/agents/workflows from
+  // mysecond-ai/product-manager-os). The arrays are present only when the
+  // server determined we're behind. Per file: overwrite if customer hasn't
+  // touched it; silently skip otherwise. Update install-state for every
+  // successful overwrite, then persist the new base_plugin_version so the
+  // next sync starts from this point. base_plugin_version may legitimately
+  // be null on this response (server soft-failed) — only persist when we
+  // actually got a SHA back.
+  const skillsResult = syncBaseTree(ctx, response.base_skills, installState);
+  summary.baseSkillsUpdated += skillsResult.updated;
+  summary.baseSkippedDueToCustomization += skillsResult.skipped;
+
+  const agentsResult = syncBaseTree(ctx, response.base_agents, installState);
+  summary.baseAgentsUpdated += agentsResult.updated;
+  summary.baseSkippedDueToCustomization += agentsResult.skipped;
+
+  const workflowsResult = syncBaseTree(ctx, response.base_workflows, installState);
+  summary.baseWorkflowsUpdated += workflowsResult.updated;
+  summary.baseSkippedDueToCustomization += workflowsResult.skipped;
+
+  // Persist install-state if anything changed (new files written, hashes
+  // updated, or base_plugin_version advanced). Always safe to write — the
+  // file shape is stable.
+  if (typeof response.base_plugin_version === 'string') {
+    installState.base_plugin_version = response.base_plugin_version;
+  }
+  if (
+    skillsResult.updated > 0 ||
+    agentsResult.updated > 0 ||
+    workflowsResult.updated > 0 ||
+    typeof response.base_plugin_version === 'string'
+  ) {
+    try {
+      writeInstallState(ctx.rootDir, installState);
+    } catch {
+      // Soft-fail: install-state is optimization, not correctness. If we
+      // can't write it, next sync re-evaluates from current local SHAs and
+      // will likely re-write the same content (idempotent).
+    }
   }
 
   if (claudeMdOverride) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -88,11 +88,18 @@ async function companionFetch(
 export async function cliSync(
   ctx: CommandContext,
   previousPaths: readonly string[],
-  opts: { timeoutMs?: number } = {}
+  opts: { timeoutMs?: number; clientBasePluginVersion?: string | null } = {}
 ): Promise<CliSyncResponse> {
   const query: Record<string, string | undefined> = {};
   if (previousPaths.length > 0) {
     query['previous_paths'] = previousPaths.join(',');
+  }
+  // Workstream H: tell the server which base plugin SHA we're installed at.
+  // Server returns base_skills/agents/workflows only when this differs from
+  // its current HEAD. New installs (no install-state.json yet) send no value
+  // and the server treats that as "fully behind".
+  if (opts.clientBasePluginVersion) {
+    query['client_base_plugin_version'] = opts.clientBasePluginVersion;
   }
   const response = await companionFetch(ctx, '/api/companion/cli-sync', {
     query,

--- a/src/lib/install-state.ts
+++ b/src/lib/install-state.ts
@@ -1,0 +1,82 @@
+// Install state — `~/.mysecond/projects/<hash>/install-state.json`.
+//
+// Workstream H: tracks the install-time SHA of every base plugin file the cli
+// has written into <project>/{.claude/skills,.claude/agents,workflows}/. On
+// every `mysecond sync`, we compare the local file's current SHA to the
+// recorded install-time SHA. If they match → the customer hasn't touched the
+// file → safe to overwrite with the latest base content. If they differ →
+// the customer customized the file → SKIP overwrite silently (per locked
+// product decision: customizations are invisible to mySecond).
+//
+// Format:
+//   {
+//     "base_plugin_version": "<40-char-hex-sha or null>",
+//     "files": {
+//       ".claude/skills/prd-generator/SKILL.md": "<sha-when-we-wrote-it>",
+//       ".claude/agents/cto.md": "<sha-when-we-wrote-it>",
+//       ...
+//     }
+//   }
+//
+// Hash format: 12-char short sha (matches mysecond-cli `shortHash` and
+// mysecond-app `shortHash` so server-supplied current_hash values are
+// directly comparable without re-hashing).
+//
+// Atomic write via the same atomicWriteFile helper used by sync-state.json.
+// Soft-fail reads — if the JSON is corrupted, return a fresh empty state and
+// let the next sync re-hydrate; better than crashing the SessionStart hook.
+
+import { mkdirSync, readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { atomicWriteFile } from './atomic-write.js';
+import { getProjectScopedCredsDir } from './creds-path.js';
+import { join } from 'node:path';
+
+export interface InstallState {
+  /** Current SHA the customer is "installed at" — null until first base sync. */
+  base_plugin_version: string | null;
+  /** project-relative file_path → 12-char shortHash recorded when we last wrote it. */
+  files: Record<string, string>;
+}
+
+function freshState(): InstallState {
+  return { base_plugin_version: null, files: {} };
+}
+
+function installStatePath(absoluteProjectDir: string): string {
+  return join(getProjectScopedCredsDir(absoluteProjectDir), 'install-state.json');
+}
+
+export function readInstallState(absoluteProjectDir: string): InstallState {
+  const path = installStatePath(absoluteProjectDir);
+  try {
+    const raw = readFileSync(path, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<InstallState>;
+    return {
+      base_plugin_version:
+        typeof parsed.base_plugin_version === 'string' ? parsed.base_plugin_version : null,
+      files:
+        parsed.files && typeof parsed.files === 'object'
+          ? Object.fromEntries(
+              Object.entries(parsed.files).filter(
+                ([, v]) => typeof v === 'string',
+              ) as Array<[string, string]>,
+            )
+          : {},
+    };
+  } catch {
+    return freshState();
+  }
+}
+
+export function writeInstallState(absoluteProjectDir: string, state: InstallState): void {
+  const path = installStatePath(absoluteProjectDir);
+  mkdirSync(dirname(path), { recursive: true });
+  atomicWriteFile(path, JSON.stringify(state, null, 2) + '\n');
+}
+
+/** Test-friendly alias — returns the canonical install-state path. */
+export function getInstallStatePath(absoluteProjectDir: string): string {
+  return installStatePath(absoluteProjectDir);
+}

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -27,6 +27,12 @@ export interface CompanionFile {
   content: string;
 }
 
+export interface BasePluginFile {
+  file_path: string;
+  content: string;
+  current_hash: string;
+}
+
 export interface CliSyncResponse {
   // Server may return either shape (legacy `files` or current `context_files`).
   context_files?: ContextFile[];
@@ -37,6 +43,16 @@ export interface CliSyncResponse {
   claude_md_override?: string | null;
   deleted_paths?: string[];
   syncedAt: string;
+  // Workstream H: base plugin update payload. `base_plugin_version` is the
+  // server's current HEAD SHA of mysecond-ai/product-manager-os; the cli
+  // persists it after each successful sync. The `base_skills` / `base_agents`
+  // / `base_workflows` arrays are present ONLY when the server determines the
+  // client is behind. Each file_path is project-relative (e.g.
+  // ".claude/skills/prd-generator/SKILL.md").
+  base_plugin_version?: string | null;
+  base_skills?: BasePluginFile[];
+  base_agents?: BasePluginFile[];
+  base_workflows?: BasePluginFile[];
   // Solo extensions (server authoritative; CLI sends nothing on cli-sync since
   // it's GET, but server may echo for debugging).
   workspace_scope?: 'solo' | 'team';

--- a/tests/commands/base-sync.test.ts
+++ b/tests/commands/base-sync.test.ts
@@ -1,0 +1,329 @@
+// Workstream H — base plugin update sync tests.
+//
+// Exercises the real construction path through runSync:
+//   1. Read install-state.json
+//   2. Send client_base_plugin_version on the cli-sync request
+//   3. For each base_skill/agent/workflow in the response, customization-detect
+//      against install-state hashes and either overwrite or silently skip
+//   4. Persist updated install-state (new hashes + advanced base_plugin_version)
+//
+// Mocks the fetch transport so we can assert the exact wire format and inject
+// any server response shape. Tmp-redirects $HOME so install-state writes don't
+// leak into the developer's real ~/.mysecond/projects/.
+
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runSync } from '../../src/commands/sync.js';
+import type { CommandContext } from '../../src/lib/context.js';
+import { writeSyncState, type SyncState } from '../../src/lib/sync-state.js';
+import { shortHash } from '../../src/lib/files.js';
+import { readInstallState, getInstallStatePath } from '../../src/lib/install-state.js';
+
+function tmpProject(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mysecond-base-sync-'));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  return root;
+}
+
+function ctx(rootDir: string): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'test-key',
+    rootDir,
+    silent: true,
+    dryRun: false,
+    forceUpdate: false,
+    fix: false,
+    strategy: 'cloud-wins',
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function seedState(rootDir: string, partial: Partial<SyncState> = {}): void {
+  const base: SyncState = {
+    files: {},
+    artifacts: {},
+    contextFiles: {},
+    lastSyncedAt: '2026-04-29T00:00:00.000Z',
+    lastNpmUpdateAt: new Date().toISOString(),
+    initCompletedSteps: [],
+    step9Auth401RetryCount: 0,
+    customerId: null,
+    workspaceScope: null,
+    customerSlug: null,
+  };
+  writeSyncState(rootDir, { ...base, ...partial });
+}
+
+const SHA_OLD = 'a'.repeat(40);
+const SHA_NEW = 'b'.repeat(40);
+
+describe('Workstream H — base plugin update sync', () => {
+  let originalFetch: typeof fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalHome: string | undefined;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    // Tmp-redirect $HOME so install-state.json writes don't touch the dev's
+    // real ~/.mysecond/projects/ tree. getProjectScopedCredsDir reads
+    // os.homedir() which falls back to $HOME on POSIX.
+    originalHome = process.env.HOME;
+    tmpHome = mkdtempSync(join(tmpdir(), 'mysecond-base-sync-home-'));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+  });
+
+  it('sends client_base_plugin_version=null on a fresh install (no install-state.json yet)', async () => {
+    const root = tmpProject();
+    seedState(root);
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        context_files: [],
+        custom_skills: [],
+        custom_agents: [],
+        custom_workflows: [],
+        base_plugin_version: SHA_NEW,
+        syncedAt: new Date().toISOString(),
+      }),
+    );
+
+    await runSync([], ctx(root));
+    const url = (fetchMock.mock.calls[0] as [URL, RequestInit])[0];
+    expect(url.pathname).toBe('/api/companion/cli-sync');
+    expect(url.searchParams.get('client_base_plugin_version')).toBe(null);
+
+    // After successful sync we persist the server SHA — next sync will send it.
+    const state = readInstallState(root);
+    expect(state.base_plugin_version).toBe(SHA_NEW);
+    expect(existsSync(getInstallStatePath(root))).toBe(true);
+  });
+
+  it('writes new base skills/agents/workflows + records install-time hashes', async () => {
+    const root = tmpProject();
+    seedState(root);
+
+    const skill = { file_path: '.claude/skills/prd-generator/SKILL.md', content: '# PRD', current_hash: shortHash('# PRD') };
+    const agent = { file_path: '.claude/agents/cto.md', content: 'cto body', current_hash: shortHash('cto body') };
+    const workflow = { file_path: 'workflows/discovery/workflow.md', content: 'wf body', current_hash: shortHash('wf body') };
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        context_files: [],
+        custom_skills: [],
+        custom_agents: [],
+        custom_workflows: [],
+        base_plugin_version: SHA_NEW,
+        base_skills: [skill],
+        base_agents: [agent],
+        base_workflows: [workflow],
+        syncedAt: new Date().toISOString(),
+      }),
+    );
+
+    await runSync([], ctx(root));
+
+    expect(readFileSync(join(root, skill.file_path), 'utf8')).toBe('# PRD');
+    expect(readFileSync(join(root, agent.file_path), 'utf8')).toBe('cto body');
+    expect(readFileSync(join(root, workflow.file_path), 'utf8')).toBe('wf body');
+
+    const state = readInstallState(root);
+    expect(state.base_plugin_version).toBe(SHA_NEW);
+    expect(state.files[skill.file_path]).toBe(skill.current_hash);
+    expect(state.files[agent.file_path]).toBe(agent.current_hash);
+    expect(state.files[workflow.file_path]).toBe(workflow.current_hash);
+  });
+
+  it('overwrites un-customized base skill on update (local hash matches install-time hash)', async () => {
+    const root = tmpProject();
+    seedState(root);
+
+    // Pre-existing install: customer has the OLD prd-generator on disk that
+    // matches the install-time hash exactly.
+    const skillPath = '.claude/skills/prd-generator/SKILL.md';
+    const oldContent = '# PRD v1';
+    mkdirSync(join(root, '.claude/skills/prd-generator'), { recursive: true });
+    writeFileSync(join(root, skillPath), oldContent);
+
+    // Seed install-state to look like a prior sync at SHA_OLD recorded the
+    // file with the matching hash.
+    const initialState = readInstallState(root);
+    initialState.base_plugin_version = SHA_OLD;
+    initialState.files[skillPath] = shortHash(oldContent);
+    const { writeInstallState } = await import('../../src/lib/install-state.js');
+    writeInstallState(root, initialState);
+
+    const newContent = '# PRD v2 — improved';
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        context_files: [],
+        custom_skills: [],
+        custom_agents: [],
+        custom_workflows: [],
+        base_plugin_version: SHA_NEW,
+        base_skills: [{ file_path: skillPath, content: newContent, current_hash: shortHash(newContent) }],
+        syncedAt: new Date().toISOString(),
+      }),
+    );
+
+    await runSync([], ctx(root));
+
+    // File overwritten with new content
+    expect(readFileSync(join(root, skillPath), 'utf8')).toBe(newContent);
+    const state = readInstallState(root);
+    expect(state.base_plugin_version).toBe(SHA_NEW);
+    expect(state.files[skillPath]).toBe(shortHash(newContent));
+  });
+
+  it('SILENTLY skips overwrite when customer has customized the skill (local hash diverges)', async () => {
+    const root = tmpProject();
+    seedState(root);
+
+    const skillPath = '.claude/skills/prd-generator/SKILL.md';
+    const installedContent = '# PRD v1';
+    const customizedContent = '# PRD v1 — with my Salesforce taxonomy';
+    mkdirSync(join(root, '.claude/skills/prd-generator'), { recursive: true });
+    // Customer customized after install: file on disk != install-time hash.
+    writeFileSync(join(root, skillPath), customizedContent);
+    const initialState = readInstallState(root);
+    initialState.base_plugin_version = SHA_OLD;
+    initialState.files[skillPath] = shortHash(installedContent);
+    const { writeInstallState } = await import('../../src/lib/install-state.js');
+    writeInstallState(root, initialState);
+
+    const newServerContent = '# PRD v2';
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        context_files: [],
+        custom_skills: [],
+        custom_agents: [],
+        custom_workflows: [],
+        base_plugin_version: SHA_NEW,
+        base_skills: [{ file_path: skillPath, content: newServerContent, current_hash: shortHash(newServerContent) }],
+        syncedAt: new Date().toISOString(),
+      }),
+    );
+
+    // Capture stdout to assert nothing about customization reaches the customer.
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runSync([], ctx(root));
+
+    // Customer's edits preserved
+    expect(readFileSync(join(root, skillPath), 'utf8')).toBe(customizedContent);
+
+    // Install-time hash not bumped (we didn't write anything)
+    const state = readInstallState(root);
+    expect(state.files[skillPath]).toBe(shortHash(installedContent));
+    // base_plugin_version DOES advance (server is up to date as of this round
+    // for everything else — next round the customer can still receive new
+    // *other* skills, just not this one until they revert)
+    expect(state.base_plugin_version).toBe(SHA_NEW);
+
+    // No mention of the skipped skill in any stdout output.
+    const allOut = writeSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(allOut).not.toContain('prd-generator');
+    expect(allOut).not.toContain('customized');
+    expect(allOut).not.toContain('skipped');
+    writeSpy.mockRestore();
+  });
+
+  it('omits base sync entirely when server response has no base_* arrays (client up to date)', async () => {
+    const root = tmpProject();
+    seedState(root);
+
+    // Pre-seed install-state so client sends a real version
+    const initialState = readInstallState(root);
+    initialState.base_plugin_version = SHA_NEW;
+    const { writeInstallState } = await import('../../src/lib/install-state.js');
+    writeInstallState(root, initialState);
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        context_files: [],
+        custom_skills: [],
+        custom_agents: [],
+        custom_workflows: [],
+        base_plugin_version: SHA_NEW,
+        // No base_skills / base_agents / base_workflows — server says we're current
+        syncedAt: new Date().toISOString(),
+      }),
+    );
+
+    const url = (fetchMock.mock.calls[0] ?? []) as unknown[];
+    await runSync([], ctx(root));
+    expect(url).toBeDefined();
+
+    const sentUrl = (fetchMock.mock.calls[0] as [URL, RequestInit])[0];
+    expect(sentUrl.searchParams.get('client_base_plugin_version')).toBe(SHA_NEW);
+
+    const state = readInstallState(root);
+    expect(state.base_plugin_version).toBe(SHA_NEW);
+  });
+
+  it('printSummary surfaces a single one-liner with /changelog link when base updates landed', async () => {
+    const root = tmpProject();
+    seedState(root);
+
+    const skillPath = '.claude/skills/prd-generator/SKILL.md';
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        context_files: [],
+        custom_skills: [],
+        custom_agents: [],
+        custom_workflows: [],
+        base_plugin_version: SHA_NEW,
+        base_skills: [{ file_path: skillPath, content: '# PRD', current_hash: shortHash('# PRD') }],
+        syncedAt: new Date().toISOString(),
+      }),
+    );
+
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runSync([], ctx(root));
+    const out = writeSpy.mock.calls.map((c) => String(c[0])).join('');
+    writeSpy.mockRestore();
+
+    expect(out).toMatch(/1 skills updated/);
+    expect(out).toContain('app.mysecond.ai/changelog');
+  });
+
+  it('graceful initialization: no install-state.json yet → first sync writes it without crashing', async () => {
+    const root = tmpProject();
+    seedState(root);
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        context_files: [],
+        custom_skills: [],
+        custom_agents: [],
+        custom_workflows: [],
+        base_plugin_version: SHA_NEW,
+        syncedAt: new Date().toISOString(),
+      }),
+    );
+
+    expect(existsSync(getInstallStatePath(root))).toBe(false);
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+    expect(existsSync(getInstallStatePath(root))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Workstream H — customers receive base plugin updates from `mysecond-ai/product-manager-os` automatically via `mysecond sync`. Per-file SHA tracking detects customizations: un-touched files overwrite cleanly; **customized files silently skip** (per locked product decision — customizations are invisible to mySecond).

- New `src/lib/install-state.ts` — `~/.mysecond/projects/<hash>/install-state.json` ledger of install-time SHAs
- `runSync` sends `client_base_plugin_version` and processes new `base_skills` / `base_agents` / `base_workflows` arrays
- One-line summary: `"X skills, Y agents, Z workflows updated — see app.mysecond.ai/changelog"` (silent mode goes to stdout so Claude sees it as session-start context)
- 7 new tests covering fresh install, un-customized overwrite, customized silent skip, up-to-date short-circuit, one-liner output, graceful initialization
- Bump to v1.3.8

## Pairs with

mysecond-app PR (server side): `feat/skill-changelog` — must merge first.

## Test plan

- [x] vitest 227/227 green (7 new in tests/commands/base-sync.test.ts)
- [x] tsc --noEmit clean
- [x] npm run build clean
- [ ] Manual smoke: install on a fresh test project, run `mysecond sync`, verify install-state.json materializes
- [ ] Manual smoke: edit a synced skill, re-sync, verify edit preserved + base_plugin_version still advances