### PR TITLE
feat(auth): device-code OAuth + supporting cli (v1.4.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mysecond/cli",
-      "version": "1.3.7",
+      "version": "1.4.0",
       "license": "UNLICENSED",
       "dependencies": {
         "proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.3.8",
+  "version": "1.4.0",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -95,9 +95,12 @@ export async function runDoctor(
         pingError = 'whoami returned malformed response';
       }
     } else if (response.status === 401) {
-      pingError = 'token rejected (401) — token may have been revoked';
+      // CXO Day 4: customer-facing copy. Don't expose status code or
+      // internal "revoked" jargon — name the cause + recovery in plain
+      // English.
+      pingError = 'Your device was disconnected. Run `mysecond init --resume` to reconnect.';
     } else {
-      pingError = `whoami returned status ${response.status}`;
+      pingError = `Connection check failed (status ${response.status}). Try again, or run \`mysecond init --resume\` if it persists.`;
     }
   } catch (err) {
     pingError =
@@ -110,7 +113,7 @@ export async function runDoctor(
   const lines: string[] = ['Status: installed.', ''];
   lines.push(`  cli version:          ${__VERSION__}`);
   lines.push(`  install state:        ${installStatePath}`);
-  lines.push(`  base_plugin_version:  ${state.base_plugin_version ?? '(none — first sync pending)'}`);
+  lines.push(`  base_plugin_version:  ${state.base_plugin_version ?? 'not yet synced'}`);
   lines.push(`  files tracked:        ${Object.keys(state.files).length}`);
   lines.push(`  token storage:        ${tokenResult.storage}`);
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,135 @@
+// `mysecond doctor` — verify the install + token state.
+//
+// Workstream B / Phase 2a Day 3. Three states (CAIO #8 P0 spec):
+//
+//   1. install-state.json missing
+//        Status: not installed.
+//        Run: npx -y @mysecond/cli@latest init
+//
+//   2. install-state.json present, no token
+//        Status: install incomplete.
+//        Run: mysecond init --resume
+//
+//   3. install-state.json present, token present
+//        Ping /api/companion/whoami; print connection summary.
+//
+// Locked decision: ship human-readable only at 2a. `--json` flag and
+// /support-bundle skill land at 2b alongside Connected Devices panel.
+//
+// Brief: ~/.claude/plans/workstream-b-device-code-brief.md
+
+import { existsSync } from 'node:fs';
+
+import type { CommandContext } from '../lib/context.js';
+import { getInstallStatePath, readInstallState } from '../lib/install-state.js';
+import { getDeviceToken } from '../lib/keychain.js';
+
+declare const __VERSION__: string;
+
+interface WhoamiResponse {
+  email: string | null;
+  team_id: string;
+  user_id: string;
+  scopes: readonly string[];
+}
+
+export async function runDoctor(
+  _args: readonly string[],
+  ctx: CommandContext
+): Promise<number> {
+  const installStatePath = getInstallStatePath(ctx.rootDir);
+
+  // ── State 1: install-state.json missing ────────────────────────────────
+  if (!existsSync(installStatePath)) {
+    process.stdout.write(
+      [
+        'Status: not installed.',
+        '',
+        'No install state found at:',
+        `  ${installStatePath}`,
+        '',
+        'To install: npx -y @mysecond/cli@latest init',
+        '',
+      ].join('\n')
+    );
+    return 1;
+  }
+
+  // ── Read install state — may surface base_plugin_version drift later ───
+  const state = readInstallState(ctx.rootDir);
+
+  // ── State 2: token missing ─────────────────────────────────────────────
+  const tokenResult = getDeviceToken(ctx.rootDir);
+  if (tokenResult === null) {
+    process.stdout.write(
+      [
+        'Status: install incomplete.',
+        '',
+        'Found install state, but no device token. The browser authorization step',
+        "didn't complete or the credential was cleared.",
+        '',
+        'To resume: mysecond init --resume',
+        '',
+      ].join('\n')
+    );
+    return 1;
+  }
+
+  // ── State 3: ping /whoami ──────────────────────────────────────────────
+  let whoami: WhoamiResponse | null = null;
+  let pingError: string | null = null;
+  try {
+    const url = new URL('/api/companion/whoami', ctx.apiBase);
+    const response = await fetch(url, {
+      headers: {
+        authorization: `Bearer ${tokenResult.token}`,
+        'user-agent': `mysecond-cli/${__VERSION__} (${process.platform}; node-${process.versions.node})`,
+      },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (response.status === 200) {
+      const body = (await response.json().catch(() => null)) as WhoamiResponse | null;
+      if (body && typeof body.team_id === 'string') {
+        whoami = body;
+      } else {
+        pingError = 'whoami returned malformed response';
+      }
+    } else if (response.status === 401) {
+      pingError = 'token rejected (401) — token may have been revoked';
+    } else {
+      pingError = `whoami returned status ${response.status}`;
+    }
+  } catch (err) {
+    pingError =
+      err instanceof Error
+        ? `network error: ${err.message}`
+        : 'network error: unknown';
+  }
+
+  // Format the report.
+  const lines: string[] = ['Status: installed.', ''];
+  lines.push(`  cli version:          ${__VERSION__}`);
+  lines.push(`  install state:        ${installStatePath}`);
+  lines.push(`  base_plugin_version:  ${state.base_plugin_version ?? '(none — first sync pending)'}`);
+  lines.push(`  files tracked:        ${Object.keys(state.files).length}`);
+  lines.push(`  token storage:        ${tokenResult.storage}`);
+
+  if (whoami) {
+    lines.push('');
+    lines.push('Connected:');
+    lines.push(`  email:    ${whoami.email ?? '(unknown)'}`);
+    lines.push(`  team_id:  ${whoami.team_id}`);
+    lines.push(`  scopes:   ${whoami.scopes.join(', ')}`);
+    lines.push('');
+    process.stdout.write(lines.join('\n'));
+    return 0;
+  }
+
+  lines.push('');
+  lines.push(`Connectivity check failed: ${pingError ?? 'unknown'}`);
+  lines.push('');
+  lines.push('If this persists: mysecond init --resume');
+  lines.push('');
+  process.stdout.write(lines.join('\n'));
+  return 1;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { runInit } from './commands/init.js';
 import { runSync } from './commands/sync.js';
 import { runArtifactSync } from './commands/artifact-sync.js';
 import { runWhereami } from './commands/whereami.js';
+import { runDoctor } from './commands/doctor.js';
 import { buildContext, parseGlobalFlags, type CommandContext } from './lib/context.js';
 import { exitFromError } from './lib/errors.js';
 
@@ -36,6 +37,11 @@ const SUBCOMMANDS: readonly Subcommand[] = [
     summary: 'Print where this project\'s COMPANION_API_KEY is loaded from + the precedence chain.',
     run: runWhereami,
   },
+  {
+    name: 'doctor',
+    summary: 'Check install state + token health. Reports next-step command on any failure.',
+    run: runDoctor,
+  },
 ];
 
 function printHelp(): void {
@@ -58,6 +64,7 @@ function printHelp(): void {
     '  --strategy <mode>      Conflict resolution: prompt | cloud-wins | local-wins | skip',
     '  --force-update         Bypass the 24-hour npm-update timebox in sync',
     '  --fix                  Resolve init conflicts interactively (`mysecond init` only)',
+    '  --resume               Re-run device-code OAuth on a partial install (`mysecond init` only)',
     '',
     'Docs: https://mysecond.ai',
   ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { runSync } from './commands/sync.js';
 import { runArtifactSync } from './commands/artifact-sync.js';
 import { runWhereami } from './commands/whereami.js';
 import { runDoctor } from './commands/doctor.js';
+import { setSilentMode } from './lib/silent-status.js';
 import { buildContext, parseGlobalFlags, type CommandContext } from './lib/context.js';
 import { exitFromError } from './lib/errors.js';
 
@@ -96,6 +97,9 @@ export async function main(argv: readonly string[]): Promise<number> {
 
   try {
     const flags = parseGlobalFlags(args.slice(1));
+    // Workstream B Day 4: enable structured JSON status protocol when --silent.
+    // Emissions before this call are no-ops, so order matters — set first.
+    setSilentMode(flags.silent);
     const ctx = buildContext(flags);
     return await match.run(flags.positional, ctx);
   } catch (err) {

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -17,6 +17,13 @@ export interface CommandContext {
   forceUpdate: boolean;
   fix: boolean;
   strategy: ConflictStrategy;
+  /**
+   * `mysecond init --resume` (Workstream B Phase 2a). When set, init re-runs
+   * the device-code OAuth step even if its ledger entry is marked complete,
+   * picking up an interrupted authorization. Other completed steps are still
+   * skipped; only the device-code step's idempotency is overridden.
+   */
+  resume: boolean;
 }
 
 export interface ParsedFlags {
@@ -26,6 +33,7 @@ export interface ParsedFlags {
   dryRun: boolean;
   forceUpdate: boolean;
   fix: boolean;
+  resume: boolean;
   strategy: ConflictStrategy | null;
   positional: string[];
 }
@@ -40,6 +48,7 @@ export function parseGlobalFlags(args: readonly string[]): ParsedFlags {
     dryRun: false,
     forceUpdate: false,
     fix: false,
+    resume: false,
     strategy: null,
     positional: [],
   };
@@ -54,6 +63,8 @@ export function parseGlobalFlags(args: readonly string[]): ParsedFlags {
       out.forceUpdate = true;
     } else if (arg === '--fix') {
       out.fix = true;
+    } else if (arg === '--resume') {
+      out.resume = true;
     } else if (arg === '--api-key') {
       const next = args[i + 1];
       if (next === undefined) throw MysecondError.invalidFlag('--api-key', 'requires a value');
@@ -124,6 +135,7 @@ export function buildContext(flags: ParsedFlags): CommandContext {
     dryRun: flags.dryRun,
     forceUpdate: flags.forceUpdate,
     fix: flags.fix,
+    resume: flags.resume,
     strategy,
   };
 }

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -119,7 +119,27 @@ export function buildContext(flags: ParsedFlags): CommandContext {
   loadDotenv(rootDir);
 
   const apiBase = process.env.COMPANION_API_URL ?? 'https://app.mysecond.ai';
-  const apiKey = flags.apiKey ?? process.env.COMPANION_API_KEY ?? '';
+
+  // Codex P0-1: load device token from keychain at context-build time.
+  // The previous design read the token in step 15, but the runner skips
+  // completed steps on re-run — so once step 15 was marked done, ctx.apiKey
+  // would be empty on subsequent inits and step 4 (/install-ready) would
+  // 401. Sourcing here makes idempotent re-runs work correctly:
+  //   precedence: --api-key flag > COMPANION_API_KEY env > keychain/file
+  let apiKey = flags.apiKey ?? process.env.COMPANION_API_KEY ?? '';
+  if (apiKey.length === 0) {
+    try {
+      // Lazy import to keep `mysecond --version` and `mysecond --help` fast
+      // (they don't need credentials).
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { getDeviceToken } = require('./keychain.js') as typeof import('./keychain.js');
+      const fromStorage = getDeviceToken(rootDir);
+      if (fromStorage !== null) apiKey = fromStorage.token;
+    } catch {
+      // Best-effort. If keychain lookup throws, fall through to empty
+      // apiKey; step 15 will run the device-code flow.
+    }
+  }
 
   // Strategy default: prompt if interactive (TTY) and not silent; cloud-wins otherwise.
   // CXO call (PR 4b design): keep customer in control where possible, default to safe

--- a/src/lib/copy.ts
+++ b/src/lib/copy.ts
@@ -80,6 +80,27 @@ export function claudeMdBlock(companyName: string, pmName: string): string {
 export const CLAUDE_MD_MARKER_START = '<!-- mysecond-start -->';
 export const CLAUDE_MD_MARKER_END = '<!-- mysecond-end -->';
 
+// CAIO #6 (Workstream B Phase 2a Day 4): the EPHEMERAL install-completion
+// message Claude Code surfaces in chat after the --silent cli exits. This
+// is DISTINCT from the persistent claudeMdBlock above (which lives in
+// CLAUDE.md and contains @import + skill-discovery instructions).
+//
+// The 3-line spec is locked: any change requires CAIO review. Stay under
+// 1KB total — Anthropic enforces a 10,000-char cap on additionalContext/
+// systemMessage/stdout per code.claude.com/docs/en/hooks. Single
+// interpolation: `<email>`. NO other variables.
+//
+// Emitted by the cli's install_completed JSON status event (Day 5 wiring)
+// or surfaced via the SessionStart hook on first post-install session.
+export function installCompleteClaudeMessage(email: string): string {
+  return [
+    '## mySecond installed',
+    `- Connected as: ${email}`,
+    '- Run /mysecond:welcome to set up your PM Operating System.',
+    '- Run mysecond doctor if anything looks off.',
+  ].join('\n');
+}
+
 // §6.8 post-install success message (May-2026 redesign per launch-feedback-log).
 // Plain-text, single primary CTA = `/welcome`. Drops premature suggestions for
 // /prd-generator + /enhance-context (customer has no context files yet).

--- a/src/lib/copy.ts
+++ b/src/lib/copy.ts
@@ -181,7 +181,7 @@ export function successBox(
     '- Context sync hooks active for every Claude Code session',
     '- Your context files will be created in step 2 below',
     '',
-    'ALMOST THERE — close and reopen Claude Code to activate the plugin.',
+    'Install complete. Quit and reopen Claude Code to load mySecond.',
     '',
     `Then run /welcome in Claude Code. It takes about 5 minutes and sets up your context files for ${company} (company, product, personas, competitors, goals).`,
     '',

--- a/src/lib/device-code.ts
+++ b/src/lib/device-code.ts
@@ -253,10 +253,19 @@ function isTokenResponse(body: unknown): body is TokenResponse {
   if (typeof body !== 'object' || body === null) return false;
   const b = body as Record<string, unknown>;
   return (
+    // Codex P0-3: reject empty access_token. A buggy/compromised server
+    // returning {access_token: ""} would otherwise silently install an
+    // unusable credential ("installed but every API call fails").
     typeof b.access_token === 'string' &&
+    b.access_token.length > 0 &&
     typeof b.team_id === 'string' &&
+    b.team_id.length > 0 &&
     typeof b.user_id === 'string' &&
-    Array.isArray(b.scopes)
+    b.user_id.length > 0 &&
+    // Codex P1-4: validate scope element types. Array.isArray accepts any
+    // element shape; downstream `scopes.join(', ')` would throw on objects.
+    Array.isArray(b.scopes) &&
+    b.scopes.every((s: unknown) => typeof s === 'string')
   );
 }
 

--- a/src/lib/device-code.ts
+++ b/src/lib/device-code.ts
@@ -18,7 +18,6 @@
 //
 // Brief: ~/.claude/plans/workstream-b-device-code-brief.md
 
-import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -271,35 +270,3 @@ function isTokenResponse(body: unknown): body is TokenResponse {
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
-
-// ── Browser open (best-effort) ─────────────────────────────────────────────
-
-/**
- * Attempt to open `url` in the user's default browser. Best-effort: returns
- * false if the spawn fails. The caller MUST have already printed the URL to
- * stdout per CAIO #10 — never rely on auto-open to be the only surface.
- */
-export function tryOpenBrowser(url: string): boolean {
-  let cmd: string;
-  let args: string[];
-  if (process.platform === 'darwin') {
-    cmd = 'open';
-    args = [url];
-  } else if (process.platform === 'win32') {
-    cmd = 'cmd';
-    args = ['/c', 'start', '""', url];
-  } else {
-    cmd = 'xdg-open';
-    args = [url];
-  }
-  try {
-    const child = spawn(cmd, args, {
-      detached: true,
-      stdio: 'ignore',
-    });
-    child.unref();
-    return true;
-  } catch {
-    return false;
-  }
-}

--- a/src/lib/device-code.ts
+++ b/src/lib/device-code.ts
@@ -1,0 +1,296 @@
+// Device-code OAuth client (Workstream B / Phase 2a Day 3).
+//
+// Talks to the unauthenticated `/api/companion/device/{code,token}` endpoints
+// to acquire a long-lived bearer token without requiring the customer to
+// paste a credential.
+//
+// Flow:
+//   1. POST /device/code → server returns user_code + device_code
+//   2. Print URL to chat (CAIO #10 — print BEFORE open attempt; the chat is
+//      the deterministic surface), then attempt browser open
+//   3. Poll POST /device/token every interval_seconds until:
+//        - 200 → return { access_token, ... }
+//        - 400 already_exchanged | invalid | expired → throw
+//        - 400 authorization_pending → wait + retry
+//        - 540s elapsed → throw TIMEOUT (CAIO #9 — 10% safety under
+//          Anthropic's 600s hook reaper; cli emits its own actionable
+//          message before the reaper kills the process)
+//
+// Brief: ~/.claude/plans/workstream-b-device-code-brief.md
+
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface DeviceCodeResponse {
+  user_code: string;
+  device_code: string;
+  verification_uri: string;
+  verification_uri_complete: string;
+  expires_in: number;
+  interval: number;
+}
+
+export interface TokenResponse {
+  access_token: string;
+  token_type: 'Bearer';
+  expires_in: number;
+  scopes: readonly string[];
+  team_id: string;
+  user_id: string;
+}
+
+export class DeviceCodeError extends Error {
+  constructor(
+    public readonly code:
+      | 'expired'
+      | 'invalid'
+      | 'already_exchanged'
+      | 'rate_limited'
+      | 'timeout'
+      | 'network'
+      | 'protocol',
+    message: string
+  ) {
+    super(message);
+    this.name = 'DeviceCodeError';
+  }
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+/** CAIO #9: 10% safety margin under Anthropic's 600s PostToolUse hook reaper. */
+export const POLL_HARD_CAP_SECONDS = 540;
+
+/** Default fetch timeout for individual /code and /token round-trips. */
+const FETCH_TIMEOUT_MS = 15_000;
+
+// ── Install-id (anonymous, device-scoped, persisted) ───────────────────────
+
+/**
+ * Persistent UUID identifying the *machine* (not the user). Stored at
+ * ~/.mysecond/install-id so it survives reinstalls of a single project but
+ * doesn't leak across machines. Aliased to user_id once device-authorized.
+ */
+export function getOrCreateInstallId(): string {
+  const dir = join(homedir(), '.mysecond');
+  const path = join(dir, 'install-id');
+  if (existsSync(path)) {
+    try {
+      const raw = readFileSync(path, 'utf8').trim();
+      if (raw.length > 0 && raw.length <= 128) return raw;
+    } catch {
+      // fall through to mint a new one
+    }
+  }
+  mkdirSync(dir, { recursive: true });
+  const id = randomUUID();
+  try {
+    writeFileSync(path, id + '\n', { mode: 0o600 });
+  } catch {
+    // Best-effort — return the in-memory value either way.
+  }
+  return id;
+}
+
+// ── HTTP ───────────────────────────────────────────────────────────────────
+
+interface DeviceCodeFetchOptions {
+  apiBase: string;
+  cliVersion: string;
+  installId: string;
+  timeoutMs?: number;
+}
+
+async function unauthedFetch(
+  path: string,
+  body: unknown,
+  opts: DeviceCodeFetchOptions
+): Promise<{ status: number; body: unknown }> {
+  const url = new URL(path, opts.apiBase);
+  const signal = AbortSignal.timeout(opts.timeoutMs ?? FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'user-agent': `mysecond-cli/${opts.cliVersion} (${process.platform}; node-${process.versions.node})`,
+        'x-mysecond-install-id': opts.installId,
+      },
+      body: JSON.stringify(body ?? {}),
+      signal,
+    });
+    let parsed: unknown = null;
+    const text = await response.text();
+    if (text.length > 0) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = text;
+      }
+    }
+    return { status: response.status, body: parsed };
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err.name === 'TimeoutError' || err.name === 'AbortError')
+    ) {
+      throw new DeviceCodeError('network', `request to ${path} timed out`);
+    }
+    throw new DeviceCodeError(
+      'network',
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+}
+
+// ── /device/code ───────────────────────────────────────────────────────────
+
+export async function requestDeviceCode(
+  opts: DeviceCodeFetchOptions
+): Promise<DeviceCodeResponse> {
+  const { status, body } = await unauthedFetch('/api/companion/device/code', {}, opts);
+  if (status !== 200) {
+    if (status === 429) {
+      throw new DeviceCodeError('rate_limited', 'Too many code requests; try again in a minute');
+    }
+    throw new DeviceCodeError('protocol', `device/code returned status ${status}`);
+  }
+  if (!isDeviceCodeResponse(body)) {
+    throw new DeviceCodeError('protocol', 'device/code returned malformed response');
+  }
+  return body;
+}
+
+function isDeviceCodeResponse(body: unknown): body is DeviceCodeResponse {
+  if (typeof body !== 'object' || body === null) return false;
+  const b = body as Record<string, unknown>;
+  return (
+    typeof b.user_code === 'string' &&
+    typeof b.device_code === 'string' &&
+    typeof b.verification_uri === 'string' &&
+    typeof b.verification_uri_complete === 'string' &&
+    typeof b.expires_in === 'number' &&
+    typeof b.interval === 'number'
+  );
+}
+
+// ── /device/token (polling) ────────────────────────────────────────────────
+
+export interface PollOptions extends DeviceCodeFetchOptions {
+  deviceCode: string;
+  intervalSeconds: number;
+  /** Override for tests; defaults to 540s per CAIO #9. */
+  hardCapSeconds?: number;
+  /** Called every poll for status reporting. */
+  onTick?: (elapsedSeconds: number) => void;
+}
+
+export async function pollForToken(opts: PollOptions): Promise<TokenResponse> {
+  const cap = opts.hardCapSeconds ?? POLL_HARD_CAP_SECONDS;
+  const start = Date.now();
+  const intervalMs = Math.max(opts.intervalSeconds, 1) * 1000;
+
+  // First poll fires immediately (so a fast browser-side authorize completes
+  // in ~5s rather than waiting for the first interval), then every intervalMs.
+  while (true) {
+    const elapsedSeconds = (Date.now() - start) / 1000;
+    if (elapsedSeconds > cap) {
+      throw new DeviceCodeError(
+        'timeout',
+        `Authorization timed out after ${Math.floor(cap)}s. Re-run mysecond init to retry.`
+      );
+    }
+    if (opts.onTick) opts.onTick(elapsedSeconds);
+
+    const { status, body } = await unauthedFetch(
+      '/api/companion/device/token',
+      { device_code: opts.deviceCode },
+      opts
+    );
+
+    if (status === 200) {
+      if (!isTokenResponse(body)) {
+        throw new DeviceCodeError('protocol', 'device/token returned malformed success response');
+      }
+      return body;
+    }
+    if (status === 429) {
+      throw new DeviceCodeError('rate_limited', 'Polling rate-limited; the cli is misbehaving — please report');
+    }
+
+    // 400 family — interpret error code.
+    const errorCode =
+      typeof body === 'object' && body !== null && typeof (body as { error?: unknown }).error === 'string'
+        ? (body as { error: string }).error
+        : 'protocol';
+
+    switch (errorCode) {
+      case 'authorization_pending':
+        // expected — wait + continue
+        await sleep(intervalMs);
+        continue;
+      case 'expired':
+        throw new DeviceCodeError('expired', 'Code expired before authorization. Re-run mysecond init.');
+      case 'already_exchanged':
+        throw new DeviceCodeError(
+          'already_exchanged',
+          'This code was already used. Re-run mysecond init for a fresh code.'
+        );
+      case 'invalid':
+        throw new DeviceCodeError('invalid', 'Server rejected the device_code. Re-run mysecond init.');
+      default:
+        throw new DeviceCodeError('protocol', `device/token returned status ${status} error=${errorCode}`);
+    }
+  }
+}
+
+function isTokenResponse(body: unknown): body is TokenResponse {
+  if (typeof body !== 'object' || body === null) return false;
+  const b = body as Record<string, unknown>;
+  return (
+    typeof b.access_token === 'string' &&
+    typeof b.team_id === 'string' &&
+    typeof b.user_id === 'string' &&
+    Array.isArray(b.scopes)
+  );
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+// ── Browser open (best-effort) ─────────────────────────────────────────────
+
+/**
+ * Attempt to open `url` in the user's default browser. Best-effort: returns
+ * false if the spawn fails. The caller MUST have already printed the URL to
+ * stdout per CAIO #10 — never rely on auto-open to be the only surface.
+ */
+export function tryOpenBrowser(url: string): boolean {
+  let cmd: string;
+  let args: string[];
+  if (process.platform === 'darwin') {
+    cmd = 'open';
+    args = [url];
+  } else if (process.platform === 'win32') {
+    cmd = 'cmd';
+    args = ['/c', 'start', '""', url];
+  } else {
+    cmd = 'xdg-open';
+    args = [url];
+  }
+  try {
+    const child = spawn(cmd, args, {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/keychain.ts
+++ b/src/lib/keychain.ts
@@ -93,12 +93,20 @@ function accountFor(absoluteProjectDir: string): string {
 // ── macOS keychain via `security` shell-out ────────────────────────────────
 
 function macosKeychainSet(account: string, token: string): void {
-  // -U updates if entry exists. -w sets the password from arg (vs prompting).
+  // -U updates if entry exists. -w with NO value reads the password from stdin
+  // (NOT as a positional arg) — this is the load-bearing security choice.
+  // Passing the token as a CLI arg ("-w <token>") leaks it via `ps aux` for
+  // the ~50-200ms duration of the security binary execution. CISO Day-2/3
+  // interim review (P1, blocks Day 4): use stdin so the token never appears
+  // in the process listing.
   // -s sets the service name (filterable in Keychain Access). -a sets account.
   execFileSync(
     'security',
-    ['add-generic-password', '-U', '-s', SERVICE_NAME, '-a', account, '-w', token],
-    { stdio: ['ignore', 'ignore', 'pipe'] }
+    ['add-generic-password', '-U', '-s', SERVICE_NAME, '-a', account, '-w'],
+    {
+      input: token,
+      stdio: ['pipe', 'ignore', 'pipe'],
+    }
   );
 }
 

--- a/src/lib/keychain.ts
+++ b/src/lib/keychain.ts
@@ -1,0 +1,255 @@
+// Keychain — OS-aware token storage for Workstream B (Phase 2a).
+//
+// macOS: `security add-generic-password` / `security find-generic-password`.
+// Linux / CI / Docker / Windows: file fallback at the existing
+// project-scoped credentials path (mode 0600) with a stderr warning on
+// the first fallback per session.
+//
+// Locked decisions per the brief:
+//   - No `keytar` (native build deps fragile across Node versions and
+//     CI environments). 2a uses `security` shell-out only.
+//   - Windows is file-fallback at 2a; native Windows Credential Manager
+//     lands in Phase 2b.
+//
+// CTO Day 1 stop condition (round-trip): every keychain write is followed
+// by an immediate read on the same call pattern. Sandboxed macOS environments
+// occasionally accept writes silently and reject reads — we fail closed and
+// fall back to file before a write that "looked like it worked" rots a
+// subsequent `sync`.
+//
+// Brief: ~/.claude/plans/workstream-b-device-code-brief.md
+
+import { execFileSync } from 'node:child_process';
+import { chmodSync, existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { atomicWriteFile } from './atomic-write.js';
+import {
+  getProjectScopedCredsPath,
+  getProjectScopedCredsDir,
+} from './creds-path.js';
+import { mkdirSync } from 'node:fs';
+
+/** Where the token came from on a successful read. */
+export type TokenStorage = 'keychain' | 'file_fallback';
+
+export interface ReadResult {
+  token: string;
+  storage: TokenStorage;
+}
+
+/**
+ * Reason a file fallback was used. Surfaced into PostHog event
+ * `mysecond.cli.install_completed.keychain_unavailable_reason`.
+ */
+export type FallbackReason =
+  | 'no_keychain' // platform without a usable keychain
+  | 'libsecret_unavailable'
+  | 'linux_headless'
+  | 'env_disabled' // MYSECOND_NO_KEYCHAIN=1
+  | 'roundtrip_failed' // wrote to keychain but couldn't read back
+  | 'write_failed'; // shell-out itself errored
+
+const SERVICE_NAME = 'ai.mysecond.cli';
+let warnedThisSession = false;
+
+function platformSupportsKeychain(): { supported: boolean; reason?: FallbackReason } {
+  if (process.env.MYSECOND_NO_KEYCHAIN === '1') {
+    return { supported: false, reason: 'env_disabled' };
+  }
+  if (process.platform === 'darwin') return { supported: true };
+  if (process.platform === 'linux') {
+    // libsecret integration deferred to Phase 2b — file fallback today.
+    return { supported: false, reason: 'libsecret_unavailable' };
+  }
+  if (process.platform === 'win32') {
+    // Windows Credential Manager deferred to Phase 2b (locked decision).
+    return { supported: false, reason: 'no_keychain' };
+  }
+  return { supported: false, reason: 'no_keychain' };
+}
+
+function emitFallbackWarningOnce(reason: FallbackReason, filePath: string): void {
+  if (warnedThisSession) return;
+  warnedThisSession = true;
+  process.stderr.write(
+    `mysecond: storing credential in file (${reason}). Path: ${filePath} (mode 0600). ` +
+      'On macOS, set MYSECOND_NO_KEYCHAIN=1 to opt out of keychain explicitly.\n'
+  );
+}
+
+function accountFor(absoluteProjectDir: string): string {
+  // One keychain entry per project so multiple projects on the same machine
+  // can each hold their own device token. Hash via the same project-hash
+  // function the rest of the cli uses for path scoping.
+  // We import lazily inside this function to keep the module's top-level
+  // import graph minimal for non-keychain callers.
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { projectHash } = require('./project-hash.js') as typeof import('./project-hash.js');
+  return `device-token-${projectHash(absoluteProjectDir)}`;
+}
+
+// ── macOS keychain via `security` shell-out ────────────────────────────────
+
+function macosKeychainSet(account: string, token: string): void {
+  // -U updates if entry exists. -w sets the password from arg (vs prompting).
+  // -s sets the service name (filterable in Keychain Access). -a sets account.
+  execFileSync(
+    'security',
+    ['add-generic-password', '-U', '-s', SERVICE_NAME, '-a', account, '-w', token],
+    { stdio: ['ignore', 'ignore', 'pipe'] }
+  );
+}
+
+function macosKeychainGet(account: string): string | null {
+  try {
+    const out = execFileSync(
+      'security',
+      ['find-generic-password', '-s', SERVICE_NAME, '-a', account, '-w'],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+    const value = out.toString('utf8').trim();
+    return value.length > 0 ? value : null;
+  } catch {
+    // Not found OR access denied (sandbox). Treat both as "missing" — the
+    // caller will fall back to file storage if write also fails round-trip.
+    return null;
+  }
+}
+
+function macosKeychainDelete(account: string): void {
+  try {
+    execFileSync(
+      'security',
+      ['delete-generic-password', '-s', SERVICE_NAME, '-a', account],
+      { stdio: 'ignore' }
+    );
+  } catch {
+    // No-op if not present.
+  }
+}
+
+// ── File fallback (existing project-scoped creds path) ─────────────────────
+
+function fileSet(absoluteProjectDir: string, token: string): void {
+  const dir = getProjectScopedCredsDir(absoluteProjectDir);
+  mkdirSync(dir, { recursive: true });
+  const filePath = getProjectScopedCredsPath(absoluteProjectDir);
+  atomicWriteFile(filePath, token + '\n', { mode: 0o600 });
+  // atomicWriteFile uses rename which preserves mode, but harden anyway —
+  // a pre-existing file with broader perms could survive the rename on
+  // some filesystems.
+  try {
+    chmodSync(filePath, 0o600);
+  } catch {
+    // best-effort; the atomic write already passed
+  }
+}
+
+function fileGet(absoluteProjectDir: string): string | null {
+  const filePath = getProjectScopedCredsPath(absoluteProjectDir);
+  if (!existsSync(filePath)) return null;
+  try {
+    const raw = readFileSync(filePath, 'utf8').trim();
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+function fileDelete(absoluteProjectDir: string): void {
+  const filePath = getProjectScopedCredsPath(absoluteProjectDir);
+  try {
+    unlinkSync(filePath);
+  } catch {
+    // No-op if not present.
+  }
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+export interface SetResult {
+  storage: TokenStorage;
+  /** Populated when storage === 'file_fallback'. */
+  fallbackReason?: FallbackReason;
+}
+
+/**
+ * Persist `token` for this project. Round-trips via a read-back to detect
+ * sandboxed-keychain "silent write success, broken read" (CTO stop condition).
+ * Falls back to file on any failure.
+ */
+export function setDeviceToken(
+  absoluteProjectDir: string,
+  token: string
+): SetResult {
+  const account = accountFor(absoluteProjectDir);
+  const platform = platformSupportsKeychain();
+
+  if (platform.supported) {
+    try {
+      macosKeychainSet(account, token);
+      // Round-trip verification.
+      const readBack = macosKeychainGet(account);
+      if (readBack === token) {
+        return { storage: 'keychain' };
+      }
+      // Wrote something the keychain didn't return — fall through to file.
+      fileSet(absoluteProjectDir, token);
+      const reason: FallbackReason = 'roundtrip_failed';
+      emitFallbackWarningOnce(reason, getProjectScopedCredsPath(absoluteProjectDir));
+      return { storage: 'file_fallback', fallbackReason: reason };
+    } catch {
+      fileSet(absoluteProjectDir, token);
+      const reason: FallbackReason = 'write_failed';
+      emitFallbackWarningOnce(reason, getProjectScopedCredsPath(absoluteProjectDir));
+      return { storage: 'file_fallback', fallbackReason: reason };
+    }
+  }
+
+  fileSet(absoluteProjectDir, token);
+  emitFallbackWarningOnce(
+    platform.reason ?? 'no_keychain',
+    getProjectScopedCredsPath(absoluteProjectDir)
+  );
+  return { storage: 'file_fallback', fallbackReason: platform.reason };
+}
+
+/**
+ * Read the device token. Tries keychain first, then file fallback. Returns
+ * null when both miss.
+ */
+export function getDeviceToken(absoluteProjectDir: string): ReadResult | null {
+  const platform = platformSupportsKeychain();
+
+  if (platform.supported) {
+    const account = accountFor(absoluteProjectDir);
+    const fromKeychain = macosKeychainGet(account);
+    if (fromKeychain !== null) {
+      return { token: fromKeychain, storage: 'keychain' };
+    }
+  }
+
+  const fromFile = fileGet(absoluteProjectDir);
+  if (fromFile !== null) {
+    return { token: fromFile, storage: 'file_fallback' };
+  }
+  return null;
+}
+
+/** Best-effort delete from BOTH stores. Used by `mysecond doctor --reset`. */
+export function clearDeviceToken(absoluteProjectDir: string): void {
+  if (platformSupportsKeychain().supported) {
+    macosKeychainDelete(accountFor(absoluteProjectDir));
+  }
+  fileDelete(absoluteProjectDir);
+  // Make sure parent dir exists for future writes.
+  try {
+    mkdirSync(dirname(getProjectScopedCredsPath(absoluteProjectDir)), {
+      recursive: true,
+    });
+  } catch {
+    /* best-effort */
+  }
+}

--- a/src/lib/keychain.ts
+++ b/src/lib/keychain.ts
@@ -201,6 +201,12 @@ export function setDeviceToken(
       // Round-trip verification.
       const readBack = macosKeychainGet(account);
       if (readBack === token) {
+        // Codex P1-1: when keychain write succeeds, ALSO delete any stale
+        // file-fallback. Otherwise: if a user later runs `security
+        // delete-generic-password ...` manually, getDeviceToken falls
+        // through to the file and returns the OLD (possibly-revoked)
+        // token. Single source of truth = keychain when keychain works.
+        fileDelete(absoluteProjectDir);
         return { storage: 'keychain' };
       }
       // Wrote something the keychain didn't return — fall through to file.

--- a/src/lib/marketplace-json.ts
+++ b/src/lib/marketplace-json.ts
@@ -3,7 +3,7 @@
 // `name + owner{name,email,url} + plugins[]` is the minimum that
 // `claude plugin marketplace add` accepts non-interactively.
 
-import { marketplaceName } from './mysecond-paths.js';
+import { marketplaceName, type PluginEntry } from './mysecond-paths.js';
 
 export interface MarketplaceJson {
   name: string;
@@ -20,7 +20,7 @@ export interface MarketplaceJson {
     description: string;
     version: string;
   };
-  plugins: Array<{ name: string; source: string }>;
+  plugins: PluginEntry[];
 }
 
 const OWNER = {
@@ -33,7 +33,23 @@ const MARKETPLACE_DESCRIPTION =
   'Your mySecond PM Operating System — context, skills, hooks, and agents tailored to your company.';
 const MARKETPLACE_VERSION = '1.0.0';
 
-export function buildMarketplaceJson(slug: string): MarketplaceJson {
+/**
+ * Build the customer-marketplace's outer marketplace.json.
+ *
+ * Workstream B Day 5+: previously hardcoded `[{name: 'pm-os', source: './plugin'}]`
+ * which silently overwrote PMO's tarball-internal manifest. PMO restructured
+ * to a multi-plugin marketplace (~11 sub-plugins including the launch-critical
+ * `pm-companion-sync`), so a single `pm-os` install was a no-op against the
+ * server's actual plugin shape.
+ *
+ * Source-of-truth is now the PMO tarball's own marketplace.json, read via
+ * `listMarketplacePluginsFromExtractDir()` and passed in here. This file
+ * becomes a thin wrapper that adds owner/metadata to the plugins[] array.
+ */
+export function buildMarketplaceJson(
+  slug: string,
+  plugins: PluginEntry[]
+): MarketplaceJson {
   return {
     name: marketplaceName(slug),
     owner: { ...OWNER },
@@ -41,7 +57,7 @@ export function buildMarketplaceJson(slug: string): MarketplaceJson {
       description: MARKETPLACE_DESCRIPTION,
       version: MARKETPLACE_VERSION,
     },
-    plugins: [{ name: 'pm-os', source: './plugin' }],
+    plugins,
   };
 }
 

--- a/src/lib/mysecond-paths.ts
+++ b/src/lib/mysecond-paths.ts
@@ -1,6 +1,7 @@
 // `~/.mysecond/...` path helpers — the mySecond-managed dir per Decision 0-C.
 // Cross-platform via `os.homedir()` + `path.join()` (guardrail #4 — never `/` or `~`).
 
+import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -68,32 +69,114 @@ export function marketplaceName(slug: string): string {
   return `mysecond-customer-${slug}`;
 }
 
-// Plugin install spec for `claude plugin install` per §6.2 step 9 sub-step (f).
-// Format: `pm-os@<marketplace-name>` per Claude Code docs.
-export function pluginInstallSpec(slug: string): string {
-  return `pm-os@${marketplaceName(slug)}`;
+/**
+ * Sentinel plugin name used by post-install Layer 1 probe.
+ * `pm-companion-sync` carries the SessionStart + PostToolUse hooks that
+ * sync customer artifacts into Companion — if it didn't land in the cache,
+ * the install is functionally broken even if other plugins look fine.
+ */
+export const SENTINEL_PLUGIN_NAME = 'pm-companion-sync';
+
+/** Single plugin entry in a marketplace.json `plugins[]` array. */
+export interface PluginEntry {
+  name: string;
+  source: string;
 }
 
-// Empirically captured 2026-04-22 23:45 UTC (DV-2):
-// `~/.claude/plugins/cache/<marketplace-name>/<plugin-name>/<version>/.claude-plugin/plugin.json`.
-export function installedPluginManifestPath(slug: string, version: string): string {
+/**
+ * Read PMO's tarball-internal `.claude-plugin/marketplace.json` and return
+ * the `plugins[]` array, transformed so each `source` is relative to the
+ * cli's outer marketplace dir layout.
+ *
+ * Background: PMO's tarball ships its own marketplace.json at
+ * `<extractDir>/.claude-plugin/marketplace.json` declaring N sub-plugins
+ * with sources like `./companion-sync` (relative to PMO root). The cli
+ * extracts the tarball into `<marketplaceDir>/plugin/`, so an entry like
+ * `{name: 'pm-companion-sync', source: './companion-sync'}` must be
+ * rewritten to `{name: 'pm-companion-sync', source: './plugin/companion-sync'}`
+ * so Claude Code can resolve it from the customer-marketplace's outer dir.
+ *
+ * Called from step-9 BEFORE atomic-rename of the tmp extract dir, so it
+ * always reads PMO's source-of-truth — never the cli-generated overwrite.
+ *
+ * Throws if the manifest is missing or malformed: PMO repo invariant
+ * guarantees it's always present in published tarballs (§6.7b spec).
+ */
+export function listMarketplacePluginsFromExtractDir(
+  extractDir: string
+): PluginEntry[] {
+  const manifestPath = join(extractDir, '.claude-plugin', 'marketplace.json');
+  const raw = readFileSync(manifestPath, 'utf-8');
+  const parsed = JSON.parse(raw) as {
+    plugins?: Array<{ name?: unknown; source?: unknown }>;
+  };
+  if (!Array.isArray(parsed.plugins) || parsed.plugins.length === 0) {
+    throw new Error(
+      `PMO tarball marketplace.json at ${manifestPath} has no plugins[] array. ` +
+        `This indicates a malformed tarball — contact support@mysecond.ai.`
+    );
+  }
+  return parsed.plugins
+    .filter(
+      (p): p is { name: string; source: string } =>
+        typeof p?.name === 'string' && typeof p?.source === 'string',
+    )
+    .map((p) => ({
+      name: p.name,
+      // PMO's source like "./companion-sync" or "companion-sync" → cli layout
+      // "./plugin/companion-sync". Strip leading "./" first to handle both forms.
+      source: `./plugin/${p.source.replace(/^\.\//, '')}`,
+    }));
+}
+
+/**
+ * Plugin install spec for `claude plugin install` per §6.2 step 9 sub-step (f).
+ * Format: `<plugin-name>@<marketplace-name>` per Claude Code docs.
+ *
+ * Workstream B Day 5+: was hardcoded `pm-os@...` — now takes plugin name
+ * to support multi-plugin marketplace install (PMO restructured 2026-04-XX).
+ * Legacy callers expecting single-plugin behavior pass SENTINEL_PLUGIN_NAME.
+ */
+export function pluginInstallSpec(slug: string, pluginName: string): string {
+  return `${pluginName}@${marketplaceName(slug)}`;
+}
+
+/**
+ * Empirically captured 2026-04-22 23:45 UTC (DV-2):
+ * `~/.claude/plugins/cache/<marketplace-name>/<plugin-name>/<version>/.claude-plugin/plugin.json`.
+ *
+ * Workstream B Day 5+: parameterized on pluginName (was hardcoded `pm-os`)
+ * for multi-plugin install probe.
+ */
+export function installedPluginManifestPath(
+  slug: string,
+  version: string,
+  pluginName: string = SENTINEL_PLUGIN_NAME
+): string {
   return join(
     homedir(),
     '.claude',
     'plugins',
     'cache',
     marketplaceName(slug),
-    'pm-os',
+    pluginName,
     version,
     '.claude-plugin',
     'plugin.json'
   );
 }
 
-// Same as above with wildcard version — used when caller doesn't know the exact
-// version (Layer 1 probe in §7.2). Returns the parent dir to glob.
-export function installedPluginCacheParent(slug: string): string {
-  return join(homedir(), '.claude', 'plugins', 'cache', marketplaceName(slug), 'pm-os');
+/**
+ * Same as above with wildcard version — used when caller doesn't know the exact
+ * version (Layer 1 probe in §7.2). Returns the parent dir to glob.
+ *
+ * Workstream B Day 5+: parameterized on pluginName (was hardcoded `pm-os`).
+ */
+export function installedPluginCacheParent(
+  slug: string,
+  pluginName: string = SENTINEL_PLUGIN_NAME
+): string {
+  return join(homedir(), '.claude', 'plugins', 'cache', marketplaceName(slug), pluginName);
 }
 
 // Slug-format guard (RED-TEAM P0-2). The slug arrives from server responses

--- a/src/lib/plugin-load-detect.ts
+++ b/src/lib/plugin-load-detect.ts
@@ -3,13 +3,21 @@
 // (soft-warn fallback) land in PR 4d (§7.3 admin-restricted disambiguation).
 //
 // Layer 1 checks the empirically-verified cache path captured in DV-2 (2026-04-22):
-// `~/.claude/plugins/cache/<marketplace-name>/pm-os/<version>/.claude-plugin/plugin.json`.
+// `~/.claude/plugins/cache/<marketplace-name>/<plugin-name>/<version>/.claude-plugin/plugin.json`.
 // `<version>` is wildcard-globbed when caller doesn't know the exact version.
+//
+// Workstream B Day 5+: parameterized on `pluginName` (was hardcoded `pm-os`).
+// PMO is now a multi-plugin marketplace; the launch-critical sentinel is
+// `pm-companion-sync` (carries the SessionStart + PostToolUse hooks).
 
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { installedPluginCacheParent, installedPluginManifestPath } from './mysecond-paths.js';
+import {
+  installedPluginCacheParent,
+  installedPluginManifestPath,
+  SENTINEL_PLUGIN_NAME,
+} from './mysecond-paths.js';
 
 export type LayerOneResult =
   | { found: true; version: string; manifestPath: string }
@@ -18,20 +26,25 @@ export type LayerOneResult =
 // Probe the canonical Layer 1 cache path. If `version` is provided, check the
 // exact path; otherwise glob under the parent dir for any version subdir
 // containing `.claude-plugin/plugin.json`.
+//
+// `pluginName` defaults to the sentinel (pm-companion-sync) — verifying its
+// presence is the load-bearing health check because it owns the sync hooks.
+// Other plugins can be probed by passing their name explicitly.
 export function probeLayerOne(
   slug: string,
-  version: string | null = null
+  version: string | null = null,
+  pluginName: string = SENTINEL_PLUGIN_NAME
 ): LayerOneResult {
   if (version !== null) {
-    const path = installedPluginManifestPath(slug, version);
+    const path = installedPluginManifestPath(slug, version, pluginName);
     if (existsSync(path)) {
       return { found: true, version, manifestPath: path };
     }
     return { found: false };
   }
 
-  // Wildcard: list version subdirs under `~/.claude/plugins/cache/<marketplace>/pm-os/`.
-  const parent = installedPluginCacheParent(slug);
+  // Wildcard: list version subdirs under `~/.claude/plugins/cache/<marketplace>/<plugin>/`.
+  const parent = installedPluginCacheParent(slug, pluginName);
   if (!existsSync(parent)) return { found: false };
 
   let entries: string[];

--- a/src/lib/silent-status.ts
+++ b/src/lib/silent-status.ts
@@ -93,3 +93,45 @@ export function emitStatus(event: StatusEvent): void {
     }
   }
 }
+
+/**
+ * Emit the install_completed event ALWAYS — regardless of silentMode.
+ *
+ * All other events are silent-only (chat hooks need clean stdout). This
+ * event is the deterministic "done" signal the Claude Code Desktop chat
+ * assistant needs to stop watching for completion. It must escape the
+ * silent-mode gate so interactive installs (Bash-invoked, not hook-invoked)
+ * also emit it.
+ *
+ * A blank line is written before the JSON so it appears visually separated
+ * from the success box prose above it.
+ *
+ * Errors are swallowed — same contract as emitStatus.
+ */
+export function emitInstallCompleted(event: StatusEvent): void {
+  try {
+    const payload = {
+      mysecond_status_protocol_version: PROTOCOL_VERSION,
+      at: new Date().toISOString(),
+      ...event,
+    };
+    // Single line, terminated by exactly one newline. The caller (step-13)
+    // is responsible for writing the blank line between the success box prose
+    // and this JSON line — emitInstallCompleted does not add leading whitespace.
+    process.stdout.write(JSON.stringify(payload) + '\n');
+  } catch (err) {
+    try {
+      process.stdout.write(
+        JSON.stringify({
+          mysecond_status_protocol_version: PROTOCOL_VERSION,
+          at: new Date().toISOString(),
+          kind: 'status_emit_failed',
+          attempted_kind: event.kind,
+          reason: err instanceof Error ? err.message : 'serialize_error',
+        }) + '\n'
+      );
+    } catch {
+      // truly best-effort
+    }
+  }
+}

--- a/src/lib/silent-status.ts
+++ b/src/lib/silent-status.ts
@@ -1,0 +1,75 @@
+// Silent status protocol — emit structured JSON events to stdout when
+// `mysecond init --silent` is invoked from a Claude Code hook.
+//
+// Workstream B Phase 2a Day 4. CAIO #5 + brief security DoD #8.
+//
+// Why JSON: the chat surface in Claude Code Desktop renders cli stdout as
+// preformatted text. With prose status messages, the install flow looks
+// chaotic ("step 4: Polling /install-ready…", "step 4/13: …"); a JSON
+// stream lets the chat client (or downstream tooling) deduplicate, render
+// progress, and show actionable errors.
+//
+// Format: one event per line, each is valid JSON terminated by \n.
+//   {"mysecond_status_protocol_version":1,"kind":"<event>","at":"<iso>","..."}
+//
+// Important per CAIO #5: the version field is named
+// `mysecond_status_protocol_version`, NOT `schema_version`. Anthropic's
+// hook stdout has reserved fields (`continue`, `stopReason`, `suppressOutput`,
+// `systemMessage`); we MUST NOT collide with those, AND we mark our private
+// fields with our namespace so a future Anthropic addition can't conflict.
+//
+// Day-5 stop condition (CTO/CAIO): the cli must NEVER emit non-JSON to
+// stdout when --silent is set. Test: assert single-line valid JSON only.
+
+const PROTOCOL_VERSION = 1;
+
+export type StatusKind =
+  | 'install_started'
+  | 'device_code_minted'
+  | 'awaiting_authorization'
+  | 'device_authorized'
+  | 'install_step_completed'
+  | 'install_completed'
+  | 'install_failed'
+  | 'timeout';
+
+export interface StatusEvent {
+  kind: StatusKind;
+  /** Free-form properties per event kind. Always JSON-serializable. */
+  [key: string]: unknown;
+}
+
+let silentMode = false;
+
+/**
+ * Set the cli into --silent mode. Call once at startup, before any status
+ * emissions. Emissions before this call are no-ops.
+ */
+export function setSilentMode(enabled: boolean): void {
+  silentMode = enabled;
+}
+
+export function isSilentMode(): boolean {
+  return silentMode;
+}
+
+/**
+ * Emit a structured status event. No-ops outside --silent mode (so a
+ * normal `mysecond init` invocation doesn't pollute stdout with JSON).
+ *
+ * Errors are swallowed: status emission must never affect the install.
+ */
+export function emitStatus(event: StatusEvent): void {
+  if (!silentMode) return;
+  try {
+    const payload = {
+      mysecond_status_protocol_version: PROTOCOL_VERSION,
+      at: new Date().toISOString(),
+      ...event,
+    };
+    // Single line, terminated by exactly one newline. NO trailing whitespace.
+    process.stdout.write(JSON.stringify(payload) + '\n');
+  } catch {
+    // best-effort
+  }
+}

--- a/src/lib/silent-status.ts
+++ b/src/lib/silent-status.ts
@@ -26,10 +26,14 @@ const PROTOCOL_VERSION = 1;
 export type StatusKind =
   | 'install_started'
   | 'device_code_minted'
+  | 'device_code_minted_timed'   // Fix C Step 1: device-code request wall-clock
   | 'awaiting_authorization'
   | 'device_authorized'
+  | 'device_authorized_timed'    // Fix C Step 1: token-poll wall-clock
   | 'keychain_write_failed' // CAIO Day 4: discriminable from generic install_failed
   | 'install_step_completed'
+  | 'plugin_install_timed'       // Fix C Step 1: per-plugin install wall-clock
+  | 'step_9_total_timed'         // Fix C Step 1: full step-9 wall-clock + summary
   | 'install_completed'
   | 'install_failed'
   | 'timeout'

--- a/src/lib/silent-status.ts
+++ b/src/lib/silent-status.ts
@@ -103,8 +103,9 @@ export function emitStatus(event: StatusEvent): void {
  * silent-mode gate so interactive installs (Bash-invoked, not hook-invoked)
  * also emit it.
  *
- * A blank line is written before the JSON so it appears visually separated
- * from the success box prose above it.
+ * This function emits exactly one JSON line to stdout. It does NOT write a
+ * blank line before the JSON — that separation is the caller's responsibility
+ * (step-13 writes '\n\n' after the success box, before calling this).
  *
  * Errors are swallowed — same contract as emitStatus.
  */
@@ -120,6 +121,10 @@ export function emitInstallCompleted(event: StatusEvent): void {
     // and this JSON line — emitInstallCompleted does not add leading whitespace.
     process.stdout.write(JSON.stringify(payload) + '\n');
   } catch (err) {
+    // Only emit the status_emit_failed fallback in silent mode. In interactive
+    // mode, surfacing raw JSON on a serialize failure would be confusing to the
+    // user; swallowing is the safer degradation.
+    if (!silentMode) return;
     try {
       process.stdout.write(
         JSON.stringify({

--- a/src/lib/silent-status.ts
+++ b/src/lib/silent-status.ts
@@ -32,7 +32,8 @@ export type StatusKind =
   | 'install_step_completed'
   | 'install_completed'
   | 'install_failed'
-  | 'timeout';
+  | 'timeout'
+  | 'status_emit_failed'; // Codex pass 2 P1-4: fallback when JSON.stringify throws
 
 export interface StatusEvent {
   kind: StatusKind;
@@ -59,6 +60,11 @@ export function isSilentMode(): boolean {
  * normal `mysecond init` invocation doesn't pollute stdout with JSON).
  *
  * Errors are swallowed: status emission must never affect the install.
+ *
+ * Codex pass 2 P1-4: when JSON.stringify throws (circular ref, BigInt,
+ * etc.), emit a fallback `status_emit_failed` event so the chat client
+ * can still detect that an event was attempted. Silent drops break
+ * funnel completeness invisibly.
  */
 export function emitStatus(event: StatusEvent): void {
   if (!silentMode) return;
@@ -70,7 +76,20 @@ export function emitStatus(event: StatusEvent): void {
     };
     // Single line, terminated by exactly one newline. NO trailing whitespace.
     process.stdout.write(JSON.stringify(payload) + '\n');
-  } catch {
-    // best-effort
+  } catch (err) {
+    try {
+      process.stdout.write(
+        JSON.stringify({
+          mysecond_status_protocol_version: PROTOCOL_VERSION,
+          at: new Date().toISOString(),
+          kind: 'status_emit_failed',
+          attempted_kind: event.kind,
+          reason: err instanceof Error ? err.message : 'serialize_error',
+        }) + '\n'
+      );
+    } catch {
+      // truly best-effort — both serializations failed (impossible in
+      // practice, but never throw out of this function)
+    }
   }
 }

--- a/src/lib/silent-status.ts
+++ b/src/lib/silent-status.ts
@@ -28,6 +28,7 @@ export type StatusKind =
   | 'device_code_minted'
   | 'awaiting_authorization'
   | 'device_authorized'
+  | 'keychain_write_failed' // CAIO Day 4: discriminable from generic install_failed
   | 'install_step_completed'
   | 'install_completed'
   | 'install_failed'

--- a/src/lib/steps/index.ts
+++ b/src/lib/steps/index.ts
@@ -14,6 +14,7 @@ import { step10 } from './step-10.js';
 import { step11 } from './step-11.js';
 import { step12 } from './step-12.js';
 import { step13 } from './step-13.js';
+import { step15 } from './step-15.js';
 
 import type { StepFn } from './types.js';
 
@@ -27,6 +28,14 @@ export interface StepEntry {
 }
 
 export const STEPS: readonly StepEntry[] = [
+  // Step 15 — device-code OAuth (Workstream B Phase 2a). Runs FIRST because
+  // every downstream step relies on ctx.apiKey being populated. Numbered 15
+  // out of order so the canonical 1..14 ledger identifiers stay stable for
+  // existing customers (runner iterates array order, not numeric order).
+  // Customers with a complete pre-WS-B ledger (1..14) re-running init will
+  // skip 1..14 and run step 15 once; step 15 itself is idempotent (validates
+  // existing key via /whoami, falls through to device-code only when needed).
+  { number: 15, fn: step15, mutates: true, description: 'Device-code OAuth (Workstream B)' },
   { number: 1, fn: step1, mutates: false, description: 'Validate project-dir + Node version' },
   { number: 2, fn: step2, mutates: false, description: '(removed in v1.5 — placeholder)' },
   { number: 3, fn: step3, mutates: false, description: '(removed in v1.5 — placeholder)' },

--- a/src/lib/steps/step-13.ts
+++ b/src/lib/steps/step-13.ts
@@ -39,8 +39,8 @@ export const step13: StepFn = async ({ ctx, shared }) => {
   // emitInstallCompleted (not emitStatus) so this event always reaches stdout
   // regardless of --silent mode — it is the deterministic "done" signal the
   // Claude Code Desktop chat assistant needs to stop its watcher loop.
-  // The blank line between the success box and this JSON is written inside
-  // emitInstallCompleted itself.
+  // The '\n\n' above (after successBox) is what separates the success box from
+  // this JSON line — emitInstallCompleted does not add leading whitespace.
   // shared.userEmail is populated by step-15 from /whoami; falls back to
   // "you" if /whoami had a network error or didn't return an email field.
   emitInstallCompleted({

--- a/src/lib/steps/step-13.ts
+++ b/src/lib/steps/step-13.ts
@@ -2,10 +2,17 @@
 // Copy redesigned May 2026 per launch-feedback-log: drop premature
 // /prd-generator + /enhance-context suggestions, lead with personalized line,
 // single primary CTA = `/welcome`. See `successBox()` in lib/copy.ts.
+//
+// Workstream B Day 5+ Item 5B: emits the `install_completed` JSON status
+// event with installCompleteClaudeMessage(email) as the message field. This
+// is the deferred-by-design Day 4 wiring — landed now so Claude Code Desktop's
+// chat surface (when invoking via hooks/--silent) gets a deterministic
+// post-install confirmation instead of paraphrasing the cli's terminal output.
 
-import { successBox } from '../copy.js';
+import { installCompleteClaudeMessage, successBox } from '../copy.js';
 import { countPluginContents } from '../plugin-counts.js';
 import { pluginExtractDir } from '../mysecond-paths.js';
+import { emitStatus } from '../silent-status.js';
 
 import type { StepFn } from './types.js';
 
@@ -27,5 +34,17 @@ export const step13: StepFn = async ({ ctx, shared }) => {
   if (!ctx.silent) {
     process.stdout.write('\n' + successBox(pmName, companyName, shared.pluginCounts) + '\n\n');
   }
+
+  // Emit install_completed JSON status event (Item 5B). shared.userEmail is
+  // populated by step-15 from /whoami; falls back to "you" if /whoami had a
+  // network error or didn't return an email field.
+  emitStatus({
+    kind: 'install_completed',
+    message: installCompleteClaudeMessage(shared.userEmail ?? 'you'),
+    skills_installed: shared.pluginCounts?.skills ?? 0,
+    agents_installed: shared.pluginCounts?.agents ?? 0,
+    workflows_installed: shared.pluginCounts?.workflows ?? 0,
+  });
+
   return { step: 13, outcome: { kind: 'completed' } };
 };

--- a/src/lib/steps/step-13.ts
+++ b/src/lib/steps/step-13.ts
@@ -12,7 +12,7 @@
 import { installCompleteClaudeMessage, successBox } from '../copy.js';
 import { countPluginContents } from '../plugin-counts.js';
 import { pluginExtractDir } from '../mysecond-paths.js';
-import { emitStatus } from '../silent-status.js';
+import { emitInstallCompleted } from '../silent-status.js';
 
 import type { StepFn } from './types.js';
 
@@ -35,10 +35,15 @@ export const step13: StepFn = async ({ ctx, shared }) => {
     process.stdout.write('\n' + successBox(pmName, companyName, shared.pluginCounts) + '\n\n');
   }
 
-  // Emit install_completed JSON status event (Item 5B). shared.userEmail is
-  // populated by step-15 from /whoami; falls back to "you" if /whoami had a
-  // network error or didn't return an email field.
-  emitStatus({
+  // Emit install_completed JSON status event (Item 5B). Calls
+  // emitInstallCompleted (not emitStatus) so this event always reaches stdout
+  // regardless of --silent mode — it is the deterministic "done" signal the
+  // Claude Code Desktop chat assistant needs to stop its watcher loop.
+  // The blank line between the success box and this JSON is written inside
+  // emitInstallCompleted itself.
+  // shared.userEmail is populated by step-15 from /whoami; falls back to
+  // "you" if /whoami had a network error or didn't return an email field.
+  emitInstallCompleted({
     kind: 'install_completed',
     message: installCompleteClaudeMessage(shared.userEmail ?? 'you'),
     skills_installed: shared.pluginCounts?.skills ?? 0,

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -162,8 +162,17 @@ async function runDeviceCodeFlow(
   // Day 5 pre-launch: user_code is NOT in the URL — customer types it
   // into the page's input form. Print the code prominently with a copy-
   // friendly hint so the customer knows where to find it.
+  //
+  // Day 5+ Item 5A (CAIO P0): write the device-code block to STDERR, not
+  // stdout. Node's process.stdout is block-buffered when piped (Claude Code
+  // Desktop's bash tool is a pipe), so a multi-line stdout.write can sit
+  // in the buffer for 30s-2min before the customer sees it. process.stderr
+  // is unbuffered by default when piped — the code surfaces in chat in ~5s.
+  // The trailing \n explicitly flushes the pipe.
+  // "Waiting for authorization..." stays on stdout — lower urgency, fine
+  // to buffer.
   if (!ctx.silent) {
-    process.stdout.write(
+    process.stderr.write(
       [
         '',
         'mySecond needs to authorize this device in your browser.',
@@ -172,10 +181,10 @@ async function runDeviceCodeFlow(
         `  Open:  ${codeResp.verification_uri_complete}`,
         '',
         'Type the code in the browser, then click Authorize.',
-        'Waiting for authorization...',
         '',
-      ].join('\n')
+      ].join('\n') + '\n'
     );
+    process.stdout.write('Waiting for authorization...\n');
   }
 
   // Silent JSON status: cli emits "device_code_minted" so the chat client

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -46,7 +46,7 @@ declare const __VERSION__: string;
 
 const WHOAMI_TIMEOUT_MS = 10_000;
 
-export const step15: StepFn = async ({ ctx }) => {
+export const step15: StepFn = async ({ ctx, shared }) => {
   // ── --resume: revoke first, then proceed to full flow ─────────────────
   if (ctx.resume) {
     if (ctx.apiKey.length > 0) {
@@ -61,13 +61,16 @@ export const step15: StepFn = async ({ ctx }) => {
       // Clear in-memory key so the post-revoke flow doesn't try to reuse it.
       (ctx as { apiKey: string }).apiKey = '';
     }
-    return runDeviceCodeFlow(ctx);
+    return runDeviceCodeFlow(ctx, shared);
   }
 
   // ── ctx.apiKey already populated → validate via /whoami ───────────────
   if (ctx.apiKey.length > 0) {
-    const whoamiOk = await validateExistingKey(ctx);
-    if (whoamiOk) {
+    // Item 5B: capture email here too so step-13 can emit install_completed
+    // with the customer's email even on the existing-credential-validated path.
+    const whoami = await fetchWhoami(ctx);
+    if (whoami.ok) {
+      if (whoami.email) shared.userEmail = whoami.email;
       return {
         step: 15,
         outcome: { kind: 'completed' },
@@ -86,12 +89,25 @@ export const step15: StepFn = async ({ ctx }) => {
     }
   }
 
-  return runDeviceCodeFlow(ctx);
+  return runDeviceCodeFlow(ctx, shared);
 };
 
 // ── /whoami validation ─────────────────────────────────────────────────────
 
-async function validateExistingKey(ctx: CommandContext): Promise<boolean> {
+/**
+ * Probe /whoami with the current apiKey. Three outcomes:
+ *   - { ok: true, email } — server returned 200; email captured for step-13.
+ *   - { ok: false, email: null } — server explicitly rejected (4xx/5xx);
+ *     caller should clear the key and re-authenticate.
+ *   - { ok: true, email: null, networkError: true } — network failure /
+ *     timeout. Don't lock the customer out on transient blips — trust the
+ *     existing key. Worst case the next sync surfaces a 401 and the
+ *     customer re-runs init then. Email is unknown so step-13 will fall
+ *     back to a generic post-install message.
+ */
+async function fetchWhoami(
+  ctx: CommandContext,
+): Promise<{ ok: boolean; email: string | null; networkError?: boolean }> {
   try {
     const url = new URL('/api/companion/whoami', ctx.apiBase);
     const response = await fetch(url, {
@@ -101,13 +117,13 @@ async function validateExistingKey(ctx: CommandContext): Promise<boolean> {
       },
       signal: AbortSignal.timeout(WHOAMI_TIMEOUT_MS),
     });
-    return response.status === 200;
+    if (response.status !== 200) return { ok: false, email: null };
+    const body = (await response.json().catch(() => null)) as { email?: string | null } | null;
+    return { ok: true, email: body?.email ?? null };
   } catch {
-    // Network error → don't lock customer out. Trust the existing key on
-    // network failure rather than force re-auth on every transient blip.
-    // Worst case: a revoked-but-cached token survives until the next
-    // network-up run, which is the same failure mode pre-Codex-fix.
-    return true;
+    // Network error / timeout — trust the existing key (preserves prior
+    // validateExistingKey behavior). Email unknown; step-13 falls back.
+    return { ok: true, email: null, networkError: true };
   }
 }
 
@@ -135,7 +151,8 @@ async function tryRevokeExistingToken(ctx: CommandContext): Promise<void> {
 // ── Full device-code flow ─────────────────────────────────────────────────
 
 async function runDeviceCodeFlow(
-  ctx: CommandContext
+  ctx: CommandContext,
+  shared: import('./types.js').StepContext['shared'],
 ): Promise<{ step: number; outcome: { kind: 'completed' }; message?: string }> {
   const installId = getOrCreateInstallId();
   const codeOpts = {
@@ -222,6 +239,15 @@ async function runDeviceCodeFlow(
 
   // Mutate ctx for downstream steps.
   (ctx as { apiKey: string }).apiKey = tokenResp.access_token;
+
+  // Item 5B: capture email from /whoami so step-13 can emit the
+  // install_completed JSON status event with installCompleteClaudeMessage(email).
+  // Best-effort — if /whoami fails here, step-13 falls back to a generic
+  // post-install message.
+  const whoami = await fetchWhoami(ctx);
+  if (whoami.email) {
+    shared.userEmail = whoami.email;
+  }
 
   // Emit a keychain_write_failed status when we fell back due to round-trip
   // failure or write error (sandboxed-keychain edge case). Not a fatal

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -160,6 +160,10 @@ async function runDeviceCodeFlow(
     installId,
   };
 
+  // Fix C Step 1: measure device-code mint wall-clock. The requestDeviceCode
+  // call does a single POST to /api/companion/device/code. If this is slow,
+  // the bottleneck is network latency to our API, not the token-poll loop.
+  const mintStartMs = performance.now();
   let codeResp;
   try {
     codeResp = await requestDeviceCode(codeOpts);
@@ -172,6 +176,13 @@ async function runDeviceCodeFlow(
     }
     throw err;
   }
+  const mintDurationMs = Math.round(performance.now() - mintStartMs);
+  // Emit in silent mode only — in interactive mode the stderr device-code
+  // block (written immediately below) is the customer-facing surface.
+  emitStatus({
+    kind: 'device_code_minted_timed',
+    duration_ms: mintDurationMs,
+  });
 
   // CAIO #10: print URL to stdout BEFORE the open attempt. The chat is the
   // deterministic surface; auto-open is best-effort.
@@ -213,6 +224,11 @@ async function runDeviceCodeFlow(
   });
 
   // Poll until authorized or 540s cap.
+  // Fix C Step 1: measure the token-poll loop wall-clock. This is the
+  // time between the user receiving the code and clicking "Authorize" in
+  // the browser — dominated by human speed, not CLI overhead. Useful to
+  // distinguish "device-code flow is slow" from "user was slow to click".
+  const pollStartMs = performance.now();
   let tokenResp;
   try {
     tokenResp = await pollForToken({
@@ -229,6 +245,14 @@ async function runDeviceCodeFlow(
     }
     throw err;
   }
+  const pollDurationMs = Math.round(performance.now() - pollStartMs);
+  // Emit timing for the poll phase regardless of silent/interactive mode —
+  // same pattern as device_code_minted_timed above. isSilentMode() check is
+  // handled inside emitStatus; we always call it so both code paths are covered.
+  emitStatus({
+    kind: 'device_authorized_timed',
+    duration_ms: pollDurationMs,
+  });
 
   // Persist the token (keychain on macOS, file fallback elsewhere).
   const setResult = setDeviceToken(ctx.rootDir, tokenResp.access_token);

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -35,7 +35,7 @@ import {
   getOrCreateInstallId,
   DeviceCodeError,
 } from '../device-code.js';
-import { setDeviceToken } from '../keychain.js';
+import { clearDeviceToken, setDeviceToken } from '../keychain.js';
 import { MysecondError } from '../errors.js';
 import { emitStatus } from '../silent-status.js';
 
@@ -51,6 +51,13 @@ export const step15: StepFn = async ({ ctx }) => {
   if (ctx.resume) {
     if (ctx.apiKey.length > 0) {
       await tryRevokeExistingToken(ctx);
+      // Codex pass 2 P1-3: clear the local cached token IMMEDIATELY after
+      // revoke. Without this, a cli crash between revoke and new-token
+      // mint would leave the keychain holding a now-revoked token. On
+      // recovery (without --resume), getDeviceToken would return that
+      // stale token, /whoami would 401, and the customer would see a
+      // confusing "credential rejected" message before re-auth fires.
+      clearDeviceToken(ctx.rootDir);
       // Clear in-memory key so the post-revoke flow doesn't try to reuse it.
       (ctx as { apiKey: string }).apiKey = '';
     }

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -37,6 +37,7 @@ import {
 } from '../device-code.js';
 import { setDeviceToken } from '../keychain.js';
 import { MysecondError } from '../errors.js';
+import { emitStatus } from '../silent-status.js';
 
 import type { CommandContext } from '../context.js';
 import type { StepFn } from './types.js';
@@ -167,6 +168,15 @@ async function runDeviceCodeFlow(
     );
   }
 
+  // Silent JSON status: cli emits "device_code_minted" so the chat client
+  // can render its own waiting UI without parsing prose stdout.
+  emitStatus({
+    kind: 'device_code_minted',
+    user_code: codeResp.user_code,
+    verification_uri: codeResp.verification_uri,
+    expires_in: codeResp.expires_in,
+  });
+
   // Best-effort browser open (after URL is already printed).
   tryOpenBrowser(codeResp.verification_uri_complete);
 
@@ -189,10 +199,16 @@ async function runDeviceCodeFlow(
   }
 
   // Persist the token (keychain on macOS, file fallback elsewhere).
-  setDeviceToken(ctx.rootDir, tokenResp.access_token);
+  const setResult = setDeviceToken(ctx.rootDir, tokenResp.access_token);
 
   // Mutate ctx for downstream steps.
   (ctx as { apiKey: string }).apiKey = tokenResp.access_token;
+
+  emitStatus({
+    kind: 'device_authorized',
+    token_storage: setResult.storage,
+    keychain_unavailable_reason: setResult.fallbackReason ?? null,
+  });
 
   return {
     step: 15,

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -1,0 +1,202 @@
+// Step 15: Device-code OAuth (Workstream B / Phase 2a Day 4).
+//
+// Runs FIRST in the step registry — before step 4's /install-ready poll —
+// because every downstream step relies on ctx.apiKey being populated. For
+// Workstream B customers, ctx.apiKey is the device-token bearer (msd_...);
+// it is acquired here when context-build time didn't already source one.
+//
+// Note: keychain/file token recovery happens at context-build time
+// (see context.ts buildContext). By the time this step runs, ctx.apiKey
+// is either:
+//   (a) empty — no credential anywhere; run device-code flow
+//   (b) populated — either a fresh-from-keychain device token, an env-var
+//       override, or a legacy companion_api_key
+//
+// Idempotency contract:
+//   - With --resume: REVOKE the existing token (if any) on the server
+//     before requesting a new code. Otherwise --resume is just "get a new
+//     token alongside" — the old one stays valid for ~90 days, which
+//     defeats the security purpose of --resume.
+//   - Without --resume + ctx.apiKey populated: validate against /whoami
+//     before trusting. A revoked token in .env would otherwise silently
+//     bypass device-code and customer would be stuck with a working
+//     ledger but failing API calls.
+//   - Without --resume + ctx.apiKey empty: run full device-code flow.
+//
+// Codex review fixes baked in: P0-1 (keychain read moved to buildContext),
+// P0-2 (whoami validation before trust), P0-4 (revoke on --resume).
+//
+// Brief: ~/.claude/plans/workstream-b-device-code-brief.md
+
+import {
+  pollForToken,
+  requestDeviceCode,
+  tryOpenBrowser,
+  getOrCreateInstallId,
+  DeviceCodeError,
+} from '../device-code.js';
+import { setDeviceToken } from '../keychain.js';
+import { MysecondError } from '../errors.js';
+
+import type { CommandContext } from '../context.js';
+import type { StepFn } from './types.js';
+
+declare const __VERSION__: string;
+
+const WHOAMI_TIMEOUT_MS = 10_000;
+
+export const step15: StepFn = async ({ ctx }) => {
+  // ── --resume: revoke first, then proceed to full flow ─────────────────
+  if (ctx.resume) {
+    if (ctx.apiKey.length > 0) {
+      await tryRevokeExistingToken(ctx);
+      // Clear in-memory key so the post-revoke flow doesn't try to reuse it.
+      (ctx as { apiKey: string }).apiKey = '';
+    }
+    return runDeviceCodeFlow(ctx);
+  }
+
+  // ── ctx.apiKey already populated → validate via /whoami ───────────────
+  if (ctx.apiKey.length > 0) {
+    const whoamiOk = await validateExistingKey(ctx);
+    if (whoamiOk) {
+      return {
+        step: 15,
+        outcome: { kind: 'completed' },
+        message: ctx.silent
+          ? undefined
+          : 'step 15: existing credential validated',
+      };
+    }
+    // Existing key didn't validate (revoked, expired, or unauthenticatable).
+    // Clear it and fall through to device-code flow.
+    (ctx as { apiKey: string }).apiKey = '';
+    if (!ctx.silent) {
+      process.stdout.write(
+        'step 15: existing credential rejected by server — re-authenticating\n'
+      );
+    }
+  }
+
+  return runDeviceCodeFlow(ctx);
+};
+
+// ── /whoami validation ─────────────────────────────────────────────────────
+
+async function validateExistingKey(ctx: CommandContext): Promise<boolean> {
+  try {
+    const url = new URL('/api/companion/whoami', ctx.apiBase);
+    const response = await fetch(url, {
+      headers: {
+        authorization: `Bearer ${ctx.apiKey}`,
+        'user-agent': `mysecond-cli/${__VERSION__} (${process.platform}; node-${process.versions.node})`,
+      },
+      signal: AbortSignal.timeout(WHOAMI_TIMEOUT_MS),
+    });
+    return response.status === 200;
+  } catch {
+    // Network error → don't lock customer out. Trust the existing key on
+    // network failure rather than force re-auth on every transient blip.
+    // Worst case: a revoked-but-cached token survives until the next
+    // network-up run, which is the same failure mode pre-Codex-fix.
+    return true;
+  }
+}
+
+// ── /revoke (single-token bearer-authed) ───────────────────────────────────
+
+async function tryRevokeExistingToken(ctx: CommandContext): Promise<void> {
+  try {
+    const url = new URL('/api/companion/device/revoke', ctx.apiBase);
+    await fetch(url, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ctx.apiKey}`,
+        'user-agent': `mysecond-cli/${__VERSION__} (${process.platform}; node-${process.versions.node})`,
+      },
+      signal: AbortSignal.timeout(WHOAMI_TIMEOUT_MS),
+    });
+    // Don't fail the resume if revoke errors — best-effort. The new token
+    // we're about to mint is the security guarantee; the old token's
+    // continued validity is a smaller residual risk.
+  } catch {
+    // network error → fall through and continue with the resume.
+  }
+}
+
+// ── Full device-code flow ─────────────────────────────────────────────────
+
+async function runDeviceCodeFlow(
+  ctx: CommandContext
+): Promise<{ step: number; outcome: { kind: 'completed' }; message?: string }> {
+  const installId = getOrCreateInstallId();
+  const codeOpts = {
+    apiBase: ctx.apiBase,
+    cliVersion: __VERSION__,
+    installId,
+  };
+
+  let codeResp;
+  try {
+    codeResp = await requestDeviceCode(codeOpts);
+  } catch (err) {
+    if (err instanceof DeviceCodeError) {
+      throw new MysecondError(
+        1,
+        `Couldn't request a device code (${err.code}): ${err.message}`
+      );
+    }
+    throw err;
+  }
+
+  // CAIO #10: print URL to stdout BEFORE the open attempt. The chat is the
+  // deterministic surface; auto-open is best-effort.
+  if (!ctx.silent) {
+    process.stdout.write(
+      [
+        '',
+        'mySecond needs to verify your identity in a browser.',
+        '',
+        `  Code:  ${codeResp.user_code}`,
+        `  Open:  ${codeResp.verification_uri_complete}`,
+        '',
+        'Confirm the code matches what you see in the browser, then click Authorize.',
+        'Waiting for authorization...',
+        '',
+      ].join('\n')
+    );
+  }
+
+  // Best-effort browser open (after URL is already printed).
+  tryOpenBrowser(codeResp.verification_uri_complete);
+
+  // Poll until authorized or 540s cap.
+  let tokenResp;
+  try {
+    tokenResp = await pollForToken({
+      ...codeOpts,
+      deviceCode: codeResp.device_code,
+      intervalSeconds: codeResp.interval,
+    });
+  } catch (err) {
+    if (err instanceof DeviceCodeError) {
+      throw new MysecondError(
+        1,
+        `Device authorization failed (${err.code}): ${err.message}`
+      );
+    }
+    throw err;
+  }
+
+  // Persist the token (keychain on macOS, file fallback elsewhere).
+  setDeviceToken(ctx.rootDir, tokenResp.access_token);
+
+  // Mutate ctx for downstream steps.
+  (ctx as { apiKey: string }).apiKey = tokenResp.access_token;
+
+  return {
+    step: 15,
+    outcome: { kind: 'completed' },
+    message: ctx.silent ? undefined : 'step 15: device authorized',
+  };
+}

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -31,7 +31,6 @@
 import {
   pollForToken,
   requestDeviceCode,
-  tryOpenBrowser,
   getOrCreateInstallId,
   DeviceCodeError,
 } from '../device-code.js';
@@ -212,9 +211,6 @@ async function runDeviceCodeFlow(
     verification_uri: codeResp.verification_uri,
     expires_in: codeResp.expires_in,
   });
-
-  // Best-effort browser open (after URL is already printed).
-  tryOpenBrowser(codeResp.verification_uri_complete);
 
   // Poll until authorized or 540s cap.
   let tokenResp;

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -159,20 +159,19 @@ async function runDeviceCodeFlow(
 
   // CAIO #10: print URL to stdout BEFORE the open attempt. The chat is the
   // deterministic surface; auto-open is best-effort.
-  // CXO Day 4: copy fixes — "authorize this device" (not "verify identity",
-  // which reads as SSO/OAuth jargon), and direction-correct verification
-  // wording ("In the browser, confirm the code matches the one above").
+  // Day 5 pre-launch: user_code is NOT in the URL — customer types it
+  // into the page's input form. Print the code prominently with a copy-
+  // friendly hint so the customer knows where to find it.
   if (!ctx.silent) {
     process.stdout.write(
       [
         '',
         'mySecond needs to authorize this device in your browser.',
         '',
-        `  Code:  ${codeResp.user_code}`,
-        '',
+        `  Code:  ${codeResp.user_code}    ← copy this`,
         `  Open:  ${codeResp.verification_uri_complete}`,
         '',
-        'In the browser, confirm the code matches the one above, then click Authorize.',
+        'Type the code in the browser, then click Authorize.',
         'Waiting for authorization...',
         '',
       ].join('\n')

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -152,16 +152,20 @@ async function runDeviceCodeFlow(
 
   // CAIO #10: print URL to stdout BEFORE the open attempt. The chat is the
   // deterministic surface; auto-open is best-effort.
+  // CXO Day 4: copy fixes — "authorize this device" (not "verify identity",
+  // which reads as SSO/OAuth jargon), and direction-correct verification
+  // wording ("In the browser, confirm the code matches the one above").
   if (!ctx.silent) {
     process.stdout.write(
       [
         '',
-        'mySecond needs to verify your identity in a browser.',
+        'mySecond needs to authorize this device in your browser.',
         '',
         `  Code:  ${codeResp.user_code}`,
+        '',
         `  Open:  ${codeResp.verification_uri_complete}`,
         '',
-        'Confirm the code matches what you see in the browser, then click Authorize.',
+        'In the browser, confirm the code matches the one above, then click Authorize.',
         'Waiting for authorization...',
         '',
       ].join('\n')
@@ -204,11 +208,35 @@ async function runDeviceCodeFlow(
   // Mutate ctx for downstream steps.
   (ctx as { apiKey: string }).apiKey = tokenResp.access_token;
 
+  // Emit a keychain_write_failed status when we fell back due to round-trip
+  // failure or write error (sandboxed-keychain edge case). Not a fatal
+  // condition — file fallback is a working credential — but worth a
+  // discriminable event so support can detect a sandboxed-keychain pattern
+  // in PostHog without grepping logs (CAIO Day 4).
+  if (
+    setResult.fallbackReason === 'roundtrip_failed' ||
+    setResult.fallbackReason === 'write_failed'
+  ) {
+    emitStatus({
+      kind: 'keychain_write_failed',
+      reason: setResult.fallbackReason,
+    });
+  }
+
   emitStatus({
     kind: 'device_authorized',
     token_storage: setResult.storage,
     keychain_unavailable_reason: setResult.fallbackReason ?? null,
   });
+
+  // CXO Day 4: parallel non-silent success line so the customer in their
+  // terminal sees an explicit "✓ authorized" instead of just "step 15:
+  // device authorized" (which doesn't tell them what to do next).
+  if (!ctx.silent) {
+    process.stdout.write(
+      '\n  ✓ Device authorized. Quit and reopen Claude Code to load the mySecond plugin — your install will continue automatically.\n\n'
+    );
+  }
 
   return {
     step: 15,

--- a/src/lib/steps/step-5b.ts
+++ b/src/lib/steps/step-5b.ts
@@ -169,18 +169,40 @@ export const step5b: StepFn = async ({ ctx }) => {
   const isMigration =
     !existing.hasKey && existsSync(join(ctx.rootDir, '.env'));
 
-  // Idempotent: if project-scoped already has the right key, skip the write.
-  if (existing.hasKey && existing.currentValue === newKey) {
-    // Still run the gitignore guard below — that's not idempotency-gated.
-  } else if (existing.hasKey && existing.currentValue !== newKey) {
-    // Drift case: project-scoped has a DIFFERENT key. Don't overwrite;
-    // assume the customer manually edited. Hook's dual-creds warning
-    // (shipped in product-manager-os PR #13) will surface the mismatch.
-    emitWarning(
-      ctx.silent,
-      `[mysecond] ⚠️ ${credsPath} has a different COMPANION_API_KEY than the one provided. Skipping overwrite — manual edit assumed. Run \`mysecond whereami\` to inspect, or delete the file to let init re-write.`
-    );
+  // Desired on-disk content. ctx.apiBase is always populated by buildContext()
+  // (src/lib/context.ts) — env var COMPANION_API_URL || prod default.
+  const wantContent = `${ENV_KEY}=${newKey}\nCOMPANION_API_URL=${ctx.apiBase}\n`;
+
+  // Read raw on-disk content for full-content comparison (catches URL drift,
+  // missing URL line, stale URL — not just key match).
+  let onDiskContent: string | null = null;
+  if (existsSync(credsPath)) {
+    try {
+      onDiskContent = readFileSync(credsPath, 'utf8');
+    } catch {
+      // unreadable — treat as needs-write
+    }
+  }
+
+  // True idempotent: file exactly matches desired content.
+  if (onDiskContent === wantContent) {
+    // No-op. Still run the gitignore guard below.
   } else {
+    // Three sub-cases for messaging:
+    //   1. Key rotation: existing.hasKey && existing.currentValue !== newKey
+    //      Previously skipped + warned "manual edit assumed". Changed because
+    //      skipping left customers stuck on stale URLs from prior init runs
+    //      (decision 0044 — staging customer issued token from staging Supabase
+    //      but creds file was missing COMPANION_API_URL → hook defaulted to
+    //      prod → silent 401).
+    //   2. Content backfill: existing.hasKey && existing.currentValue === newKey
+    //      but on-disk content differs (URL missing, URL stale). This is the
+    //      installed-base recovery path: customers who ran old CLI re-run
+    //      init and get URL written without rotating the key.
+    //   3. Fresh write: !existing.hasKey
+    const isKeyRotation = existing.hasKey && existing.currentValue !== newKey;
+    const isContentBackfill = existing.hasKey && existing.currentValue === newKey;
+
     // Write (atomic via temp+rename) with mode 0o600.
     //
     // Note: atomicWriteFile uses a deterministic temp filename
@@ -192,9 +214,7 @@ export const step5b: StepFn = async ({ ctx }) => {
     // (c) sub-millisecond timing. Accepted risk for v1.3.4; revisit if any
     // hardened-environment customer surfaces this.
     try {
-      const apiUrl = ctx.apiBase || 'https://app.mysecond.ai';
-      const credsContent = `${ENV_KEY}=${newKey}\nCOMPANION_API_URL=${apiUrl}\n`;
-      atomicWriteFile(credsPath, credsContent, { mode: 0o600 });
+      atomicWriteFile(credsPath, wantContent, { mode: 0o600 });
     } catch (err) {
       emitWarning(
         ctx.silent,
@@ -217,7 +237,17 @@ export const step5b: StepFn = async ({ ctx }) => {
       // statSync errors are non-fatal here — ignore.
     }
 
-    if (isMigration) {
+    if (isKeyRotation) {
+      emit(
+        ctx.silent,
+        `[mysecond] Rotated COMPANION_API_KEY in project-scoped credentials. Run \`mysecond whereami\` to inspect.`
+      );
+    } else if (isContentBackfill) {
+      emit(
+        ctx.silent,
+        '[mysecond] Updated project-scoped credentials with COMPANION_API_URL.'
+      );
+    } else if (isMigration) {
       emit(
         ctx.silent,
         '[mysecond] Secured your API key: moved out of .env (which can be committed to git) into a global file. Run `mysecond whereami` to see where your credentials live.'

--- a/src/lib/steps/step-5b.ts
+++ b/src/lib/steps/step-5b.ts
@@ -192,7 +192,9 @@ export const step5b: StepFn = async ({ ctx }) => {
     // (c) sub-millisecond timing. Accepted risk for v1.3.4; revisit if any
     // hardened-environment customer surfaces this.
     try {
-      atomicWriteFile(credsPath, `${ENV_KEY}=${newKey}\n`, { mode: 0o600 });
+      const apiUrl = ctx.apiBase || 'https://app.mysecond.ai';
+      const credsContent = `${ENV_KEY}=${newKey}\nCOMPANION_API_URL=${apiUrl}\n`;
+      atomicWriteFile(credsPath, credsContent, { mode: 0o600 });
     } catch (err) {
       emitWarning(
         ctx.silent,

--- a/src/lib/steps/step-9.ts
+++ b/src/lib/steps/step-9.ts
@@ -334,11 +334,14 @@ async function doStep9(
   // Post-install filesystem probe — verify the SENTINEL plugin landed where
   // we expect (the launch-critical sync hooks). Other plugins are checked
   // implicitly via the install-loop status codes above.
-  const probe = probeLayerOne(slug, meta.version, SENTINEL_PLUGIN_NAME);
+  // Pass null for version so we match by plugin name only — Claude Code
+  // installs at its own version (e.g. 1.0.0 from plugin.json) which differs
+  // from the regen-timestamp version in meta. Any installed version passes.
+  const probe = probeLayerOne(slug, null, SENTINEL_PLUGIN_NAME);
   if (!probe.found) {
     throw new MysecondError(
       6,
-      `Plugin install reported success but ${marketplaceName(slug)}/${SENTINEL_PLUGIN_NAME}/${meta.version} not in cache. Re-run \`mysecond init\` to retry.`
+      `Plugin install reported success but ${marketplaceName(slug)}/${SENTINEL_PLUGIN_NAME} not found in cache. Re-run \`mysecond init\` to retry.`
     );
   }
 
@@ -417,8 +420,9 @@ function tryFallback(
       // is already in the degraded "stale cache" state and the banner explains.
     }
 
-    // Probe for the cached version's sentinel plugin.
-    const probe = probeLayerOne(slug, hit.version, SENTINEL_PLUGIN_NAME);
+    // Probe for the sentinel plugin by name only (version-agnostic — Claude Code
+    // installs at plugin.json version which may differ from the cached version).
+    const probe = probeLayerOne(slug, null, SENTINEL_PLUGIN_NAME);
     if (!probe.found) return null;
 
     return { version: hit.version, cachedAgeHours: hit.cached_age_hours };

--- a/src/lib/steps/step-9.ts
+++ b/src/lib/steps/step-9.ts
@@ -29,6 +29,7 @@ import {
 import { acquireMarketplaceLock } from '../marketplace-lock.js';
 import { buildMarketplaceJson, serializeMarketplaceJson } from '../marketplace-json.js';
 import {
+  listMarketplacePluginsFromExtractDir,
   marketplaceDir,
   marketplaceJsonPath,
   marketplaceName,
@@ -36,7 +37,9 @@ import {
   marketplaceTmpJsonPath,
   pluginInstallSpec,
   pluginTmpExtractDir,
+  SENTINEL_PLUGIN_NAME,
   validateSlug,
+  type PluginEntry,
 } from '../mysecond-paths.js';
 import { fetchAndExtractPlugin } from '../plugin-tarball.js';
 import { probeLayerOne } from '../plugin-load-detect.js';
@@ -188,8 +191,27 @@ async function doStep9(
     }
   }
 
-  // Sub-step (e): generate marketplace.json into the tmp tree, atomic rename.
-  const marketplaceJsonContent = serializeMarketplaceJson(buildMarketplaceJson(slug));
+  // Sub-step (e): read PMO's tarball-internal marketplace.json (source of
+  // truth for the multi-plugin layout), build the cli-side outer manifest
+  // wrapping its plugins[], atomic rename.
+  //
+  // CRITICAL ORDERING (CAIO Day 5+ review): list the plugins BEFORE the
+  // atomic rename. Reading from `pluginTmpExtractDir(slug)` gives us PMO's
+  // tarball-internal manifest. After atomic rename + further cli operations,
+  // the manifest at `marketplaceJsonPath(slug)` would be the cli-generated
+  // one — which previously hardcoded a single `pm-os` entry and silently
+  // dropped all 11 sub-plugins.
+  let plugins: PluginEntry[];
+  try {
+    plugins = listMarketplacePluginsFromExtractDir(tmpExtractDir);
+  } catch (err) {
+    rmSync(tmpMarketplaceDir, { recursive: true, force: true });
+    throw new MysecondError(
+      6,
+      `Couldn't read PMO marketplace manifest from extracted tarball: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  const marketplaceJsonContent = serializeMarketplaceJson(buildMarketplaceJson(slug, plugins));
   const tmpMarketplaceJsonPath = marketplaceTmpJsonPath(slug);
   mkdirSync(join(tmpMarketplaceDir, '.claude-plugin'), { recursive: true });
   writeFileSync(tmpMarketplaceJsonPath, marketplaceJsonContent);
@@ -259,35 +281,64 @@ async function doStep9(
     );
   }
 
-  const installResult = spawnSync(
-    'claude',
-    ['plugin', 'install', pluginInstallSpec(slug), '--scope', 'user'],
-    { stdio: ctx.silent ? 'pipe' : 'inherit' }
-  );
-  // RED-TEAM R2 P1-A: ENOENT detection (same as marketplace add above).
-  if (installResult.error !== undefined && (installResult.error as NodeJS.ErrnoException).code === 'ENOENT') {
-    throw new MysecondError(
-      6,
-      "Cannot find 'claude' binary on PATH (between marketplace add + plugin install). Re-run `mysecond init` from the same shell where `which claude` works."
+  // Install loop over all sub-plugins from PMO's marketplace (Workstream B
+  // Day 5+). Previously single-shot `claude plugin install pm-os@<m>` which
+  // silently no-op'd against PMO's multi-plugin layout. Now iterates the
+  // plugins[] read from PMO's manifest above. Tracks failures; hard-fails
+  // ONLY if the launch-critical sentinel (`pm-companion-sync`) doesn't land
+  // — other plugins may legitimately error out (corrupt sub-plugin, partial
+  // marketplace) without breaking the customer's core sync flow.
+  const failedPlugins: string[] = [];
+  for (const plugin of plugins) {
+    const spec = pluginInstallSpec(slug, plugin.name);
+    const installResult = spawnSync(
+      'claude',
+      ['plugin', 'install', spec, '--scope', 'user'],
+      { stdio: ctx.silent ? 'pipe' : 'inherit' }
     );
-  }
-  if (installResult.status !== 0) {
-    // RED-TEAM R2 P1-A: surface the actual exit value (could be null on
-    // ENOENT-during-execution, vs the early ENOENT branch above).
-    const exitDisplay = installResult.status ?? 'ENOENT';
-    throw new MysecondError(
-      6,
-      `claude plugin install ${pluginInstallSpec(slug)} failed (exit ${exitDisplay}). Re-run \`mysecond init\` or contact support@mysecond.ai.`
-    );
+    // ENOENT on the binary is fatal regardless of which plugin in the loop
+    // hit it — PATH issue affects every plugin install.
+    if (installResult.error !== undefined && (installResult.error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new MysecondError(
+        6,
+        "Cannot find 'claude' binary on PATH (between marketplace add + plugin install). Re-run `mysecond init` from the same shell where `which claude` works."
+      );
+    }
+    if (installResult.status !== 0) {
+      failedPlugins.push(plugin.name);
+      // Sentinel failure = hard stop. Without pm-companion-sync, the
+      // customer's PostToolUse + SessionStart hooks never fire and
+      // artifacts never sync to Companion — that's the core value prop.
+      if (plugin.name === SENTINEL_PLUGIN_NAME) {
+        const exitDisplay = installResult.status ?? 'ENOENT';
+        throw new MysecondError(
+          6,
+          `claude plugin install ${spec} failed (exit ${exitDisplay}). This is the launch-critical sync plugin; without it, your context files won't sync to mysecond.ai. Re-run \`mysecond init\` or contact support@mysecond.ai.`
+        );
+      }
+      // Non-sentinel failure: warn and continue. Customer's success box at
+      // step-13 reflects partial install via shared.failedPlugins.
+      if (!ctx.silent) {
+        process.stderr.write(
+          `  ⚠ skipped ${plugin.name} (claude plugin install exited ${installResult.status ?? 'ENOENT'})\n`
+        );
+      }
+    }
   }
 
-  // Post-install filesystem probe (CTO-8 carry — re-runs step 9 next
-  // invocation if plugin didn't actually land where we expect).
-  const probe = probeLayerOne(slug, meta.version);
+  // Surface partial-install state to step-13 for the success box.
+  if (failedPlugins.length > 0) {
+    shared.failedPlugins = failedPlugins;
+  }
+
+  // Post-install filesystem probe — verify the SENTINEL plugin landed where
+  // we expect (the launch-critical sync hooks). Other plugins are checked
+  // implicitly via the install-loop status codes above.
+  const probe = probeLayerOne(slug, meta.version, SENTINEL_PLUGIN_NAME);
   if (!probe.found) {
     throw new MysecondError(
       6,
-      `Plugin install reported success but ${marketplaceName(slug)}/pm-os/${meta.version} not in cache. Re-run \`mysecond init\` to retry.`
+      `Plugin install reported success but ${marketplaceName(slug)}/${SENTINEL_PLUGIN_NAME}/${meta.version} not in cache. Re-run \`mysecond init\` to retry.`
     );
   }
 
@@ -319,11 +370,27 @@ function tryFallback(
     rmSync(marketplaceTarget, { recursive: true, force: true });
     mkdirSync(marketplaceTarget, { recursive: true });
     // Copy the cached plugin tree into ./plugin/ + write a fresh marketplace.json.
-    cpSync(hit.source_dir, join(marketplaceTarget, 'plugin'), { recursive: true });
+    const restoredPluginDir = join(marketplaceTarget, 'plugin');
+    cpSync(hit.source_dir, restoredPluginDir, { recursive: true });
+
+    // Workstream B Day 5+: read PMO's manifest from the restored ./plugin/
+    // tree (mirrors step-9 main path) to populate the cli-side outer
+    // marketplace.json. Without this, the CTO-flagged fallback bug ships
+    // the legacy single `pm-os` shape and customers restored from LKG
+    // never get the multi-plugin install.
+    let plugins: PluginEntry[];
+    try {
+      plugins = listMarketplacePluginsFromExtractDir(restoredPluginDir);
+    } catch {
+      // LKG cache predates the multi-plugin manifest — can't restore safely
+      // without the plugins list. Treat as miss; main path will refetch
+      // (or surface its own error if network down too).
+      return null;
+    }
     mkdirSync(join(marketplaceTarget, '.claude-plugin'), { recursive: true });
     writeFileSync(
       marketplaceJsonPath(slug),
-      serializeMarketplaceJson(buildMarketplaceJson(slug))
+      serializeMarketplaceJson(buildMarketplaceJson(slug, plugins))
     );
 
     // Run marketplace add against the rehydrated dir (best-effort — if Claude
@@ -335,15 +402,23 @@ function tryFallback(
     );
     if (result.status !== 0) return null;
 
-    const installResult = spawnSync(
-      'claude',
-      ['plugin', 'install', pluginInstallSpec(slug), '--scope', 'user'],
-      { stdio: 'pipe' }
-    );
-    if (installResult.status !== 0) return null;
+    // Install loop over the LKG plugins. Same sentinel-fail-hard semantics
+    // as the main path: pm-companion-sync MUST install for fallback to count.
+    for (const plugin of plugins) {
+      const installResult = spawnSync(
+        'claude',
+        ['plugin', 'install', pluginInstallSpec(slug, plugin.name), '--scope', 'user'],
+        { stdio: 'pipe' }
+      );
+      if (installResult.status !== 0 && plugin.name === SENTINEL_PLUGIN_NAME) {
+        return null;
+      }
+      // Non-sentinel install failures during fallback are silent — customer
+      // is already in the degraded "stale cache" state and the banner explains.
+    }
 
-    // Probe for the cached version (which is what's now installed).
-    const probe = probeLayerOne(slug, hit.version);
+    // Probe for the cached version's sentinel plugin.
+    const probe = probeLayerOne(slug, hit.version, SENTINEL_PLUGIN_NAME);
     if (!probe.found) return null;
 
     return { version: hit.version, cachedAgeHours: hit.cached_age_hours };

--- a/src/lib/steps/step-9.ts
+++ b/src/lib/steps/step-9.ts
@@ -43,6 +43,7 @@ import {
 } from '../mysecond-paths.js';
 import { fetchAndExtractPlugin } from '../plugin-tarball.js';
 import { probeLayerOne } from '../plugin-load-detect.js';
+import { emitStatus } from '../silent-status.js';
 import { writeSyncState } from '../sync-state.js';
 
 import type { StepFn } from './types.js';
@@ -89,6 +90,10 @@ async function doStep9(
   shared: import('./types.js').StepContext['shared'],
   slug: string
 ): Promise<import('./types.js').StepResult> {
+  // Fix C Step 1: measure step-9 total wall-clock so we can see how much of
+  // the install time is actually consumed here. Emitted as step_9_total_timed
+  // at step end (silent mode) and logged to stderr (interactive mode).
+  const step9StartMs = performance.now();
   // Sub-step (a): fetch signed URL.
   let meta;
   try {
@@ -289,13 +294,41 @@ async function doStep9(
   // — other plugins may legitimately error out (corrupt sub-plugin, partial
   // marketplace) without breaking the customer's core sync flow.
   const failedPlugins: string[] = [];
-  for (const plugin of plugins) {
+  for (let pluginIdx = 0; pluginIdx < plugins.length; pluginIdx++) {
+    // plugins[] is bounded by the loop condition; the non-null assertion is safe.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const plugin = plugins[pluginIdx]!;
     const spec = pluginInstallSpec(slug, plugin.name);
+    // Fix C Step 1: per-plugin wall-clock measurement. We want to see
+    // which plugin(s) are slow before deciding whether to parallelize.
+    const pluginStartMs = performance.now();
     const installResult = spawnSync(
       'claude',
       ['plugin', 'install', spec, '--scope', 'user'],
       { stdio: ctx.silent ? 'pipe' : 'inherit' }
     );
+    const pluginDurationMs = Math.round(performance.now() - pluginStartMs);
+
+    // Fix C Step 1: emit per-plugin timing in silent mode.
+    emitStatus({
+      kind: 'plugin_install_timed',
+      plugin: plugin.name,
+      duration_ms: pluginDurationMs,
+      exit_code: installResult.status ?? -1,
+      plugin_index: pluginIdx,
+      plugin_total: plugins.length,
+    });
+
+    // Fix C Step 1: write progress to stderr in interactive mode so a
+    // terminal user can see real-time progress without contaminating the
+    // JSON event stream on stdout.
+    if (!ctx.silent) {
+      const durationSec = Math.round(pluginDurationMs / 1000);
+      process.stderr.write(
+        `[mysecond] Installed ${plugin.name} in ${durationSec}s (${pluginIdx + 1}/${plugins.length})\n`
+      );
+    }
+
     // ENOENT on the binary is fatal regardless of which plugin in the loop
     // hit it — PATH issue affects every plugin install.
     if (installResult.error !== undefined && (installResult.error as NodeJS.ErrnoException).code === 'ENOENT') {
@@ -351,6 +384,24 @@ async function doStep9(
   // Reset auth-thrash counter on success (CTO-v1.3-B3 critical).
   state.step9Auth401RetryCount = 0;
   writeSyncState(ctx.rootDir, state);
+
+  // Fix C Step 1: emit step-level total timing. Includes everything from
+  // signed-URL fetch through plugin probe — the full wall-clock the customer
+  // is waiting for. Emitted in silent mode as step_9_total_timed JSON event.
+  const step9DurationMs = Math.round(performance.now() - step9StartMs);
+  emitStatus({
+    kind: 'step_9_total_timed',
+    duration_ms: step9DurationMs,
+    plugin_count: plugins.length,
+    failed_count: failedPlugins.length,
+  });
+  // Also write to stderr in interactive mode so the terminal user can see
+  // the total plugin-install phase time without grepping stdout JSON.
+  if (!ctx.silent) {
+    process.stderr.write(
+      `[mysecond] Plugin install phase complete: ${plugins.length} plugins in ${Math.round(step9DurationMs / 1000)}s (${failedPlugins.length} failed)\n`
+    );
+  }
 
   return { step: 9, outcome: { kind: 'completed' } };
 }

--- a/src/lib/steps/types.ts
+++ b/src/lib/steps/types.ts
@@ -29,6 +29,12 @@ export interface StepContext {
     // Step 9 populates these from /plugin-tarball + extraction.
     pluginVersion?: string;
     pluginSha256?: string;
+    // Workstream B Day 5+: sub-plugin install loop (multi-plugin PMO
+    // marketplace) tracks any non-sentinel plugins whose `claude plugin
+    // install` exited non-zero. Sentinel (pm-companion-sync) failure is
+    // hard-fail; non-sentinel failures degrade gracefully and surface here
+    // for step-13 to acknowledge in the success box.
+    failedPlugins?: string[];
     // Step 9 stale-cache fallback signaling — runner uses this to print the
     // banner from §6.2.B after the success box.
     staleCacheUsed?: { cachedAgeHours: number };

--- a/src/lib/steps/types.ts
+++ b/src/lib/steps/types.ts
@@ -22,6 +22,10 @@ export interface StepContext {
     companyName?: string;
     customerSlug?: string;
     workspaceScope?: 'solo' | 'team';
+    // Step 15 populates from /whoami after device-code OAuth completes.
+    // Used by step-13 to emit the install_completed JSON status event with
+    // the customer's email in the message field.
+    userEmail?: string;
     // Step 9 populates these from /plugin-tarball + extraction.
     pluginVersion?: string;
     pluginSha256?: string;

--- a/tests/lib/marketplace-json.test.ts
+++ b/tests/lib/marketplace-json.test.ts
@@ -4,15 +4,22 @@ import {
   buildMarketplaceJson,
   serializeMarketplaceJson,
 } from '../../src/lib/marketplace-json.js';
+import type { PluginEntry } from '../../src/lib/mysecond-paths.js';
+
+const SAMPLE_PLUGINS: PluginEntry[] = [
+  { name: 'pm-companion-sync', source: './plugin/companion-sync' },
+  { name: 'pm-discovery', source: './plugin/discovery' },
+  { name: 'pm-strategy', source: './plugin/strategy' },
+];
 
 describe('marketplace-json', () => {
   it('builds canonical schema with mysecond-customer- prefix', () => {
-    const json = buildMarketplaceJson('acme-corp-a3f2');
+    const json = buildMarketplaceJson('acme-corp-a3f2', SAMPLE_PLUGINS);
     expect(json.name).toBe('mysecond-customer-acme-corp-a3f2');
   });
 
   it('includes required owner block per DV-1 verification', () => {
-    const json = buildMarketplaceJson('test');
+    const json = buildMarketplaceJson('test', SAMPLE_PLUGINS);
     expect(json.owner).toEqual({
       name: 'mySecond',
       email: 'support@mysecond.ai',
@@ -20,19 +27,30 @@ describe('marketplace-json', () => {
     });
   });
 
-  it('declares pm-os plugin with relative ./plugin source per §6.7b', () => {
-    const json = buildMarketplaceJson('test');
-    expect(json.plugins).toHaveLength(1);
-    expect(json.plugins[0]).toEqual({ name: 'pm-os', source: './plugin' });
+  it('passes plugins[] through unchanged (Workstream B Day 5+ multi-plugin)', () => {
+    // Previously this synthesized [{name: 'pm-os', source: './plugin'}]
+    // unconditionally — silently overwrote PMO's tarball-internal manifest.
+    // Now it's a passthrough wrapper; caller (step-9) reads PMO's manifest
+    // via listMarketplacePluginsFromExtractDir() and feeds it here.
+    const json = buildMarketplaceJson('test', SAMPLE_PLUGINS);
+    expect(json.plugins).toHaveLength(3);
+    expect(json.plugins).toEqual(SAMPLE_PLUGINS);
+  });
+
+  it('handles a single-plugin manifest (back-compat)', () => {
+    const single: PluginEntry[] = [{ name: 'pm-companion-sync', source: './plugin/companion-sync' }];
+    const json = buildMarketplaceJson('test', single);
+    expect(json.plugins).toEqual(single);
   });
 
   it('serializes with trailing newline + 2-space indent for stable diffs', () => {
-    const out = serializeMarketplaceJson(buildMarketplaceJson('test'));
+    const out = serializeMarketplaceJson(buildMarketplaceJson('test', SAMPLE_PLUGINS));
     expect(out.endsWith('\n')).toBe(true);
     // Should be valid JSON.
     expect(() => JSON.parse(out)).not.toThrow();
     // Should round-trip.
     const reparsed = JSON.parse(out);
     expect(reparsed.name).toBe('mysecond-customer-test');
+    expect(reparsed.plugins).toHaveLength(3);
   });
 });

--- a/tests/lib/mysecond-paths.test.ts
+++ b/tests/lib/mysecond-paths.test.ts
@@ -1,10 +1,14 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 import {
   installedPluginManifestPath,
+  listMarketplacePluginsFromExtractDir,
   isForbiddenProjectDir,
   marketplaceDir,
   marketplaceJsonPath,
@@ -45,12 +49,35 @@ describe('mysecond-paths (Decision 0-C cross-platform path handling)', () => {
     expect(marketplaceName('acme-a3f2')).toBe('mysecond-customer-acme-a3f2');
   });
 
-  it('pluginInstallSpec uses mysecond-customer- prefix per CAIO P0-2 fix', () => {
-    expect(pluginInstallSpec('acme-a3f2')).toBe('pm-os@mysecond-customer-acme-a3f2');
+  it('pluginInstallSpec uses mysecond-customer- prefix + parameterized plugin name (Workstream B Day 5+ multi-plugin)', () => {
+    expect(pluginInstallSpec('acme-a3f2', 'pm-companion-sync')).toBe(
+      'pm-companion-sync@mysecond-customer-acme-a3f2'
+    );
+    expect(pluginInstallSpec('acme-a3f2', 'pm-strategy')).toBe(
+      'pm-strategy@mysecond-customer-acme-a3f2'
+    );
   });
 
-  it('installedPluginManifestPath uses marketplace-name path segment per DV-2', () => {
-    // DV-2 captured: `~/.claude/plugins/cache/<marketplace-name>/pm-os/<version>/.claude-plugin/plugin.json`
+  it('installedPluginManifestPath uses marketplace-name + parameterized plugin segment (Workstream B Day 5+)', () => {
+    // DV-2 captured: `~/.claude/plugins/cache/<marketplace-name>/<plugin-name>/<version>/.claude-plugin/plugin.json`
+    // PMO restructured to multi-plugin marketplace; sentinel is now pm-companion-sync.
+    expect(installedPluginManifestPath('acme', '1.0.0', 'pm-companion-sync')).toBe(
+      join(
+        homedir(),
+        '.claude',
+        'plugins',
+        'cache',
+        'mysecond-customer-acme',
+        'pm-companion-sync',
+        '1.0.0',
+        '.claude-plugin',
+        'plugin.json'
+      )
+    );
+  });
+
+  it('installedPluginManifestPath defaults to sentinel plugin when name omitted', () => {
+    // Default arg = SENTINEL_PLUGIN_NAME = pm-companion-sync.
     expect(installedPluginManifestPath('acme', '1.0.0')).toBe(
       join(
         homedir(),
@@ -58,7 +85,7 @@ describe('mysecond-paths (Decision 0-C cross-platform path handling)', () => {
         'plugins',
         'cache',
         'mysecond-customer-acme',
-        'pm-os',
+        'pm-companion-sync',
         '1.0.0',
         '.claude-plugin',
         'plugin.json'
@@ -78,5 +105,88 @@ describe('mysecond-paths (Decision 0-C cross-platform path handling)', () => {
   it('isForbiddenProjectDir allows normal paths', () => {
     expect(isForbiddenProjectDir('/tmp/foo')).toBe(false);
     expect(isForbiddenProjectDir(join(homedir(), 'projects', 'my-pm-os'))).toBe(false);
+  });
+});
+
+describe('listMarketplacePluginsFromExtractDir (Workstream B Day 5+ multi-plugin)', () => {
+  // Each test creates a tmpdir, writes a fixture marketplace.json, and
+  // verifies the helper transforms PMO's source paths into the cli's
+  // outer marketplace dir layout.
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'mysecond-test-'));
+    mkdirSync(join(tmpRoot, '.claude-plugin'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('reads PMO manifest + transforms source paths to cli layout', () => {
+    writeFileSync(
+      join(tmpRoot, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'product-manager-os',
+        plugins: [
+          { name: 'pm-companion-sync', source: './companion-sync' },
+          { name: 'pm-discovery', source: './discovery' },
+        ],
+      })
+    );
+
+    const out = listMarketplacePluginsFromExtractDir(tmpRoot);
+    expect(out).toEqual([
+      { name: 'pm-companion-sync', source: './plugin/companion-sync' },
+      { name: 'pm-discovery', source: './plugin/discovery' },
+    ]);
+  });
+
+  it('handles source paths without leading ./', () => {
+    writeFileSync(
+      join(tmpRoot, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'product-manager-os',
+        plugins: [{ name: 'pm-foo', source: 'foo' }],
+      })
+    );
+
+    const out = listMarketplacePluginsFromExtractDir(tmpRoot);
+    expect(out).toEqual([{ name: 'pm-foo', source: './plugin/foo' }]);
+  });
+
+  it('throws if marketplace.json is missing', () => {
+    // No file written.
+    expect(() => listMarketplacePluginsFromExtractDir(tmpRoot)).toThrow();
+  });
+
+  it('throws if plugins[] is missing or empty', () => {
+    writeFileSync(
+      join(tmpRoot, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({ name: 'product-manager-os', plugins: [] })
+    );
+    expect(() => listMarketplacePluginsFromExtractDir(tmpRoot)).toThrow(/no plugins/);
+  });
+
+  it('throws if marketplace.json is malformed JSON', () => {
+    writeFileSync(join(tmpRoot, '.claude-plugin', 'marketplace.json'), 'not-json{');
+    expect(() => listMarketplacePluginsFromExtractDir(tmpRoot)).toThrow();
+  });
+
+  it('filters out malformed plugin entries (missing name or source)', () => {
+    writeFileSync(
+      join(tmpRoot, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'product-manager-os',
+        plugins: [
+          { name: 'pm-good', source: './good' },
+          { name: 'pm-no-source' }, // missing source
+          { source: './no-name' }, // missing name
+          null, // null entry
+        ],
+      })
+    );
+    const out = listMarketplacePluginsFromExtractDir(tmpRoot);
+    expect(out).toEqual([{ name: 'pm-good', source: './plugin/good' }]);
   });
 });

--- a/tests/lib/post-install-message.test.ts
+++ b/tests/lib/post-install-message.test.ts
@@ -21,7 +21,7 @@ describe('successBox: locked structure (May-2026 redesign)', () => {
       - Context sync hooks active for every Claude Code session
       - Your context files will be created in step 2 below
 
-      ALMOST THERE — close and reopen Claude Code to activate the plugin.
+      Install complete. Quit and reopen Claude Code to load mySecond.
 
       Then run /welcome in Claude Code. It takes about 5 minutes and sets up your context files for Acme Corp (company, product, personas, competitors, goals).
 

--- a/tests/lib/step-13.test.ts
+++ b/tests/lib/step-13.test.ts
@@ -106,7 +106,7 @@ describe('step-13: install_completed JSON status event', () => {
     expect(completed.message).toContain('Connected as: you');
   });
 
-  it('does not emit JSON to stdout when not in silent mode', async () => {
+  it('emits install_completed to stdout even in non-silent (interactive) mode', async () => {
     setSilentMode(false);
     const sctx = makeContext({
       silent: false,
@@ -116,12 +116,26 @@ describe('step-13: install_completed JSON status event', () => {
     });
     await step13(sctx);
 
-    // Non-silent: no JSON events emitted (silent-status no-ops).
-    const jsonLines = stdoutWrites.filter((s) => s.startsWith('{'));
-    expect(jsonLines).toHaveLength(0);
-    // The framed success box still prints though.
-    const allWrites = stdoutWrites.join('');
-    expect(allWrites).toContain('mySecond PM OS installed');
+    // install_completed must appear in stdout regardless of silentMode —
+    // it is the deterministic done-signal for the chat assistant.
+    const allOutput = stdoutWrites.join('');
+    const jsonLines = stdoutWrites.filter((s) => s.trim().startsWith('{'));
+    const events = jsonLines.map((line) => JSON.parse(line.trim()));
+    const completed = events.find(
+      (e: { kind?: string }) => e.kind === 'install_completed',
+    );
+    expect(completed).toBeTruthy();
+    expect(completed.mysecond_status_protocol_version).toBe(1);
+
+    // install_started must NOT appear in interactive mode (emitStatus is still
+    // silent-only — only install_completed bypasses the gate).
+    const started = events.find(
+      (e: { kind?: string }) => e.kind === 'install_started',
+    );
+    expect(started).toBeUndefined();
+
+    // The framed success box still prints in interactive mode.
+    expect(allOutput).toContain('mySecond PM OS installed');
   });
 
   it('still completes the step (returns kind: completed) regardless of email', async () => {

--- a/tests/lib/step-13.test.ts
+++ b/tests/lib/step-13.test.ts
@@ -84,6 +84,8 @@ describe('step-13: install_completed JSON status event', () => {
     expect(completed.agents_installed).toBe(6);
     expect(completed.workflows_installed).toBe(4);
     expect(completed.mysecond_status_protocol_version).toBe(1);
+    // Protocol contract: `at` must be an ISO 8601 timestamp.
+    expect(completed.at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
   it('falls back to "you" when shared.userEmail is missing', async () => {
@@ -126,6 +128,10 @@ describe('step-13: install_completed JSON status event', () => {
     );
     expect(completed).toBeTruthy();
     expect(completed.mysecond_status_protocol_version).toBe(1);
+    // Count fields must be wired on the non-silent path too.
+    expect(completed.skills_installed).toBe(91);
+    expect(completed.agents_installed).toBe(6);
+    expect(completed.workflows_installed).toBe(4);
 
     // install_started must NOT appear in interactive mode (emitStatus is still
     // silent-only — only install_completed bypasses the gate).

--- a/tests/lib/step-13.test.ts
+++ b/tests/lib/step-13.test.ts
@@ -1,0 +1,137 @@
+// Tests for step-13 — Workstream B Day 5+ Item 5B.
+//
+// Step 13 prints the framed success box AND emits the install_completed
+// JSON status event. This file pins the event content + shape.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { step13 } from '../../src/lib/steps/step-13.js';
+import { setSilentMode } from '../../src/lib/silent-status.js';
+import type { CommandContext } from '../../src/lib/context.js';
+import type { StepContext } from '../../src/lib/steps/types.js';
+
+function makeContext(opts: {
+  silent: boolean;
+  userEmail?: string;
+  pmName?: string;
+  companyName?: string;
+}): StepContext {
+  const ctx: CommandContext = {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'msd_test',
+    rootDir: '/tmp/test',
+    silent: opts.silent,
+    dryRun: false,
+    forceUpdate: false,
+    fix: false,
+    resume: false,
+    strategy: 'cloud-wins',
+  };
+  return {
+    ctx,
+    state: {} as never,
+    shared: {
+      pmName: opts.pmName,
+      companyName: opts.companyName,
+      userEmail: opts.userEmail,
+      pluginCounts: { skills: 91, agents: 6, workflows: 4 },
+    },
+  };
+}
+
+describe('step-13: install_completed JSON status event', () => {
+  let stdoutWrites: string[] = [];
+  let originalStdoutWrite: typeof process.stdout.write;
+
+  beforeEach(() => {
+    stdoutWrites = [];
+    originalStdoutWrite = process.stdout.write;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+      stdoutWrites.push(chunk.toString());
+      return true;
+    }) as any;
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalStdoutWrite;
+    setSilentMode(false);
+  });
+
+  it('emits install_completed event with installCompleteClaudeMessage(email) when email is known', async () => {
+    setSilentMode(true);
+    const sctx = makeContext({
+      silent: true,
+      userEmail: 'ron@mysecond.ai',
+      pmName: 'Ron',
+      companyName: 'mySecond',
+    });
+    await step13(sctx);
+
+    // Find the JSON-shaped install_completed event in stdout writes.
+    const jsonLines = stdoutWrites.filter((s) => s.startsWith('{'));
+    const events = jsonLines.map((line) => JSON.parse(line));
+    const completed = events.find(
+      (e: { kind?: string }) => e.kind === 'install_completed',
+    );
+
+    expect(completed).toBeTruthy();
+    expect(completed.message).toContain('## mySecond installed');
+    expect(completed.message).toContain('Connected as: ron@mysecond.ai');
+    expect(completed.message).toContain('/mysecond:welcome');
+    expect(completed.message).toContain('mysecond doctor');
+    expect(completed.skills_installed).toBe(91);
+    expect(completed.agents_installed).toBe(6);
+    expect(completed.workflows_installed).toBe(4);
+    expect(completed.mysecond_status_protocol_version).toBe(1);
+  });
+
+  it('falls back to "you" when shared.userEmail is missing', async () => {
+    setSilentMode(true);
+    const sctx = makeContext({
+      silent: true,
+      userEmail: undefined,
+      pmName: 'You',
+      companyName: 'your company',
+    });
+    await step13(sctx);
+
+    const jsonLines = stdoutWrites.filter((s) => s.startsWith('{'));
+    const events = jsonLines.map((line) => JSON.parse(line));
+    const completed = events.find(
+      (e: { kind?: string }) => e.kind === 'install_completed',
+    );
+
+    expect(completed).toBeTruthy();
+    expect(completed.message).toContain('Connected as: you');
+  });
+
+  it('does not emit JSON to stdout when not in silent mode', async () => {
+    setSilentMode(false);
+    const sctx = makeContext({
+      silent: false,
+      userEmail: 'ron@mysecond.ai',
+      pmName: 'Ron',
+      companyName: 'mySecond',
+    });
+    await step13(sctx);
+
+    // Non-silent: no JSON events emitted (silent-status no-ops).
+    const jsonLines = stdoutWrites.filter((s) => s.startsWith('{'));
+    expect(jsonLines).toHaveLength(0);
+    // The framed success box still prints though.
+    const allWrites = stdoutWrites.join('');
+    expect(allWrites).toContain('mySecond PM OS installed');
+  });
+
+  it('still completes the step (returns kind: completed) regardless of email', async () => {
+    setSilentMode(false);
+    const sctx = makeContext({
+      silent: true,
+      userEmail: undefined,
+    });
+    const result = await step13(sctx);
+    expect(result.outcome.kind).toBe('completed');
+    expect(result.step).toBe(13);
+  });
+});

--- a/tests/lib/step-5b.test.ts
+++ b/tests/lib/step-5b.test.ts
@@ -76,7 +76,9 @@ describe('step-5b — project-scoped credential write', () => {
       'credentials'
     );
     expect(existsSync(credsPath)).toBe(true);
-    expect(readFileSync(credsPath, 'utf8')).toBe(`COMPANION_API_KEY=${TEST_KEY}\n`);
+    expect(readFileSync(credsPath, 'utf8')).toBe(
+      `COMPANION_API_KEY=${TEST_KEY}\nCOMPANION_API_URL=https://app.mysecond.ai\n`
+    );
   });
 
   it('credential file is chmod 600', async () => {
@@ -118,7 +120,9 @@ describe('step-5b — project-scoped credential write', () => {
     // We don't strictly assert mtime didn't change (atomic-write rewrites
     // every time), but the test asserts no crash + content unchanged.
     expect(existsSync(credsPath)).toBe(true);
-    expect(readFileSync(credsPath, 'utf8')).toBe(`COMPANION_API_KEY=${TEST_KEY}\n`);
+    expect(readFileSync(credsPath, 'utf8')).toBe(
+      `COMPANION_API_KEY=${TEST_KEY}\nCOMPANION_API_URL=https://app.mysecond.ai\n`
+    );
   });
 
   it('drift case: project-scoped has DIFFERENT key — does NOT overwrite + warns', async () => {
@@ -136,6 +140,39 @@ describe('step-5b — project-scoped credential write', () => {
     // Warning was emitted to stderr.
     const warnings = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(warnings).toContain('different COMPANION_API_KEY');
+  });
+
+  it('T21: writes COMPANION_API_URL from ctx.apiBase override (staging)', async () => {
+    if (process.platform === 'win32') return;
+    const stagingUrl = 'https://staging-foo.example.com';
+    await step5b(makeStepCtx({ apiBase: stagingUrl }));
+
+    const credsPath = join(
+      tmpRoot,
+      '.mysecond',
+      'projects',
+      projectHash(projectDir),
+      'credentials'
+    );
+    const contents = readFileSync(credsPath, 'utf8');
+    expect(contents).toContain(`COMPANION_API_KEY=${TEST_KEY}`);
+    expect(contents).toContain(`COMPANION_API_URL=${stagingUrl}`);
+  });
+
+  it('T22: writes COMPANION_API_URL=prod default when ctx.apiBase is prod', async () => {
+    if (process.platform === 'win32') return;
+    await step5b(makeStepCtx());
+
+    const credsPath = join(
+      tmpRoot,
+      '.mysecond',
+      'projects',
+      projectHash(projectDir),
+      'credentials'
+    );
+    expect(readFileSync(credsPath, 'utf8')).toContain(
+      'COMPANION_API_URL=https://app.mysecond.ai'
+    );
   });
 });
 

--- a/tests/lib/step-5b.test.ts
+++ b/tests/lib/step-5b.test.ts
@@ -125,21 +125,60 @@ describe('step-5b — project-scoped credential write', () => {
     );
   });
 
-  it('drift case: project-scoped has DIFFERENT key — does NOT overwrite + warns', async () => {
+  it('key rotation: project-scoped has DIFFERENT key — DOES overwrite with new key + URL', async () => {
     if (process.platform === 'win32') return;
     const credsDir = join(tmpRoot, '.mysecond', 'projects', projectHash(projectDir));
     mkdirSync(credsDir, { recursive: true, mode: 0o700 });
     const credsPath = join(credsDir, 'credentials');
-    writeFileSync(credsPath, 'COMPANION_API_KEY=manually-edited-key\n', { mode: 0o600 });
+    writeFileSync(credsPath, 'COMPANION_API_KEY=old-key\n', { mode: 0o600 });
 
-    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
     await step5b(makeStepCtx());
 
-    // File still has the manually-edited value (no overwrite).
-    expect(readFileSync(credsPath, 'utf8')).toBe('COMPANION_API_KEY=manually-edited-key\n');
-    // Warning was emitted to stderr.
-    const warnings = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
-    expect(warnings).toContain('different COMPANION_API_KEY');
+    // File is rewritten with new key + URL. Decision 0044: skipping on key
+    // rotation left customers stuck on stale URLs.
+    expect(readFileSync(credsPath, 'utf8')).toBe(
+      `COMPANION_API_KEY=${TEST_KEY}\nCOMPANION_API_URL=https://app.mysecond.ai\n`
+    );
+    // Rotation message emitted to stdout (info-level, not warning).
+    const stdout = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(stdout).toContain('Rotated COMPANION_API_KEY');
+  });
+
+  it('T23: backfill — existing creds with matching key but no URL — adds URL', async () => {
+    if (process.platform === 'win32') return;
+    // Simulate installed-base customer: ran OLD CLI (pre-fix), creds file has
+    // only COMPANION_API_KEY=. Re-running init must backfill the URL line.
+    const credsDir = join(tmpRoot, '.mysecond', 'projects', projectHash(projectDir));
+    mkdirSync(credsDir, { recursive: true, mode: 0o700 });
+    const credsPath = join(credsDir, 'credentials');
+    writeFileSync(credsPath, `COMPANION_API_KEY=${TEST_KEY}\n`, { mode: 0o600 });
+
+    await step5b(makeStepCtx());
+
+    expect(readFileSync(credsPath, 'utf8')).toBe(
+      `COMPANION_API_KEY=${TEST_KEY}\nCOMPANION_API_URL=https://app.mysecond.ai\n`
+    );
+  });
+
+  it('T24: existing creds with stale URL — overwrites URL on re-init with different apiBase', async () => {
+    if (process.platform === 'win32') return;
+    // Customer first installed against staging, then re-inits against prod.
+    // New apiBase wins — they should not stay stuck on the stale URL.
+    const credsDir = join(tmpRoot, '.mysecond', 'projects', projectHash(projectDir));
+    mkdirSync(credsDir, { recursive: true, mode: 0o700 });
+    const credsPath = join(credsDir, 'credentials');
+    writeFileSync(
+      credsPath,
+      `COMPANION_API_KEY=${TEST_KEY}\nCOMPANION_API_URL=https://staging-old.example.com\n`,
+      { mode: 0o600 }
+    );
+
+    await step5b(makeStepCtx({ apiBase: 'https://prod-new.example.com' }));
+
+    expect(readFileSync(credsPath, 'utf8')).toBe(
+      `COMPANION_API_KEY=${TEST_KEY}\nCOMPANION_API_URL=https://prod-new.example.com\n`
+    );
   });
 
   it('T21: writes COMPANION_API_URL from ctx.apiBase override (staging)', async () => {

--- a/tests/lib/step-timing.test.ts
+++ b/tests/lib/step-timing.test.ts
@@ -1,0 +1,297 @@
+// Fix C Step 1 — timing instrumentation tests.
+//
+// Two coverage strategies:
+//
+// 1. STRUCTURAL (step-9): step-9's install loop has too many heavy dependencies
+//    (signed-URL fetch, tarball extract, filesystem ops, marketplace lock) to
+//    unit-test the full step without a large mock surface. We use the same
+//    structural approach as step-9-counter-reset.test.ts — read the source,
+//    assert the timing patterns are present in every required call site.
+//    This is the right trade-off: a structural test catches refactor-regressions
+//    without the fragility of mocking 8+ external modules.
+//
+// 2. BEHAVIORAL (step-15): step-15's runDeviceCodeFlow is simpler — two async
+//    function calls (requestDeviceCode + pollForToken) with no filesystem ops.
+//    We can vi.mock the device-code module to control timing and assert that
+//    emitStatus receives the correct timing events.
+//
+// Both tests verify the "emitted in silent mode / written to stderr in
+// non-silent mode" contract required by Fix C Step 1.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── Paths ────────────────────────────────────────────────────────────────────
+
+const STEP9_PATH = join(import.meta.dirname ?? __dirname, '..', '..', 'src', 'lib', 'steps', 'step-9.ts');
+const STEP15_PATH = join(import.meta.dirname ?? __dirname, '..', '..', 'src', 'lib', 'steps', 'step-15.ts');
+
+// ─── Part 1: Structural assertions for step-9 ────────────────────────────────
+
+describe('Fix C Step 1 — step-9 structural timing assertions', () => {
+  const source = readFileSync(STEP9_PATH, 'utf8');
+
+  it('imports emitStatus from silent-status.js', () => {
+    expect(source).toContain("import { emitStatus } from '../silent-status.js'");
+  });
+
+  it('records step-9 start time before the install loop', () => {
+    // Must call performance.now() before the for loop begins.
+    // The variable name is step9StartMs per the implementation.
+    expect(source).toContain('const step9StartMs = performance.now()');
+  });
+
+  it('emits plugin_install_timed event with required fields per plugin', () => {
+    expect(source).toContain("kind: 'plugin_install_timed'");
+    expect(source).toContain('plugin: plugin.name');
+    expect(source).toContain('duration_ms: pluginDurationMs');
+    expect(source).toContain('exit_code:');
+    expect(source).toContain('plugin_index:');
+    expect(source).toContain('plugin_total:');
+  });
+
+  it('measures per-plugin duration as Math.round(performance.now() - pluginStartMs)', () => {
+    expect(source).toContain('const pluginStartMs = performance.now()');
+    expect(source).toContain('const pluginDurationMs = Math.round(performance.now() - pluginStartMs)');
+  });
+
+  it('emits step_9_total_timed event with required fields', () => {
+    expect(source).toContain("kind: 'step_9_total_timed'");
+    expect(source).toContain('duration_ms: step9DurationMs');
+    expect(source).toContain('plugin_count:');
+    expect(source).toContain('failed_count:');
+  });
+
+  it('writes stderr progress line per plugin in non-silent mode', () => {
+    // The stderr line uses ctx.silent guard and the format:
+    // [mysecond] Installed <plugin> in <N>s (<i+1>/<total>)
+    expect(source).toContain('process.stderr.write');
+    expect(source).toContain('[mysecond] Installed');
+    expect(source).toContain('plugin.name');
+    // Timing in seconds (not ms) for human readability.
+    expect(source).toContain('durationSec');
+  });
+
+  it('stderr progress line is inside !ctx.silent guard', () => {
+    // The [mysecond] Installed ... stderr write must be inside a silent check.
+    // Verify by looking for the guard pattern close to the write.
+    const installedLineBlock = source.match(
+      /if \(!ctx\.silent\)\s*\{[\s\S]{0,200}?\[mysecond\] Installed/
+    );
+    expect(installedLineBlock).not.toBeNull();
+  });
+
+  it('emits plugin_install_timed BEFORE checking ENOENT / failure (measurement even on error)', () => {
+    // The emitStatus call must come before the ENOENT check so we capture
+    // timing data even when the install fails.
+    const emojiPos = source.indexOf("kind: 'plugin_install_timed'");
+    const enoentPos = source.indexOf("Cannot find 'claude' binary on PATH (between marketplace add");
+    expect(emojiPos).toBeGreaterThan(0);
+    expect(enoentPos).toBeGreaterThan(0);
+    expect(emojiPos).toBeLessThan(enoentPos);
+  });
+
+  it('emits step_9_total_timed BEFORE the final return (not after)', () => {
+    // Total timing is emitted just before `return { step: 9, outcome: ... }`.
+    const totalPos = source.indexOf("kind: 'step_9_total_timed'");
+    const finalReturnPos = source.lastIndexOf("return { step: 9, outcome: { kind: 'completed' } };");
+    expect(totalPos).toBeGreaterThan(0);
+    expect(finalReturnPos).toBeGreaterThan(0);
+    expect(totalPos).toBeLessThan(finalReturnPos);
+  });
+});
+
+// ─── Part 2: Structural assertions for step-15 ───────────────────────────────
+
+describe('Fix C Step 1 — step-15 structural timing assertions', () => {
+  const source = readFileSync(STEP15_PATH, 'utf8');
+
+  it('measures device-code mint wall-clock', () => {
+    expect(source).toContain('const mintStartMs = performance.now()');
+    expect(source).toContain('const mintDurationMs = Math.round(performance.now() - mintStartMs)');
+  });
+
+  it('emits device_code_minted_timed event with duration_ms', () => {
+    expect(source).toContain("kind: 'device_code_minted_timed'");
+    expect(source).toContain('duration_ms: mintDurationMs');
+  });
+
+  it('emits device_code_minted_timed AFTER requestDeviceCode resolves', () => {
+    // mintDurationMs must be set after requestDeviceCode returns.
+    const mintDurationPos = source.indexOf('const mintDurationMs = Math.round');
+    const requestPos = source.indexOf('codeResp = await requestDeviceCode(codeOpts)');
+    expect(mintDurationPos).toBeGreaterThan(requestPos);
+  });
+
+  it('measures token-poll wall-clock', () => {
+    expect(source).toContain('const pollStartMs = performance.now()');
+    expect(source).toContain('const pollDurationMs = Math.round(performance.now() - pollStartMs)');
+  });
+
+  it('emits device_authorized_timed event with duration_ms', () => {
+    expect(source).toContain("kind: 'device_authorized_timed'");
+    expect(source).toContain('duration_ms: pollDurationMs');
+  });
+
+  it('emits device_authorized_timed AFTER pollForToken resolves', () => {
+    const pollDurationPos = source.indexOf('const pollDurationMs = Math.round');
+    const pollTokenPos = source.indexOf('tokenResp = await pollForToken(');
+    expect(pollDurationPos).toBeGreaterThan(pollTokenPos);
+  });
+});
+
+// ─── Part 3: Behavioral — emitStatus receives plugin_install_timed in silent mode ──
+
+// We test the emit behavior without running step-9's full machinery by
+// directly testing that emitStatus in silent mode writes to stdout.
+// This validates the protocol contract without needing to mock 8+ modules.
+
+describe('Fix C Step 1 — emitStatus writes plugin_install_timed to stdout in silent mode', () => {
+  let stdoutWrites: string[] = [];
+  let stderrWrites: string[] = [];
+  let originalStdoutWrite: typeof process.stdout.write;
+  let originalStderrWrite: typeof process.stderr.write;
+
+  beforeEach(async () => {
+    stdoutWrites = [];
+    stderrWrites = [];
+    originalStdoutWrite = process.stdout.write;
+    originalStderrWrite = process.stderr.write;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = (chunk: string | Uint8Array): boolean => {
+      stdoutWrites.push(chunk.toString());
+      return true;
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stderr as any).write = (chunk: string | Uint8Array): boolean => {
+      stderrWrites.push(chunk.toString());
+      return true;
+    };
+  });
+
+  afterEach(async () => {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    // Reset silent mode to false after each test.
+    const { setSilentMode } = await import('../../src/lib/silent-status.js');
+    setSilentMode(false);
+  });
+
+  it('emitStatus writes plugin_install_timed JSON to stdout in silent mode', async () => {
+    const { setSilentMode, emitStatus } = await import('../../src/lib/silent-status.js');
+    setSilentMode(true);
+
+    emitStatus({
+      kind: 'plugin_install_timed',
+      plugin: 'pm-strategy',
+      duration_ms: 42000,
+      exit_code: 0,
+      plugin_index: 3,
+      plugin_total: 13,
+    });
+
+    const jsonLines = stdoutWrites.filter((s) => s.trim().startsWith('{'));
+    expect(jsonLines.length).toBeGreaterThanOrEqual(1);
+    const event = JSON.parse(jsonLines[0]);
+    expect(event.kind).toBe('plugin_install_timed');
+    expect(event.plugin).toBe('pm-strategy');
+    expect(event.duration_ms).toBe(42000);
+    expect(event.exit_code).toBe(0);
+    expect(event.plugin_index).toBe(3);
+    expect(event.plugin_total).toBe(13);
+    expect(event.mysecond_status_protocol_version).toBe(1);
+    expect(event.at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('emitStatus writes step_9_total_timed JSON to stdout in silent mode', async () => {
+    const { setSilentMode, emitStatus } = await import('../../src/lib/silent-status.js');
+    setSilentMode(true);
+
+    emitStatus({
+      kind: 'step_9_total_timed',
+      duration_ms: 540000,
+      plugin_count: 13,
+      failed_count: 0,
+    });
+
+    const jsonLines = stdoutWrites.filter((s) => s.trim().startsWith('{'));
+    expect(jsonLines.length).toBeGreaterThanOrEqual(1);
+    const event = JSON.parse(jsonLines[0]);
+    expect(event.kind).toBe('step_9_total_timed');
+    expect(event.duration_ms).toBe(540000);
+    expect(event.plugin_count).toBe(13);
+    expect(event.failed_count).toBe(0);
+  });
+
+  it('emitStatus does NOT write to stdout for plugin_install_timed in non-silent mode', async () => {
+    const { setSilentMode, emitStatus } = await import('../../src/lib/silent-status.js');
+    setSilentMode(false);
+
+    emitStatus({
+      kind: 'plugin_install_timed',
+      plugin: 'pm-strategy',
+      duration_ms: 42000,
+      exit_code: 0,
+      plugin_index: 0,
+      plugin_total: 1,
+    });
+
+    const jsonLines = stdoutWrites.filter((s) => s.trim().startsWith('{'));
+    expect(jsonLines.length).toBe(0);
+  });
+
+  it('emitStatus writes device_code_minted_timed JSON to stdout in silent mode', async () => {
+    const { setSilentMode, emitStatus } = await import('../../src/lib/silent-status.js');
+    setSilentMode(true);
+
+    emitStatus({
+      kind: 'device_code_minted_timed',
+      duration_ms: 320,
+    });
+
+    const jsonLines = stdoutWrites.filter((s) => s.trim().startsWith('{'));
+    expect(jsonLines.length).toBeGreaterThanOrEqual(1);
+    const event = JSON.parse(jsonLines[0]);
+    expect(event.kind).toBe('device_code_minted_timed');
+    expect(event.duration_ms).toBe(320);
+  });
+
+  it('emitStatus writes device_authorized_timed JSON to stdout in silent mode', async () => {
+    const { setSilentMode, emitStatus } = await import('../../src/lib/silent-status.js');
+    setSilentMode(true);
+
+    emitStatus({
+      kind: 'device_authorized_timed',
+      duration_ms: 18500,
+    });
+
+    const jsonLines = stdoutWrites.filter((s) => s.trim().startsWith('{'));
+    expect(jsonLines.length).toBeGreaterThanOrEqual(1);
+    const event = JSON.parse(jsonLines[0]);
+    expect(event.kind).toBe('device_authorized_timed');
+    expect(event.duration_ms).toBe(18500);
+  });
+});
+
+// ─── Part 4: Behavioral — stderr progress lines in non-silent mode ────────────
+
+describe('Fix C Step 1 — step-9 stderr progress line format (structural)', () => {
+  const source = readFileSync(STEP9_PATH, 'utf8');
+
+  it('stderr format matches expected grep pattern: [mysecond] Installed <name> in <N>s (<i>/<total>)', () => {
+    // Verify the template literal produces the right shape.
+    // We check the format parts are present in a single stderr.write call.
+    const stderrBlock = source.match(
+      /process\.stderr\.write\(\s*`\[mysecond\] Installed \$\{plugin\.name\} in \$\{.*?\}s \(\$\{.*?\}\/\$\{.*?\}\)/
+    );
+    expect(stderrBlock).not.toBeNull();
+  });
+
+  it('step_9_total_timed stderr line matches expected grep pattern', () => {
+    expect(source).toContain('[mysecond] Plugin install phase complete:');
+    expect(source).toContain('plugins in');
+    expect(source).toContain('failed)');
+  });
+});


### PR DESCRIPTION
## What this PR does

Adds **device-code OAuth** to the cli (Workstream B Phase 2a). Replaces the API-key-paste install flow with browser-based authorization. Customer pastes `npx -y @mysecond/cli@1.4.0 init` (no key, no slug-leaking-key). cli prints an 8-character code, opens browser, customer types code on the page, clicks Authorize, cli receives a long-lived bearer token and persists it to the OS keychain (file fallback for Linux/CI/Windows).

**Companion PR:** [`mysecond-app` → feat/device-code-oauth](https://github.com/mysecond-ai/mysecond-app/pull/NEW). App PR ships the endpoints; this PR (cli) consumes them.

## Version

**v1.3.8 → v1.4.0** (minor — new auth feature; H's v1.3.8 already on npm `@latest`).

## New surface

| Module | Purpose |
|---|---|
| `src/lib/keychain.ts` | OS-aware token storage. macOS via `security` shell-out (token via stdin, never `ps aux`-visible). File fallback at `~/.mysecond/projects/<hash>/credentials` mode 0600. Round-trip verification per CTO Day 1 stop condition. |
| `src/lib/device-code.ts` | OAuth client. Polls `/device/token` at server-provided `interval_seconds` with **540s hard cap** (10% safety under Anthropic's 600s hook reaper per CAIO #9). Prints URL to stdout BEFORE attempting browser open (CAIO #10 — chat is the deterministic surface). |
| `src/lib/silent-status.ts` | Structured JSON `--silent` status protocol. Field name `mysecond_status_protocol_version: 1` (NOT `schema_version` — would collide with Anthropic reserved hook fields per CAIO #5). Fallback `status_emit_failed` event when JSON.stringify fails. |
| `src/lib/steps/step-15.ts` | New init step (slot 15, runs FIRST in array order). Idempotent contract: existing token → /whoami validate → fall through if rejected; `--resume` → revoke + clearDeviceToken + fresh device-code flow. |
| `src/commands/doctor.ts` | New `mysecond doctor` 3-state diagnostic (CAIO #8): `not installed` / `install incomplete` / `installed` (pings /whoami). |
| `--resume` flag | Re-run device-code OAuth on a partial install. Calls `/api/companion/device/revoke` first to invalidate the old token before minting a new one (red-team P0-4). |

## Locked decisions per the brief

- **No `keytar`** — native build deps fragile. macOS uses `security` shell-out; Windows + Linux + CI/Docker use file fallback.
- **Windows Credential Manager → Phase 2b.**
- **`mysecond doctor --json` → Phase 2b.**
- **No `mysecond check-path` PreToolUse hook** (Workstream G defense-in-depth dropped as overengineering).

## Review coverage (all findings applied)

| Pass | Findings | Resolution |
|---|---|---|
| CTO+CISO Day 1 (formal) | 4 P1s | ✅ all (b13022e — schema corrections to migrations) |
| CISO Days 2-3 interim | 1 P1 (`security` token in `ps aux`) | ✅ stdin pattern (06af155) |
| **Codex pass 1** | P0/P1s | ✅ all (136941c) |
| CAIO Day 4 PM (formal) | claudeMdBlock + JSON protocol | ✅ all (e3612da, e160656) |
| CXO Day 4 PM (formal) | UX rewrites | ✅ applied |
| **Codex pass 2** | 2 P1s | ✅ all (21d5ddb — clearDeviceToken after revoke + status_emit_failed fallback) |

## Pre-push gates

- ✅ `npm run typecheck` clean
- ✅ `npm run build` emits `dist/mysecond.mjs` (~126kb)
- ✅ All 236 tests passing

## Manual verification (Ron, today)

End-to-end full-loop test against the production-equivalent Vercel preview deploy succeeded:
- Mint → authorize → exchange → bearer-auth `/whoami` round-trip all green
- Real `msd_`-prefixed token issued, real team_id + user_id bound

## Known issues / Phase 2b

- Windows keychain (file fallback at 2a)
- `whereami` keychain-aware evolution
- `doctor --json` flag
- `forward-compat.md` note: `NotebookEdit` PostToolUse matcher when Anthropic ships it (per CAIO Day 4 — explicitly skipped in `plugin.json` until documented; the previous "speculative hedge" pattern was rejected per the lesson from invented `triggers` field that broke 62 skills)

## Coordination with app PR

Order: **app PR merges first**, then this cli PR.

Why: the cli's step-15 calls new endpoints (`/device/code`, `/device/token`, `/device/revoke`, `/whoami`) that don't exist until the app deploys. cli works against the legacy companion_api_key path during the rollout window via `validateCompanionApiKey`'s prefix dispatch.

After app deploys + this cli ships to npm, customer install commands change:
- Before: `COMPANION_API_KEY=msd_xxx MYSECOND_CUSTOMER_SLUG=... npx -y @mysecond/cli init`
- After: `MYSECOND_CUSTOMER_SLUG=... npx -y @mysecond/cli@1.4.0 init` (no API_KEY pre-fill — device-code authorization replaces it)

Update post-checkout email template to drop the `COMPANION_API_KEY=` env-var prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
