### PR TITLE
fix(cli): v1.4.1 — sentinel + copy fixes (CLI-1..5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -48,7 +48,7 @@ export class MysecondError extends Error {
   static invalidApiKey(detail?: string): MysecondError {
     return new MysecondError(
       1,
-      `Invalid API key. Get a new one at https://mysecond.ai/activate/complete${detail ? ` (${detail})` : ''}.`,
+      `Invalid API key. Run \`mysecond init\` to re-authorize. If this persists, contact support@mysecond.ai${detail ? ` (${detail})` : ''}.`,
       { subCode: 'invalid_key' }
     );
   }

--- a/src/lib/mysecond-paths.ts
+++ b/src/lib/mysecond-paths.ts
@@ -71,11 +71,14 @@ export function marketplaceName(slug: string): string {
 
 /**
  * Sentinel plugin name used by post-install Layer 1 probe.
- * `pm-companion-sync` carries the SessionStart + PostToolUse hooks that
- * sync customer artifacts into Companion — if it didn't land in the cache,
- * the install is functionally broken even if other plugins look fine.
+ * `pm-os` is the single plugin shipped today. The probe verifies its
+ * cache directory landed, but the install command's exit code is the
+ * authoritative signal — probe failures log informationally and do not
+ * abort install. (Historical: prior to single-plugin consolidation,
+ * the sentinel was `pm-companion-sync` to verify the SECOND plugin
+ * landed in a multi-plugin install.)
  */
-export const SENTINEL_PLUGIN_NAME = 'pm-companion-sync';
+export const SENTINEL_PLUGIN_NAME = 'pm-os';
 
 /** Single plugin entry in a marketplace.json `plugins[]` array. */
 export interface PluginEntry {

--- a/src/lib/plugin-load-detect.ts
+++ b/src/lib/plugin-load-detect.ts
@@ -6,9 +6,9 @@
 // `~/.claude/plugins/cache/<marketplace-name>/<plugin-name>/<version>/.claude-plugin/plugin.json`.
 // `<version>` is wildcard-globbed when caller doesn't know the exact version.
 //
-// Workstream B Day 5+: parameterized on `pluginName` (was hardcoded `pm-os`).
-// PMO is now a multi-plugin marketplace; the launch-critical sentinel is
-// `pm-companion-sync` (carries the SessionStart + PostToolUse hooks).
+// Workstream B Day 5+: parameterized on `pluginName` (defaults to the sentinel).
+// The launch-critical sentinel plugin is `pm-os` (see SENTINEL_PLUGIN_NAME);
+// it carries the SessionStart + PostToolUse hooks.
 
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
@@ -27,9 +27,9 @@ export type LayerOneResult =
 // exact path; otherwise glob under the parent dir for any version subdir
 // containing `.claude-plugin/plugin.json`.
 //
-// `pluginName` defaults to the sentinel (pm-companion-sync) — verifying its
-// presence is the load-bearing health check because it owns the sync hooks.
-// Other plugins can be probed by passing their name explicitly.
+// `pluginName` defaults to the sentinel (`pm-os`) — verifying its presence is
+// the load-bearing health check because it owns the sync hooks. Other plugins
+// can be probed by passing their name explicitly.
 export function probeLayerOne(
   slug: string,
   version: string | null = null,

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -198,16 +198,21 @@ async function runDeviceCodeFlow(
   // The trailing \n explicitly flushes the pipe.
   // "Waiting for authorization..." stays on stdout — lower urgency, fine
   // to buffer.
+  // Day 5+ CLI-4: render the verification URL as a Markdown bare link
+  // ([url](url)) on its own line. This format survives Claude Code Desktop
+  // chat summarization where bare URLs in code blocks otherwise get
+  // collapsed/dropped. CISO decision (mysecond-app
+  // src/app/api/companion/device/code/route.ts:95-103): user_code MUST NOT
+  // be embedded in the URL — code is transferred manually by the customer.
   if (!ctx.silent) {
     process.stderr.write(
       [
         '',
-        'mySecond needs to authorize this device in your browser.',
+        'Authorize this device:',
         '',
-        `  Code:  ${codeResp.user_code}    ← copy this`,
-        `  Open:  ${codeResp.verification_uri_complete}`,
+        `    [${codeResp.verification_uri}](${codeResp.verification_uri})`,
         '',
-        'Type the code in the browser, then click Authorize.',
+        `Code: ${codeResp.user_code} (type into the page)`,
         '',
       ].join('\n') + '\n'
     );

--- a/src/lib/steps/step-9.ts
+++ b/src/lib/steps/step-9.ts
@@ -286,13 +286,11 @@ async function doStep9(
     );
   }
 
-  // Install loop over all sub-plugins from PMO's marketplace (Workstream B
-  // Day 5+). Previously single-shot `claude plugin install pm-os@<m>` which
-  // silently no-op'd against PMO's multi-plugin layout. Now iterates the
-  // plugins[] read from PMO's manifest above. Tracks failures; hard-fails
-  // ONLY if the launch-critical sentinel (`pm-companion-sync`) doesn't land
-  // — other plugins may legitimately error out (corrupt sub-plugin, partial
-  // marketplace) without breaking the customer's core sync flow.
+  // Install loop over all sub-plugins from PMO's marketplace. Today
+  // there's only one plugin (`pm-os`); the loop is preserved for the
+  // multi-plugin future. Tracks failures; hard-fails on the sentinel
+  // (`pm-os` itself) since that's the entire install — non-sentinel
+  // failures degrade gracefully.
   const failedPlugins: string[] = [];
   for (let pluginIdx = 0; pluginIdx < plugins.length; pluginIdx++) {
     // plugins[] is bounded by the loop condition; the non-null assertion is safe.
@@ -339,14 +337,14 @@ async function doStep9(
     }
     if (installResult.status !== 0) {
       failedPlugins.push(plugin.name);
-      // Sentinel failure = hard stop. Without pm-companion-sync, the
-      // customer's PostToolUse + SessionStart hooks never fire and
-      // artifacts never sync to Companion — that's the core value prop.
+      // Single-plugin era: `claude plugin install` exit code is the
+      // authoritative signal. A non-zero exit on the only plugin (`pm-os`)
+      // means the install genuinely failed — surface a clear error.
       if (plugin.name === SENTINEL_PLUGIN_NAME) {
         const exitDisplay = installResult.status ?? 'ENOENT';
         throw new MysecondError(
           6,
-          `claude plugin install ${spec} failed (exit ${exitDisplay}). This is the launch-critical sync plugin; without it, your context files won't sync to mysecond.ai. Re-run \`mysecond init\` or contact support@mysecond.ai.`
+          `claude plugin install ${spec} failed (exit ${exitDisplay}). Re-run \`mysecond init\` or contact support@mysecond.ai.`
         );
       }
       // Non-sentinel failure: warn and continue. Customer's success box at
@@ -364,17 +362,16 @@ async function doStep9(
     shared.failedPlugins = failedPlugins;
   }
 
-  // Post-install filesystem probe — verify the SENTINEL plugin landed where
-  // we expect (the launch-critical sync hooks). Other plugins are checked
-  // implicitly via the install-loop status codes above.
-  // Pass null for version so we match by plugin name only — Claude Code
-  // installs at its own version (e.g. 1.0.0 from plugin.json) which differs
-  // from the regen-timestamp version in meta. Any installed version passes.
+  // Post-install filesystem probe — informational only. The install
+  // command's exit code (checked above) is the authoritative success
+  // signal. The probe is best-effort verification that pm-os landed in
+  // the cache directory we expect; if it doesn't (different cache path,
+  // version mismatch, race), we log to stderr and continue. Throwing
+  // here previously false-alarmed with exit 6 even on healthy installs.
   const probe = probeLayerOne(slug, null, SENTINEL_PLUGIN_NAME);
-  if (!probe.found) {
-    throw new MysecondError(
-      6,
-      `Plugin install reported success but ${marketplaceName(slug)}/${SENTINEL_PLUGIN_NAME} not found in cache. Re-run \`mysecond init\` to retry.`
+  if (!probe.found && !ctx.silent) {
+    process.stderr.write(
+      `[mysecond] note: plugin cache probe for ${marketplaceName(slug)}/${SENTINEL_PLUGIN_NAME} did not match — install reported success, continuing.\n`
     );
   }
 
@@ -457,7 +454,7 @@ function tryFallback(
     if (result.status !== 0) return null;
 
     // Install loop over the LKG plugins. Same sentinel-fail-hard semantics
-    // as the main path: pm-companion-sync MUST install for fallback to count.
+    // as the main path: `pm-os` MUST install for fallback to count.
     for (const plugin of plugins) {
       const installResult = spawnSync(
         'claude',

--- a/src/lib/steps/types.ts
+++ b/src/lib/steps/types.ts
@@ -31,7 +31,7 @@ export interface StepContext {
     pluginSha256?: string;
     // Workstream B Day 5+: sub-plugin install loop (multi-plugin PMO
     // marketplace) tracks any non-sentinel plugins whose `claude plugin
-    // install` exited non-zero. Sentinel (pm-companion-sync) failure is
+    // install` exited non-zero. Sentinel (pm-os) failure is
     // hard-fail; non-sentinel failures degrade gracefully and surface here
     // for step-13 to acknowledge in the success box.
     failedPlugins?: string[];

--- a/tests/lib/mysecond-paths.test.ts
+++ b/tests/lib/mysecond-paths.test.ts
@@ -77,7 +77,7 @@ describe('mysecond-paths (Decision 0-C cross-platform path handling)', () => {
   });
 
   it('installedPluginManifestPath defaults to sentinel plugin when name omitted', () => {
-    // Default arg = SENTINEL_PLUGIN_NAME = pm-companion-sync.
+    // Default arg = SENTINEL_PLUGIN_NAME = pm-os (single-plugin era).
     expect(installedPluginManifestPath('acme', '1.0.0')).toBe(
       join(
         homedir(),
@@ -85,7 +85,7 @@ describe('mysecond-paths (Decision 0-C cross-platform path handling)', () => {
         'plugins',
         'cache',
         'mysecond-customer-acme',
-        'pm-companion-sync',
+        'pm-os',
         '1.0.0',
         '.claude-plugin',
         'plugin.json'


### PR DESCRIPTION
## v1.4.1 — patch fixing canary findings

Five fixes bundled into one publish:

**CLI-1 + CLI-2**: SENTINEL_PLUGIN_NAME stale (`pm-companion-sync` → `pm-os`); sentinel miss now logs informational stderr and exits 0 instead of throwing exit 6. Single-plugin install no longer false-alarms on every run.

**CLI-3**: Removed "non-fatal warning" copy. Either succeed cleanly or fail clearly. No middle-ground soft warnings.

**CLI-4**: Device-auth URL output reformatted as Markdown bare-URL on its own line, surviving Claude Code Desktop chat summarization. Code stays manual-typed (CISO decision against URL-embedded codes preserved).

**CLI-5**: 401 error message updated. Was: "Get a new one at /activate/complete" (stale URL). Now: "Run \`mysecond init\` to re-authorize."

## Test plan
- [ ] Local install via npm pack snapshot: \`npm pack && npm install -g ./mysecond-cli-1.4.1.tgz && mysecond init\` in fresh folder
- [ ] Verify exit 0 on success
- [ ] Grep terminal output for "non-fatal" — must not appear
- [ ] Trigger 401 via revoked device → confirm new error copy
- [ ] Run install via Claude Code Desktop chat → verify URL preserved in summary