### PR TITLE
fix(cli): exclude index.md from context-file sync (PMO-4)

### DIFF
--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -126,6 +126,12 @@ export const CONTEXT_DIR = 'context';
 // Server PER_FILE_LIMIT is 50KB. Pre-filter to skip wasted round-trips.
 export const CONTEXT_PER_FILE_LIMIT = 50 * 1024;
 
+// Filenames under context/ that are auto-generated metadata, not real context
+// files. These must not sync to context_files. PMO-4: `index.md` is generated
+// by various tools as a directory listing/index — treating it as user-edited
+// context pollutes the server-side context_files table.
+const EXCLUDED_CONTEXT_FILENAMES = new Set<string>(['index.md']);
+
 // Classify a write event's file path as a context file. Same path-safety
 // gate as classifyArtifactType — leading '/', traversal, absolute paths
 // rejected. Only `.md` files under `context/` qualify; nested paths
@@ -138,7 +144,15 @@ export const CONTEXT_PER_FILE_LIMIT = 50 * 1024;
 export function isContextFile(relativePath: string): boolean {
   if (relativePath.startsWith('/') || relativePath.includes('..')) return false;
   if (!relativePath.toLowerCase().startsWith(CONTEXT_DIR + '/')) return false;
-  return relativePath.toLowerCase().endsWith('.md');
+  if (!relativePath.toLowerCase().endsWith('.md')) return false;
+
+  // PMO-4: filter auto-generated index files; they're metadata, not context.
+  const filename = relativePath.split('/').pop()?.toLowerCase();
+  if (filename !== undefined && EXCLUDED_CONTEXT_FILENAMES.has(filename)) {
+    return false;
+  }
+
+  return true;
 }
 
 // Classify a write event's file path into an artifact_type for PostToolUse.
@@ -230,6 +244,8 @@ function walkContextDir(
       continue;
     }
     if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    // PMO-4: skip auto-generated metadata files (mirrors isContextFile).
+    if (EXCLUDED_CONTEXT_FILENAMES.has(entry.name.toLowerCase())) continue;
 
     let content: string;
     try {

--- a/tests/lib/payload.test.ts
+++ b/tests/lib/payload.test.ts
@@ -144,6 +144,24 @@ describe('isContextFile', () => {
     expect(isContextFile('context/company.MD')).toBe(true);
     expect(isContextFile('context/product.Md')).toBe(true);
   });
+
+  // PMO-4: index.md is auto-generated metadata, not a real context file. Must
+  // not sync to context_files even though it lives under context/.
+  it('rejects auto-generated index.md', () => {
+    expect(isContextFile('context/index.md')).toBe(false);
+    expect(isContextFile('context/Index.md')).toBe(false);
+    expect(isContextFile('context/INDEX.MD')).toBe(false);
+  });
+
+  it('rejects index.md in nested context paths', () => {
+    expect(isContextFile('context/personas/index.md')).toBe(false);
+    expect(isContextFile('context/sub/deep/index.md')).toBe(false);
+  });
+
+  it('still accepts other files alongside excluded index.md', () => {
+    expect(isContextFile('context/company.md')).toBe(true);
+    expect(isContextFile('context/personas/buyer.md')).toBe(true);
+  });
 });
 
 describe('scanContextFiles', () => {


### PR DESCRIPTION
## Problem
`index.md` is auto-generated metadata, not a context file. But `isContextFile()` returns true for any `.md` under `context/`, so it gets synced to context_files via the artifact-sync hook.

## Fix
Add `EXCLUDED_CONTEXT_FILENAMES` blocklist to `src/lib/payload.ts`. `index.md` excluded explicitly. Case-insensitive. Applied in both `isContextFile` (PostToolUse single-file path) and `walkContextDir` (SessionStart full-scan path) so the two sync routes agree.

## Follow-up note
App-side ingestion at `mysecond-app/src/app/api/companion/files/` was not touched. If the app does its own filtering/ingestion logic beyond accepting what the CLI sends, it may also need the same exclusion. Recommended follow-up to confirm.

## Test plan
- [x] Unit tests pass for payload.ts (34/34)
- [x] tsc --noEmit clean
- [x] build succeeds
- [ ] Manual: write `context/index.md` in test folder; trigger sync; verify it does NOT appear in context_files server-side