### PR TITLE
feat(cli): v1.4.2 — two-command auth flow (deterministic fix for agent-backgrounding)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,8 @@ function printHelp(): void {
     '  --strategy <mode>      Conflict resolution: prompt | cloud-wins | local-wins | skip',
     '  --force-update         Bypass the 24-hour npm-update timebox in sync',
     '  --fix                  Resolve init conflicts interactively (`mysecond init` only)',
-    '  --resume               Re-run device-code OAuth on a partial install (`mysecond init` only)',
+    '  --auth-only            Mint device code, persist state, exit (`mysecond init` only). Pairs with --resume.',
+    '  --resume               Resume install from persisted auth state OR re-run device-code OAuth (`mysecond init` only)',
     '',
     'Docs: https://mysecond.ai',
   ];

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -24,6 +24,15 @@ export interface CommandContext {
    * skipped; only the device-code step's idempotency is overridden.
    */
   resume: boolean;
+  /**
+   * `mysecond init --auth-only` (v1.4.2). Mints a device code, persists
+   * pending-auth state, and exits ~5s. Pairs with a follow-up
+   * `mysecond init --resume` to finish install. Two-command flow exists
+   * because Claude Code Desktop's bash tool buffers single-command stdout
+   * until completion, so a 9-minute single-command flow never surfaces
+   * the auth code to the agent.
+   */
+  authOnly: boolean;
 }
 
 export interface ParsedFlags {
@@ -34,6 +43,7 @@ export interface ParsedFlags {
   forceUpdate: boolean;
   fix: boolean;
   resume: boolean;
+  authOnly: boolean;
   strategy: ConflictStrategy | null;
   positional: string[];
 }
@@ -49,6 +59,7 @@ export function parseGlobalFlags(args: readonly string[]): ParsedFlags {
     forceUpdate: false,
     fix: false,
     resume: false,
+    authOnly: false,
     strategy: null,
     positional: [],
   };
@@ -65,6 +76,8 @@ export function parseGlobalFlags(args: readonly string[]): ParsedFlags {
       out.fix = true;
     } else if (arg === '--resume') {
       out.resume = true;
+    } else if (arg === '--auth-only') {
+      out.authOnly = true;
     } else if (arg === '--api-key') {
       const next = args[i + 1];
       if (next === undefined) throw MysecondError.invalidFlag('--api-key', 'requires a value');
@@ -156,6 +169,7 @@ export function buildContext(flags: ParsedFlags): CommandContext {
     forceUpdate: flags.forceUpdate,
     fix: flags.fix,
     resume: flags.resume,
+    authOnly: flags.authOnly,
     strategy,
   };
 }

--- a/src/lib/init-runner.ts
+++ b/src/lib/init-runner.ts
@@ -166,9 +166,13 @@ export async function runInit(ctx: CommandContext): Promise<number> {
       if (!ctx.silent) {
         process.stdout.write('\nDRY-RUN PASSED — would exit 0 on real run.\n');
       }
-    } else {
+    } else if (!ctx.authOnly) {
       // CTO BLOCKING-1: emit install.completed on first-time success.
       // Re-runs (resume from partial) still emit — server can deduplicate on slug.
+      // Guard against false positives from --auth-only: that mode mints a
+      // device code and exits without completing the install. Emitting
+      // install.completed on auth-only would inflate the install funnel
+      // top-of-funnel metric for every two-command run.
       void emitTelemetry(ctx, 'mysecond.install.completed', {
         slug: sctx.shared.customerId ?? telemetrySlug,
       });

--- a/src/lib/init-runner.ts
+++ b/src/lib/init-runner.ts
@@ -35,11 +35,18 @@ export async function runInit(ctx: CommandContext): Promise<number> {
   // CTO BLOCKING-1: install funnel telemetry. Fire-and-forget — never block
   // install on telemetry. Slug may not be known yet (comes from env or step 4),
   // so send what we have. Completed event fires after all 13 steps succeed.
+  //
+  // Guard against --auth-only: that mode runs only step 15 (device-code mint)
+  // and exits — it is not part of the install funnel. install.completed is
+  // already guarded the same way; firing started without completed would
+  // artificially deflate the funnel ratio.
   const telemetrySlug = process.env.MYSECOND_CUSTOMER_SLUG ?? state.customerSlug ?? 'unknown';
-  void emitTelemetry(ctx, 'mysecond.install.started', {
-    slug: telemetrySlug,
-    resuming: state.initCompletedSteps !== undefined && state.initCompletedSteps.length > 0,
-  });
+  if (!ctx.authOnly) {
+    void emitTelemetry(ctx, 'mysecond.install.started', {
+      slug: telemetrySlug,
+      resuming: state.initCompletedSteps !== undefined && state.initCompletedSteps.length > 0,
+    });
+  }
 
   // Stale-tmp cleanup on resume (CTO-2 + RT-1 lock-scoped — §6.2).
   // Scan ~/.mysecond/marketplaces/, .claude/sync-state.json parent dir,

--- a/src/lib/init-runner.ts
+++ b/src/lib/init-runner.ts
@@ -79,7 +79,26 @@ export async function runInit(ctx: CommandContext): Promise<number> {
 
   try {
     for (const entry of STEPS) {
-      if (isStepComplete(state, entry.number)) {
+      // v1.4.2 two-command auth flow: in --auth-only mode, run step 15
+      // (device-code mint) only and exit. Subsequent steps wait for
+      // `mysecond init --resume` to complete the install.
+      if (ctx.authOnly && entry.number !== 15) {
+        if (!ctx.silent && entry.number === 1) {
+          // Print this once, after step 15 has run.
+          process.stdout.write(
+            '\n(auth-only mode: install will continue when you run --resume)\n'
+          );
+        }
+        break;
+      }
+
+      // --resume forces step 15 (device-code OAuth) to re-run regardless of
+      // ledger state. v1.4.2: this is the only way the two-command flow's
+      // poll-only path executes when the customer has a partial install with
+      // step 15 already marked (e.g., legacy --resume callers, or a re-run
+      // after a token revocation).
+      const resumeForcesStep15 = ctx.resume && entry.number === 15;
+      if (isStepComplete(state, entry.number) && !resumeForcesStep15) {
         if (!ctx.silent) {
           process.stdout.write(`step ${entry.number}/${STEPS.length}: ${entry.description} — already done, skipping\n`);
         }
@@ -132,7 +151,13 @@ export async function runInit(ctx: CommandContext): Promise<number> {
       // (Node version check, install-ready poll, plugin-load probe) but never
       // advances the ledger so the synthetic doesn't pollute the customer's
       // (or staging's) state.
-      if (!ctx.dryRun) {
+      //
+      // v1.4.2: in --auth-only mode, do NOT mark step 15 complete. The auth
+      // hasn't actually completed — only the code was minted. --resume needs
+      // step 15 to run again (in poll-only mode) to exchange the code for a
+      // token. If we marked it complete here, --resume would skip step 15
+      // entirely and try to run downstream steps with an empty apiKey.
+      if (!ctx.dryRun && !(ctx.authOnly && entry.number === 15)) {
         markStepComplete(ctx.rootDir, state, entry.number);
       }
     }

--- a/src/lib/mysecond-paths.ts
+++ b/src/lib/mysecond-paths.ts
@@ -5,6 +5,8 @@ import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+import { projectHash } from './project-hash.js';
+
 const MYSECOND_HOME_DIRNAME = '.mysecond';
 
 export function mysecondHome(): string {
@@ -42,6 +44,19 @@ export function pluginExtractDir(slug: string): string {
 
 export function pluginTmpExtractDir(slug: string, pid: number = process.pid): string {
   return join(marketplaceTmpDir(slug, pid), 'plugin');
+}
+
+// Pending-auth state for the two-command flow (v1.4.2).
+// `mysecond init --auth-only` mints a device code, persists pending-auth state
+// here, and exits ~5s. `mysecond init --resume` reads this file, polls for the
+// token, then runs the rest of install.
+// Path: `~/.mysecond/projects/<projectHash>/pending-auth.json` (mode 0600).
+export function pendingAuthDir(absoluteProjectDir: string): string {
+  return join(mysecondHome(), 'projects', projectHash(absoluteProjectDir));
+}
+
+export function pendingAuthPath(absoluteProjectDir: string): string {
+  return join(pendingAuthDir(absoluteProjectDir), 'pending-auth.json');
 }
 
 // Last-known-good cache root: `~/.mysecond/cache/last-known-good/`

--- a/src/lib/pending-auth.ts
+++ b/src/lib/pending-auth.ts
@@ -1,0 +1,99 @@
+// Pending auth state — persisted between `mysecond init --auth-only` and
+// `mysecond init --resume` (v1.4.2 two-command auth flow).
+//
+// Why split into two commands: Claude Code Desktop's bash tool runs single
+// commands in BACKGROUND mode ("No streaming: Results returned after
+// completion") — the agent doesn't surface auth-code stdout/stderr until the
+// 9-min token-poll completes. Customer never sees the code. Splitting the
+// flow into a fast-exit auth-mint command + a separate resume command makes
+// the auth phase fast enough that the agent surfaces output naturally.
+//
+// File lives at `~/.mysecond/projects/<projectHash>/pending-auth.json`,
+// chmod 600. Cleaned up on successful resume OR on detection of expiry.
+
+import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs';
+
+import { atomicWriteFile } from './atomic-write.js';
+import { pendingAuthDir, pendingAuthPath } from './mysecond-paths.js';
+
+export interface PendingAuthState {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  /** ISO-8601 UTC timestamp of code expiry. */
+  expires_at: string;
+  /** Server-suggested polling interval in seconds. */
+  interval_seconds: number;
+  /** Slug we minted the code against (mostly debug surface; not load-bearing). */
+  slug: string;
+  /** ISO-8601 UTC timestamp the code was minted. */
+  minted_at: string;
+}
+
+/** Persist pending auth state at chmod 600. Atomic write + chmod hardening. */
+export function writePendingAuth(
+  absoluteProjectDir: string,
+  state: PendingAuthState
+): void {
+  const dir = pendingAuthDir(absoluteProjectDir);
+  mkdirSync(dir, { recursive: true });
+  const path = pendingAuthPath(absoluteProjectDir);
+  atomicWriteFile(path, JSON.stringify(state, null, 2) + '\n', { mode: 0o600 });
+  // Defensive — atomicWriteFile uses rename, which preserves source mode but
+  // can survive a pre-existing wider-mode dest on some filesystems.
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // Best-effort; the atomic write already passed.
+  }
+}
+
+/** Read pending auth state. Returns null if file is missing or unreadable. */
+export function readPendingAuth(
+  absoluteProjectDir: string
+): PendingAuthState | null {
+  const path = pendingAuthPath(absoluteProjectDir);
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<PendingAuthState>;
+    if (
+      typeof parsed.device_code !== 'string' ||
+      typeof parsed.user_code !== 'string' ||
+      typeof parsed.verification_uri !== 'string' ||
+      typeof parsed.expires_at !== 'string' ||
+      typeof parsed.interval_seconds !== 'number' ||
+      typeof parsed.slug !== 'string' ||
+      typeof parsed.minted_at !== 'string'
+    ) {
+      return null;
+    }
+    return parsed as PendingAuthState;
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort delete. No-op if missing. */
+export function clearPendingAuth(absoluteProjectDir: string): void {
+  try {
+    unlinkSync(pendingAuthPath(absoluteProjectDir));
+  } catch {
+    // No-op if not present.
+  }
+}
+
+/** True if the persisted state is past its expires_at. */
+export function isPendingAuthExpired(state: PendingAuthState): boolean {
+  const expires = Date.parse(state.expires_at);
+  if (!Number.isFinite(expires)) return true;
+  return Date.now() >= expires;
+}
+
+/** Seconds remaining until expiry; 0 if already expired or unparseable. */
+export function pendingAuthSecondsRemaining(state: PendingAuthState): number {
+  const expires = Date.parse(state.expires_at);
+  if (!Number.isFinite(expires)) return 0;
+  const remainingMs = expires - Date.now();
+  return Math.max(0, Math.floor(remainingMs / 1000));
+}

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -228,6 +228,37 @@ function printResumeHint(slug: string): void {
 async function runAuthOnlyMint(
   ctx: CommandContext,
 ): Promise<{ step: number; outcome: { kind: 'completed' }; message?: string }> {
+  // RED-TEAM: if a customer runs `--auth-only` twice without `--resume` in
+  // between, a fresh mint would overwrite the previous pending-auth state.
+  // The first device_code is then orphaned server-side; if the customer
+  // authorized that one (e.g., from a chat that surfaced the first code),
+  // `--resume` polls the SECOND code and fails silently. Reuse any unexpired
+  // pending state instead of minting fresh.
+  const existing = readPendingAuth(ctx.rootDir);
+  if (existing !== null && !isPendingAuthExpired(existing)) {
+    if (!ctx.silent) {
+      printAuthBanner({
+        user_code: existing.user_code,
+        verification_uri: existing.verification_uri,
+        expires_in: pendingAuthSecondsRemaining(existing),
+      });
+      printResumeHint(existing.slug);
+    }
+    emitStatus({
+      kind: 'device_code_minted',
+      user_code: existing.user_code,
+      verification_uri: existing.verification_uri,
+      expires_in: pendingAuthSecondsRemaining(existing),
+    });
+    return {
+      step: 15,
+      outcome: { kind: 'completed' },
+      message: ctx.silent
+        ? undefined
+        : 'step 15: reusing unexpired device code (auth-only mode)',
+    };
+  }
+
   const installId = getOrCreateInstallId();
   const codeOpts = {
     apiBase: ctx.apiBase,

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -23,6 +23,17 @@
 //     ledger but failing API calls.
 //   - Without --resume + ctx.apiKey empty: run full device-code flow.
 //
+// v1.4.2 — two-command auth flow:
+//   - --auth-only: mint code, print ALL-CAPS banner + structured marker,
+//     persist pending-auth state, return early. Runner exits after this
+//     step (no further steps run).
+//   - --resume + pending-auth state present: skip the mint, poll using the
+//     persisted device_code, then continue with the rest of install. On
+//     expiry of pending state: clear it and surface a clear "re-run with
+//     --auth-only" message.
+//   - Default flow (no flags): mint + poll inline, but print the new
+//     ALL-CAPS banner before polling so SOME agents may surface it.
+//
 // Codex review fixes baked in: P0-1 (keychain read moved to buildContext),
 // P0-2 (whoami validation before trust), P0-4 (revoke on --resume).
 //
@@ -33,10 +44,19 @@ import {
   requestDeviceCode,
   getOrCreateInstallId,
   DeviceCodeError,
+  type DeviceCodeResponse,
 } from '../device-code.js';
 import { clearDeviceToken, setDeviceToken } from '../keychain.js';
 import { MysecondError } from '../errors.js';
 import { emitStatus } from '../silent-status.js';
+import {
+  clearPendingAuth,
+  isPendingAuthExpired,
+  pendingAuthSecondsRemaining,
+  readPendingAuth,
+  writePendingAuth,
+  type PendingAuthState,
+} from '../pending-auth.js';
 
 import type { CommandContext } from '../context.js';
 import type { StepFn } from './types.js';
@@ -46,18 +66,35 @@ declare const __VERSION__: string;
 const WHOAMI_TIMEOUT_MS = 10_000;
 
 export const step15: StepFn = async ({ ctx, shared }) => {
-  // ── --resume: revoke first, then proceed to full flow ─────────────────
+  // ── --auth-only: mint, persist, exit ─────────────────────────────────
+  // The runner detects ctx.authOnly and short-circuits the rest of the
+  // pipeline after this step returns.
+  if (ctx.authOnly) {
+    return runAuthOnlyMint(ctx);
+  }
+
+  // ── --resume with pending-auth state: skip mint, poll only ──────────
+  // The fast path for the two-command flow: customer ran --auth-only,
+  // authorized in the browser, now runs --resume to finish install.
   if (ctx.resume) {
+    const pending = readPendingAuth(ctx.rootDir);
+    if (pending !== null) {
+      if (isPendingAuthExpired(pending)) {
+        clearPendingAuth(ctx.rootDir);
+        throw new MysecondError(
+          1,
+          'Device code expired. Re-run with --auth-only to mint a fresh code.'
+        );
+      }
+      return runPollOnly(ctx, shared, pending);
+    }
+
+    // --resume with NO pending state. Treat as the legacy resume (revoke +
+    // full mint+poll inline) — preserves v1.4.0/1.4.1 behavior for callers
+    // upgrading without re-running --auth-only.
     if (ctx.apiKey.length > 0) {
       await tryRevokeExistingToken(ctx);
-      // Codex pass 2 P1-3: clear the local cached token IMMEDIATELY after
-      // revoke. Without this, a cli crash between revoke and new-token
-      // mint would leave the keychain holding a now-revoked token. On
-      // recovery (without --resume), getDeviceToken would return that
-      // stale token, /whoami would 401, and the customer would see a
-      // confusing "credential rejected" message before re-auth fires.
       clearDeviceToken(ctx.rootDir);
-      // Clear in-memory key so the post-revoke flow doesn't try to reuse it.
       (ctx as { apiKey: string }).apiKey = '';
     }
     return runDeviceCodeFlow(ctx, shared);
@@ -147,7 +184,200 @@ async function tryRevokeExistingToken(ctx: CommandContext): Promise<void> {
   }
 }
 
-// ── Full device-code flow ─────────────────────────────────────────────────
+// ── Visual output: ALL-CAPS banner + structured marker ────────────────────
+
+function printAuthBanner(
+  codeResp: { user_code: string; verification_uri: string; expires_in: number }
+): void {
+  // Both formats per CAIO recommendation. ALL-CAPS banner survives LLM
+  // chat summarization; structured marker enables agent regex parsing.
+  // Written to stderr — Node block-buffers stdout when piped (Claude Code
+  // Desktop's bash tool is a pipe), so a multi-line stdout.write can sit
+  // in the buffer for 30s-2min; stderr flushes immediately.
+  const expiresMins = Math.max(1, Math.round(codeResp.expires_in / 60));
+  const lines = [
+    '',
+    '============================================================',
+    '  AUTHORIZATION REQUIRED',
+    '',
+    `  Code:    ${codeResp.user_code}`,
+    `  URL:     ${codeResp.verification_uri}`,
+    `  Expires: ${expiresMins} minutes`,
+    '============================================================',
+    '',
+    `[mysecond:auth-required] code=${codeResp.user_code} url=${codeResp.verification_uri} expires_in=${codeResp.expires_in}`,
+    '',
+    'Authorize at the URL above, paste the code, click Authorize.',
+    '',
+  ];
+  process.stderr.write(lines.join('\n') + '\n');
+}
+
+function printResumeHint(slug: string): void {
+  process.stderr.write(
+    [
+      'Then run this command to finish installation:',
+      `  MYSECOND_CUSTOMER_SLUG=${slug} npx -y @mysecond/cli@latest init --resume`,
+      '',
+    ].join('\n') + '\n'
+  );
+}
+
+// ── --auth-only: mint + persist + exit ────────────────────────────────────
+
+async function runAuthOnlyMint(
+  ctx: CommandContext,
+): Promise<{ step: number; outcome: { kind: 'completed' }; message?: string }> {
+  const installId = getOrCreateInstallId();
+  const codeOpts = {
+    apiBase: ctx.apiBase,
+    cliVersion: __VERSION__,
+    installId,
+  };
+
+  let codeResp: DeviceCodeResponse;
+  try {
+    codeResp = await requestDeviceCode(codeOpts);
+  } catch (err) {
+    if (err instanceof DeviceCodeError) {
+      throw new MysecondError(
+        1,
+        `Couldn't request a device code (${err.code}): ${err.message}`
+      );
+    }
+    throw err;
+  }
+
+  const slug = process.env.MYSECOND_CUSTOMER_SLUG ?? 'unknown';
+  const mintedAt = new Date();
+  const expiresAt = new Date(mintedAt.getTime() + codeResp.expires_in * 1000);
+
+  const state: PendingAuthState = {
+    device_code: codeResp.device_code,
+    user_code: codeResp.user_code,
+    verification_uri: codeResp.verification_uri,
+    expires_at: expiresAt.toISOString(),
+    interval_seconds: codeResp.interval,
+    slug,
+    minted_at: mintedAt.toISOString(),
+  };
+  writePendingAuth(ctx.rootDir, state);
+
+  if (!ctx.silent) {
+    printAuthBanner(codeResp);
+    printResumeHint(slug);
+  }
+
+  emitStatus({
+    kind: 'device_code_minted',
+    user_code: codeResp.user_code,
+    verification_uri: codeResp.verification_uri,
+    expires_in: codeResp.expires_in,
+  });
+
+  return {
+    step: 15,
+    outcome: { kind: 'completed' },
+    message: ctx.silent ? undefined : 'step 15: device code minted (auth-only mode)',
+  };
+}
+
+// ── --resume from pending-auth state: poll only ───────────────────────────
+
+async function runPollOnly(
+  ctx: CommandContext,
+  shared: import('./types.js').StepContext['shared'],
+  pending: PendingAuthState,
+): Promise<{ step: number; outcome: { kind: 'completed' }; message?: string }> {
+  const installId = getOrCreateInstallId();
+  const codeOpts = {
+    apiBase: ctx.apiBase,
+    cliVersion: __VERSION__,
+    installId,
+  };
+
+  if (!ctx.silent) {
+    process.stderr.write(
+      [
+        '',
+        `Resuming install. Code: ${pending.user_code} (${pendingAuthSecondsRemaining(pending)}s remaining).`,
+        'Waiting for authorization...',
+        '',
+      ].join('\n') + '\n'
+    );
+  }
+
+  let tokenResp;
+  try {
+    tokenResp = await pollForToken({
+      ...codeOpts,
+      deviceCode: pending.device_code,
+      intervalSeconds: pending.interval_seconds,
+    });
+  } catch (err) {
+    if (err instanceof DeviceCodeError) {
+      // On expired/invalid/already_exchanged, clear the stale state so the
+      // customer's next --auth-only run starts clean.
+      if (
+        err.code === 'expired' ||
+        err.code === 'invalid' ||
+        err.code === 'already_exchanged'
+      ) {
+        clearPendingAuth(ctx.rootDir);
+      }
+      throw new MysecondError(
+        1,
+        `Device authorization failed (${err.code}): ${err.message}`
+      );
+    }
+    throw err;
+  }
+
+  // Persist the token (keychain on macOS, file fallback elsewhere).
+  const setResult = setDeviceToken(ctx.rootDir, tokenResp.access_token);
+
+  // Mutate ctx for downstream steps.
+  (ctx as { apiKey: string }).apiKey = tokenResp.access_token;
+
+  // Successfully exchanged — clear pending state.
+  clearPendingAuth(ctx.rootDir);
+
+  // Best-effort whoami for step-13 email.
+  const whoami = await fetchWhoami(ctx);
+  if (whoami.email) {
+    shared.userEmail = whoami.email;
+  }
+
+  if (
+    setResult.fallbackReason === 'roundtrip_failed' ||
+    setResult.fallbackReason === 'write_failed'
+  ) {
+    emitStatus({
+      kind: 'keychain_write_failed',
+      reason: setResult.fallbackReason,
+    });
+  }
+
+  emitStatus({
+    kind: 'device_authorized',
+    token_storage: setResult.storage,
+    keychain_unavailable_reason: setResult.fallbackReason ?? null,
+  });
+
+  if (!ctx.silent) {
+    process.stdout.write(
+      '\n  ✓ Device authorized. Continuing install...\n\n'
+    );
+  }
+
+  return {
+    step: 15,
+    outcome: { kind: 'completed' },
+    message: ctx.silent ? undefined : 'step 15: device authorized (resumed)',
+  };
+}
+
+// ── Full device-code flow (legacy single-command path) ────────────────────
 
 async function runDeviceCodeFlow(
   ctx: CommandContext,
@@ -160,11 +390,9 @@ async function runDeviceCodeFlow(
     installId,
   };
 
-  // Fix C Step 1: measure device-code mint wall-clock. The requestDeviceCode
-  // call does a single POST to /api/companion/device/code. If this is slow,
-  // the bottleneck is network latency to our API, not the token-poll loop.
+  // Fix C Step 1: measure device-code mint wall-clock.
   const mintStartMs = performance.now();
-  let codeResp;
+  let codeResp: DeviceCodeResponse;
   try {
     codeResp = await requestDeviceCode(codeOpts);
   } catch (err) {
@@ -177,50 +405,19 @@ async function runDeviceCodeFlow(
     throw err;
   }
   const mintDurationMs = Math.round(performance.now() - mintStartMs);
-  // Emit in silent mode only — in interactive mode the stderr device-code
-  // block (written immediately below) is the customer-facing surface.
   emitStatus({
     kind: 'device_code_minted_timed',
     duration_ms: mintDurationMs,
   });
 
-  // CAIO #10: print URL to stdout BEFORE the open attempt. The chat is the
-  // deterministic surface; auto-open is best-effort.
-  // Day 5 pre-launch: user_code is NOT in the URL — customer types it
-  // into the page's input form. Print the code prominently with a copy-
-  // friendly hint so the customer knows where to find it.
-  //
-  // Day 5+ Item 5A (CAIO P0): write the device-code block to STDERR, not
-  // stdout. Node's process.stdout is block-buffered when piped (Claude Code
-  // Desktop's bash tool is a pipe), so a multi-line stdout.write can sit
-  // in the buffer for 30s-2min before the customer sees it. process.stderr
-  // is unbuffered by default when piped — the code surfaces in chat in ~5s.
-  // The trailing \n explicitly flushes the pipe.
-  // "Waiting for authorization..." stays on stdout — lower urgency, fine
-  // to buffer.
-  // Day 5+ CLI-4: render the verification URL as a Markdown bare link
-  // ([url](url)) on its own line. This format survives Claude Code Desktop
-  // chat summarization where bare URLs in code blocks otherwise get
-  // collapsed/dropped. CISO decision (mysecond-app
-  // src/app/api/companion/device/code/route.ts:95-103): user_code MUST NOT
-  // be embedded in the URL — code is transferred manually by the customer.
+  // v1.4.2: print the NEW ALL-CAPS banner BEFORE polling. Some agents may
+  // surface this even in single-command mode. The banner replaces the prior
+  // free-form Markdown link block — same information, deterministic shape.
   if (!ctx.silent) {
-    process.stderr.write(
-      [
-        '',
-        'Authorize this device:',
-        '',
-        `    [${codeResp.verification_uri}](${codeResp.verification_uri})`,
-        '',
-        `Code: ${codeResp.user_code} (type into the page)`,
-        '',
-      ].join('\n') + '\n'
-    );
+    printAuthBanner(codeResp);
     process.stdout.write('Waiting for authorization...\n');
   }
 
-  // Silent JSON status: cli emits "device_code_minted" so the chat client
-  // can render its own waiting UI without parsing prose stdout.
   emitStatus({
     kind: 'device_code_minted',
     user_code: codeResp.user_code,
@@ -229,10 +426,6 @@ async function runDeviceCodeFlow(
   });
 
   // Poll until authorized or 540s cap.
-  // Fix C Step 1: measure the token-poll loop wall-clock. This is the
-  // time between the user receiving the code and clicking "Authorize" in
-  // the browser — dominated by human speed, not CLI overhead. Useful to
-  // distinguish "device-code flow is slow" from "user was slow to click".
   const pollStartMs = performance.now();
   let tokenResp;
   try {
@@ -251,9 +444,6 @@ async function runDeviceCodeFlow(
     throw err;
   }
   const pollDurationMs = Math.round(performance.now() - pollStartMs);
-  // Emit timing for the poll phase regardless of silent/interactive mode —
-  // same pattern as device_code_minted_timed above. isSilentMode() check is
-  // handled inside emitStatus; we always call it so both code paths are covered.
   emitStatus({
     kind: 'device_authorized_timed',
     duration_ms: pollDurationMs,
@@ -265,20 +455,12 @@ async function runDeviceCodeFlow(
   // Mutate ctx for downstream steps.
   (ctx as { apiKey: string }).apiKey = tokenResp.access_token;
 
-  // Item 5B: capture email from /whoami so step-13 can emit the
-  // install_completed JSON status event with installCompleteClaudeMessage(email).
-  // Best-effort — if /whoami fails here, step-13 falls back to a generic
-  // post-install message.
+  // Best-effort whoami for step-13 email.
   const whoami = await fetchWhoami(ctx);
   if (whoami.email) {
     shared.userEmail = whoami.email;
   }
 
-  // Emit a keychain_write_failed status when we fell back due to round-trip
-  // failure or write error (sandboxed-keychain edge case). Not a fatal
-  // condition — file fallback is a working credential — but worth a
-  // discriminable event so support can detect a sandboxed-keychain pattern
-  // in PostHog without grepping logs (CAIO Day 4).
   if (
     setResult.fallbackReason === 'roundtrip_failed' ||
     setResult.fallbackReason === 'write_failed'
@@ -295,9 +477,6 @@ async function runDeviceCodeFlow(
     keychain_unavailable_reason: setResult.fallbackReason ?? null,
   });
 
-  // CXO Day 4: parallel non-silent success line so the customer in their
-  // terminal sees an explicit "✓ authorized" instead of just "step 15:
-  // device authorized" (which doesn't tell them what to do next).
   if (!ctx.silent) {
     process.stdout.write(
       '\n  ✓ Device authorized. Quit and reopen Claude Code to load the mySecond plugin — your install will continue automatically.\n\n'

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -244,12 +244,9 @@ async function runAuthOnlyMint(
       });
       printResumeHint(existing.slug);
     }
-    emitStatus({
-      kind: 'device_code_minted',
-      user_code: existing.user_code,
-      verification_uri: existing.verification_uri,
-      expires_in: pendingAuthSecondsRemaining(existing),
-    });
+    // Reuse path: the original mint already emitted `device_code_minted`.
+    // Re-emitting here would double-count mints in downstream telemetry/
+    // dashboards. Skip — no new event needed for re-displaying the same code.
     return {
       step: 15,
       outcome: { kind: 'completed' },

--- a/tests/lib/auth-only-invariants.test.ts
+++ b/tests/lib/auth-only-invariants.test.ts
@@ -72,6 +72,17 @@ describe('--auth-only invariants — init-runner', () => {
     expect(source).toContain('ctx.authOnly && entry.number !== 15');
     expect(source).toMatch(/break;/);
   });
+
+  it('does NOT emit install.started telemetry in --auth-only mode', () => {
+    // Mirror of install.completed: started must also be guarded so the funnel
+    // ratio (started → completed) isn't artificially deflated by every
+    // --auth-only run incrementing started without ever incrementing completed.
+    const startedIdx = source.indexOf("'mysecond.install.started'");
+    expect(startedIdx).toBeGreaterThan(0);
+    // Look for the guard within ~500 chars before the emit.
+    const guardWindow = source.slice(Math.max(0, startedIdx - 500), startedIdx);
+    expect(guardWindow).toMatch(/!\s*ctx\.authOnly/);
+  });
 });
 
 describe('--auth-only invariants — step-15 runAuthOnlyMint', () => {
@@ -91,5 +102,20 @@ describe('--auth-only invariants — step-15 runAuthOnlyMint', () => {
   it('writes pending-auth state on a fresh mint', () => {
     // Sanity: the mint path still persists state for --resume to pick up.
     expect(source).toContain('writePendingAuth(ctx.rootDir, state)');
+  });
+
+  it('does NOT emit device_code_minted on the reuse path', () => {
+    // The reuse branch displays an existing device code. The original mint
+    // already emitted `device_code_minted`; re-emitting here would
+    // double-count mints in downstream telemetry/dashboards. Assert that
+    // between the reuse-branch entry and its `return` there is no
+    // `device_code_minted` emit.
+    const reuseIdx = source.indexOf('isPendingAuthExpired(existing)');
+    expect(reuseIdx).toBeGreaterThan(0);
+    // Find the matching return statement that closes the reuse branch.
+    const reuseReturnIdx = source.indexOf("message: ctx.silent", reuseIdx);
+    expect(reuseReturnIdx).toBeGreaterThan(reuseIdx);
+    const reuseBlock = source.slice(reuseIdx, reuseReturnIdx);
+    expect(reuseBlock).not.toContain("kind: 'device_code_minted'");
   });
 });

--- a/tests/lib/auth-only-invariants.test.ts
+++ b/tests/lib/auth-only-invariants.test.ts
@@ -1,0 +1,95 @@
+// v1.4.2 two-command auth flow — invariant tests.
+//
+// These are structural source-level assertions (same pattern used by
+// step-timing.test.ts) because runInit has too many heavy dependencies
+// (network, keychain, child_process, marketplace lock) to unit-test the full
+// runner without a sprawling mock surface.
+//
+// What we're guarding against:
+//
+//   1. A future refactor of init-runner.ts removes the `!ctx.authOnly` guard
+//      around `markStepComplete(... 15)`. If that happens, --resume would skip
+//      step 15 (because the ledger says it's done), tries to use an empty
+//      apiKey, and breaks every customer in the two-command flow.
+//
+//   2. A future refactor removes the `!ctx.authOnly` guard around the
+//      install.completed telemetry emit. False positives inflate the install
+//      funnel top-of-funnel metric for every --auth-only run.
+//
+//   3. A future refactor removes the unexpired-pending-state reuse in
+//      step-15's runAuthOnlyMint. Without it, repeated --auth-only invocations
+//      orphan the previous device_code server-side.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const RUNNER_PATH = join(
+  import.meta.dirname ?? __dirname,
+  '..',
+  '..',
+  'src',
+  'lib',
+  'init-runner.ts'
+);
+const STEP15_PATH = join(
+  import.meta.dirname ?? __dirname,
+  '..',
+  '..',
+  'src',
+  'lib',
+  'steps',
+  'step-15.ts'
+);
+
+describe('--auth-only invariants — init-runner', () => {
+  const source = readFileSync(RUNNER_PATH, 'utf8');
+
+  it('does NOT mark step 15 complete in --auth-only mode (ledger invariant)', () => {
+    // The runner must call markStepComplete only when NOT in auth-only mode
+    // for step 15. Otherwise --resume would skip the device-token exchange
+    // and downstream steps run with an empty apiKey.
+    expect(source).toContain('!ctx.dryRun && !(ctx.authOnly && entry.number === 15)');
+    expect(source).toContain('markStepComplete(ctx.rootDir, state, entry.number)');
+  });
+
+  it('does NOT emit install.completed telemetry in --auth-only mode', () => {
+    // Auth-only is mint-only; install hasn't actually completed. Emitting
+    // install.completed inflates the funnel metric.
+    expect(source).toContain('!ctx.authOnly');
+    expect(source).toContain("'mysecond.install.completed'");
+    // The completed-emit branch must be guarded by !ctx.authOnly.
+    const completedIdx = source.indexOf("'mysecond.install.completed'");
+    expect(completedIdx).toBeGreaterThan(0);
+    // Look for the guard within ~500 chars before the emit.
+    const guardWindow = source.slice(Math.max(0, completedIdx - 500), completedIdx);
+    expect(guardWindow).toMatch(/!\s*ctx\.authOnly/);
+  });
+
+  it('breaks out of the step loop in --auth-only mode after step 15', () => {
+    // Sanity check: the runner's auth-only short-circuit must remain.
+    expect(source).toContain('ctx.authOnly && entry.number !== 15');
+    expect(source).toMatch(/break;/);
+  });
+});
+
+describe('--auth-only invariants — step-15 runAuthOnlyMint', () => {
+  const source = readFileSync(STEP15_PATH, 'utf8');
+
+  it('reuses an unexpired pending-auth state instead of overwriting', () => {
+    // Repeated --auth-only must not orphan a previously-minted device_code.
+    expect(source).toContain('readPendingAuth(ctx.rootDir)');
+    expect(source).toContain('isPendingAuthExpired(existing)');
+    // The reuse path must short-circuit BEFORE requestDeviceCode is called.
+    const reuseIdx = source.indexOf('isPendingAuthExpired(existing)');
+    const mintIdx = source.indexOf('requestDeviceCode(codeOpts)', reuseIdx);
+    expect(reuseIdx).toBeGreaterThan(0);
+    expect(mintIdx).toBeGreaterThan(reuseIdx);
+  });
+
+  it('writes pending-auth state on a fresh mint', () => {
+    // Sanity: the mint path still persists state for --resume to pick up.
+    expect(source).toContain('writePendingAuth(ctx.rootDir, state)');
+  });
+});

--- a/tests/lib/context.test.ts
+++ b/tests/lib/context.test.ts
@@ -44,6 +44,25 @@ describe('parseGlobalFlags', () => {
     const f = parseGlobalFlags(['arg1', '--silent', 'arg2']);
     expect(f.positional).toEqual(['arg1', 'arg2']);
   });
+
+  // v1.4.2: two-command auth flow flags.
+  it('parses --auth-only flag', () => {
+    const f = parseGlobalFlags(['--auth-only']);
+    expect(f.authOnly).toBe(true);
+    expect(f.resume).toBe(false);
+  });
+
+  it('parses --resume flag', () => {
+    const f = parseGlobalFlags(['--resume']);
+    expect(f.resume).toBe(true);
+    expect(f.authOnly).toBe(false);
+  });
+
+  it('defaults authOnly + resume to false', () => {
+    const f = parseGlobalFlags([]);
+    expect(f.authOnly).toBe(false);
+    expect(f.resume).toBe(false);
+  });
 });
 
 describe('buildContext', () => {

--- a/tests/lib/pending-auth.test.ts
+++ b/tests/lib/pending-auth.test.ts
@@ -1,0 +1,113 @@
+// Tests for the v1.4.2 two-command auth flow's pending-auth state module.
+// Covers: write+read round-trip, mode 0600 hardening, expiry detection,
+// clear, and malformed-state handling.
+
+import { mkdirSync, mkdtempSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearPendingAuth,
+  isPendingAuthExpired,
+  pendingAuthSecondsRemaining,
+  readPendingAuth,
+  writePendingAuth,
+  type PendingAuthState,
+} from '../../src/lib/pending-auth.js';
+import { pendingAuthPath } from '../../src/lib/mysecond-paths.js';
+
+describe('pending-auth state', () => {
+  let prevHome: string | undefined;
+  let projectDir: string;
+
+  beforeEach(() => {
+    prevHome = process.env.HOME;
+    // Sandbox HOME so we don't pollute the real ~/.mysecond.
+    const sandboxHome = mkdtempSync(join(tmpdir(), 'mysecond-pending-auth-'));
+    process.env.HOME = sandboxHome;
+    projectDir = mkdtempSync(join(tmpdir(), 'mysecond-project-'));
+  });
+
+  afterEach(() => {
+    if (prevHome !== undefined) process.env.HOME = prevHome;
+    else delete process.env.HOME;
+  });
+
+  function sampleState(overrides: Partial<PendingAuthState> = {}): PendingAuthState {
+    const minted = new Date('2026-05-05T12:00:00.000Z');
+    const expires = new Date(minted.getTime() + 540_000); // +9 min
+    return {
+      device_code: 'dc-abc-123',
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://app.mysecond.ai/device',
+      expires_at: expires.toISOString(),
+      interval_seconds: 5,
+      slug: 'acme-x1',
+      minted_at: minted.toISOString(),
+      ...overrides,
+    };
+  }
+
+  it('writes + reads round-trip', () => {
+    const state = sampleState();
+    writePendingAuth(projectDir, state);
+    const read = readPendingAuth(projectDir);
+    expect(read).toEqual(state);
+  });
+
+  it('persists at chmod 0600', () => {
+    writePendingAuth(projectDir, sampleState());
+    const path = pendingAuthPath(projectDir);
+    const stat = statSync(path);
+    // Mask off the file-type bits, only check perms.
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it('returns null for missing file', () => {
+    expect(readPendingAuth(projectDir)).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    const path = pendingAuthPath(projectDir);
+    mkdirSync(join(path, '..'), { recursive: true });
+    writeFileSync(path, '{not json', { mode: 0o600 });
+    expect(readPendingAuth(projectDir)).toBeNull();
+  });
+
+  it('returns null when required fields are missing', () => {
+    const path = pendingAuthPath(projectDir);
+    mkdirSync(join(path, '..'), { recursive: true });
+    writeFileSync(path, JSON.stringify({ user_code: 'ABCD' }), { mode: 0o600 });
+    expect(readPendingAuth(projectDir)).toBeNull();
+  });
+
+  it('clears the file (idempotent)', () => {
+    writePendingAuth(projectDir, sampleState());
+    expect(readPendingAuth(projectDir)).not.toBeNull();
+    clearPendingAuth(projectDir);
+    expect(readPendingAuth(projectDir)).toBeNull();
+    // Second call should not throw.
+    clearPendingAuth(projectDir);
+  });
+
+  it('detects expiry', () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    expect(isPendingAuthExpired(sampleState({ expires_at: past }))).toBe(true);
+    const future = new Date(Date.now() + 60_000).toISOString();
+    expect(isPendingAuthExpired(sampleState({ expires_at: future }))).toBe(false);
+  });
+
+  it('reports seconds remaining', () => {
+    const future = new Date(Date.now() + 120_000).toISOString();
+    const remaining = pendingAuthSecondsRemaining(sampleState({ expires_at: future }));
+    expect(remaining).toBeGreaterThan(110);
+    expect(remaining).toBeLessThanOrEqual(120);
+  });
+
+  it('reports 0 for expired state', () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    expect(pendingAuthSecondsRemaining(sampleState({ expires_at: past }))).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

v1.4.0/v1.4.1: Claude Code Desktop's chat agent runs single-command `init` in BACKGROUND mode. Bash tool docs explicitly state "No streaming: Results returned after completion." Agent doesn't surface the auth code until 9-min timeout. Customer never sees code, install fails.

## Fix

Split install into two commands per CTO + CAIO review:

- `init --auth-only`: mints device code, prints ALL-CAPS banner + structured marker, persists pending-auth state, exits in ~5s. Agent sees output naturally.
- `init --resume`: reads pending auth state, polls for completion, finishes install.

Default `init` (no flags) preserved for backward compat — same single-command behavior, but with the new ALL-CAPS banner printed before polling so some agents may surface the code.

## State

Pending auth persists to `~/.mysecond/projects/<hash>/pending-auth.json` (chmod 600). Cleaned up after resume or expiry.

## Architectural notes

- Step 15 now has three modes: auth-only mint, resume-from-pending poll, legacy mint+poll inline.
- `--auth-only` does NOT mark step 15 complete in the ledger (auth hasn't completed — only the code was minted). `--resume` would otherwise skip step 15 entirely on the second invocation.
- `--resume` forces step 15 to re-run regardless of ledger state, so customers with a partial install (or revoked token) can recover.
- Banner + marker written to stderr (Node block-buffers stdout on pipes; stderr flushes immediately).

## Test plan

- [ ] init --auth-only exits 0 within ~10s (manual)
- [ ] init --resume succeeds after manual authorization (manual)
- [ ] init --resume fails cleanly if auth expired (manual)
- [ ] init (no flags) still works for v1.3.x callers (manual)
- [ ] ALL-CAPS banner visible in real terminal (manual)
- [ ] Structured marker parseable by regex (`/\[mysecond:auth-required\] code=(\S+) url=(\S+) expires_in=(\d+)/`)
- [x] Tests cover new flag paths + pending-auth state module
- [x] typecheck + build pass