### PR TITLE
feat(cli): v1.4.4 — legacy companion_api_key deprecation messaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -124,6 +124,23 @@ function loadDotenv(rootDir: string): void {
   }
 }
 
+// v1.4.4 — extract the bare token from whatever keychain.ts fileGet
+// returned. Two formats live at the same project-scoped path:
+//   1. Bare token (setDeviceToken writes `<token>\n` — current path).
+//   2. Dotenv-style (step-5b writes `COMPANION_API_KEY=<token>\n
+//      COMPANION_API_URL=<url>\n` — legacy path for pre-1.4.2 installs
+//      whose device-code flow never completed).
+// Returns the extracted token, or the raw value if neither format
+// matches (defensive — preserves prior behavior for unknown inputs).
+function normalizeStoredTokenValue(raw: string): string {
+  // Bare-token shortcut: no newline AND no equals → return as-is.
+  if (!raw.includes('\n') && !raw.includes('=')) return raw;
+  // Dotenv shape: extract the COMPANION_API_KEY line value.
+  const match = raw.match(/^COMPANION_API_KEY=(.+)$/m);
+  if (match !== null && match[1] !== undefined) return match[1].trim();
+  return raw;
+}
+
 // v1.4.4 legacy-key warning state. Module-scoped so a single process only
 // emits the marker + prose once even if buildContext is called twice.
 // Exported test-only resetter (legacy_key_warning_reset_for_tests) lets
@@ -222,8 +239,17 @@ export function buildContext(flags: ParsedFlags): CommandContext {
     // it to silence." Caught by codex review on v1.4.4 PR #28.
     if (!apiKey.startsWith('msd_')) {
       const fromKeychain = loadKeychainToken();
-      if (fromKeychain !== null && fromKeychain.startsWith('msd_')) {
-        apiKey = fromKeychain;
+      // Normalize: keychain.ts's fileGet returns the raw file contents.
+      // setDeviceToken writes bare `<token>\n`, but step-5b legacy writes
+      // dotenv-style `COMPANION_API_KEY=<token>\nCOMPANION_API_URL=...`
+      // to the SAME path. Without parsing the latter, file-fallback users
+      // whose first init never completed device-code stay stuck in a
+      // re-auth loop even though a valid msd_ token exists on disk.
+      // Codex P2 follow-up on PR #28.
+      const normalizedKeychainToken =
+        fromKeychain !== null ? normalizeStoredTokenValue(fromKeychain) : null;
+      if (normalizedKeychainToken !== null && normalizedKeychainToken.startsWith('msd_')) {
+        apiKey = normalizedKeychainToken;
         apiKeySource = 'keychain';
         keychainRescue = true;
       }

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -123,6 +123,31 @@ function loadDotenv(rootDir: string): void {
   }
 }
 
+// v1.4.4 legacy-key warning state. Module-scoped so a single process only
+// emits the marker + prose once even if buildContext is called twice.
+// Exported test-only resetter (legacy_key_warning_reset_for_tests) lets
+// vitest restore the unwarned state between cases.
+let legacyKeyWarningEmitted = false;
+
+export function _legacyKeyWarningResetForTests(): void {
+  legacyKeyWarningEmitted = false;
+}
+
+function emitLegacyKeyWarning(source: 'flag' | 'env', silent: boolean): void {
+  if (legacyKeyWarningEmitted) return;
+  legacyKeyWarningEmitted = true;
+  // Structured marker — always emitted, even under silent. Stable public
+  // contract; format changes follow semver.
+  process.stderr.write(`[mysecond:legacy-key-detected] source=${source}\n`);
+  if (silent) return;
+  // Human prose — suppressed under silent. Never echoes the token value,
+  // prefix, or truncation; source label only.
+  const flagOrEnv = source === 'flag' ? '--api-key value' : 'COMPANION_API_KEY';
+  process.stderr.write(
+    `[mysecond] ⚠️  Your ${flagOrEnv} looks like a legacy team key. It will stop working soon — run \`mysecond init\` to re-authenticate.\n`
+  );
+}
+
 export function buildContext(flags: ParsedFlags): CommandContext {
   // Resolve rootDir BEFORE loading .env (so we know where to look for .env).
   // Precedence: --project-dir flag > $CLAUDE_PROJECT_DIR env > cwd().
@@ -139,7 +164,17 @@ export function buildContext(flags: ParsedFlags): CommandContext {
   // would be empty on subsequent inits and step 4 (/install-ready) would
   // 401. Sourcing here makes idempotent re-runs work correctly:
   //   precedence: --api-key flag > COMPANION_API_KEY env > keychain/file
-  let apiKey = flags.apiKey ?? process.env.COMPANION_API_KEY ?? '';
+  let apiKey: string;
+  let apiKeySource: 'flag' | 'env' | 'keychain' | 'none' = 'none';
+  if (flags.apiKey !== null && flags.apiKey.length > 0) {
+    apiKey = flags.apiKey;
+    apiKeySource = 'flag';
+  } else if (typeof process.env.COMPANION_API_KEY === 'string' && process.env.COMPANION_API_KEY.length > 0) {
+    apiKey = process.env.COMPANION_API_KEY;
+    apiKeySource = 'env';
+  } else {
+    apiKey = '';
+  }
   if (apiKey.length === 0) {
     try {
       // Lazy import to keep `mysecond --version` and `mysecond --help` fast
@@ -147,11 +182,35 @@ export function buildContext(flags: ParsedFlags): CommandContext {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { getDeviceToken } = require('./keychain.js') as typeof import('./keychain.js');
       const fromStorage = getDeviceToken(rootDir);
-      if (fromStorage !== null) apiKey = fromStorage.token;
+      if (fromStorage !== null) {
+        apiKey = fromStorage.token;
+        apiKeySource = 'keychain';
+      }
     } catch {
       // Best-effort. If keychain lookup throws, fall through to empty
       // apiKey; step 15 will run the device-code flow.
     }
+  }
+
+  // v1.4.4: legacy `companion_api_key` deprecation warning.
+  // Source-based gating: keychain-sourced tokens are msd_-prefixed by
+  // construction (setDeviceToken is the only writer). Flag/env-sourced
+  // tokens that don't start with msd_ are the legacy team-shared keys
+  // server-side PR3b will stop accepting. Warn once per process so the
+  // customer can re-auth via `mysecond init` before the cutover.
+  //
+  // Hard rules:
+  //   - Never print token bytes (or prefix/truncation). Bash-tool stderr
+  //     is captured into model context and persisted in transcripts —
+  //     token material there is a leak.
+  //   - Do not call process.exit. isTTY is always false inside Claude
+  //     Code's Bash tool, so a !isTTY hard-fail would misfire for the
+  //     dominant interactive population. Let companionFetch's 401
+  //     surfacing + step-15's rejection path handle headless callers.
+  //   - `[mysecond:legacy-key-detected]` is a stable public contract.
+  //     Format changes (source labels, additional fields) follow semver.
+  if ((apiKeySource === 'flag' || apiKeySource === 'env') && !apiKey.startsWith('msd_')) {
+    emitLegacyKeyWarning(apiKeySource, flags.silent);
   }
 
   // Strategy default: prompt if interactive (TTY) and not silent; cloud-wins otherwise.

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -5,6 +5,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { isAbsolute, resolve } from 'node:path';
 
 import { MysecondError } from './errors.js';
+import { getDeviceToken } from './keychain.js';
 
 export type ConflictStrategy = 'prompt' | 'cloud-wins' | 'local-wins' | 'skip';
 
@@ -148,6 +149,24 @@ function emitLegacyKeyWarning(source: 'flag' | 'env', silent: boolean): void {
   );
 }
 
+// Keychain-rescue variant. Fires when the env-supplied bearer is legacy
+// (non-msd_) but a valid msd_ device token is present in keychain — we
+// silently prefer the keychain token so callers don't 401-loop, but the
+// stale env var is still flagged so the customer knows to clean it up.
+// The marker carries `keychain-rescue=true` so agent harnesses can
+// distinguish this case from the plain legacy-key-detected event.
+function emitLegacyKeyRescueWarning(silent: boolean): void {
+  if (legacyKeyWarningEmitted) return;
+  legacyKeyWarningEmitted = true;
+  process.stderr.write(
+    `[mysecond:legacy-key-detected] source=env keychain-rescue=true\n`
+  );
+  if (silent) return;
+  process.stderr.write(
+    `[mysecond] ⚠️  Your COMPANION_API_KEY env var is set to a retired legacy key — using the device token from keychain instead. Unset COMPANION_API_KEY in your shell (e.g., remove it from ~/.zshrc / ~/.bashrc) to silence this warning.\n`
+  );
+}
+
 export function buildContext(flags: ParsedFlags): CommandContext {
   // Resolve rootDir BEFORE loading .env (so we know where to look for .env).
   // Precedence: --project-dir flag > $CLAUDE_PROJECT_DIR env > cwd().
@@ -164,31 +183,57 @@ export function buildContext(flags: ParsedFlags): CommandContext {
   // would be empty on subsequent inits and step 4 (/install-ready) would
   // 401. Sourcing here makes idempotent re-runs work correctly:
   //   precedence: --api-key flag > COMPANION_API_KEY env > keychain/file
-  let apiKey: string;
+  //
+  // v1.4.4 keychain-rescue exception: when COMPANION_API_KEY is a legacy
+  // (non-msd_) value AND keychain has a valid msd_ device token, the
+  // keychain wins. Without this rescue, customers with the legacy key
+  // exported in their shell rc (.zshrc, .bashrc) would re-auth on every
+  // run after server PR3b — env keeps clobbering the freshly minted
+  // msd_ token. --api-key flag is explicit user override and is never
+  // rescued.
+  let apiKey = '';
   let apiKeySource: 'flag' | 'env' | 'keychain' | 'none' = 'none';
+  let keychainRescue = false;
+
+  // Lazy keychain lookup — memoized so the rescue check and the
+  // empty-credential fallback share a single shell-out.
+  let keychainTokenCache: string | null | undefined = undefined;
+  const loadKeychainToken = (): string | null => {
+    if (keychainTokenCache !== undefined) return keychainTokenCache;
+    try {
+      const fromStorage = getDeviceToken(rootDir);
+      keychainTokenCache = fromStorage !== null ? fromStorage.token : null;
+    } catch {
+      // Best-effort. If keychain lookup throws, treat as absent.
+      keychainTokenCache = null;
+    }
+    return keychainTokenCache;
+  };
+
   if (flags.apiKey !== null && flags.apiKey.length > 0) {
     apiKey = flags.apiKey;
     apiKeySource = 'flag';
   } else if (typeof process.env.COMPANION_API_KEY === 'string' && process.env.COMPANION_API_KEY.length > 0) {
     apiKey = process.env.COMPANION_API_KEY;
     apiKeySource = 'env';
-  } else {
-    apiKey = '';
+    // Keychain rescue: legacy env value blocks self-healing after
+    // server PR3b retires the key class. If keychain has a valid msd_
+    // token, prefer it; the warning shifts to "your env is stale, unset
+    // it to silence." Caught by codex review on v1.4.4 PR #28.
+    if (!apiKey.startsWith('msd_')) {
+      const fromKeychain = loadKeychainToken();
+      if (fromKeychain !== null && fromKeychain.startsWith('msd_')) {
+        apiKey = fromKeychain;
+        apiKeySource = 'keychain';
+        keychainRescue = true;
+      }
+    }
   }
   if (apiKey.length === 0) {
-    try {
-      // Lazy import to keep `mysecond --version` and `mysecond --help` fast
-      // (they don't need credentials).
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { getDeviceToken } = require('./keychain.js') as typeof import('./keychain.js');
-      const fromStorage = getDeviceToken(rootDir);
-      if (fromStorage !== null) {
-        apiKey = fromStorage.token;
-        apiKeySource = 'keychain';
-      }
-    } catch {
-      // Best-effort. If keychain lookup throws, fall through to empty
-      // apiKey; step 15 will run the device-code flow.
+    const fromKeychain = loadKeychainToken();
+    if (fromKeychain !== null) {
+      apiKey = fromKeychain;
+      apiKeySource = 'keychain';
     }
   }
 
@@ -209,7 +254,9 @@ export function buildContext(flags: ParsedFlags): CommandContext {
   //     surfacing + step-15's rejection path handle headless callers.
   //   - `[mysecond:legacy-key-detected]` is a stable public contract.
   //     Format changes (source labels, additional fields) follow semver.
-  if ((apiKeySource === 'flag' || apiKeySource === 'env') && !apiKey.startsWith('msd_')) {
+  if (keychainRescue) {
+    emitLegacyKeyRescueWarning(flags.silent);
+  } else if ((apiKeySource === 'flag' || apiKeySource === 'env') && !apiKey.startsWith('msd_')) {
     emitLegacyKeyWarning(apiKeySource, flags.silent);
   }
 

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -124,21 +124,33 @@ function loadDotenv(rootDir: string): void {
   }
 }
 
-// v1.4.4 — extract the bare token from whatever keychain.ts fileGet
-// returned. Two formats live at the same project-scoped path:
+// v1.4.4 — extract the bare token (and paired API URL, if present)
+// from whatever keychain.ts fileGet returned. Two formats live at the
+// same project-scoped path:
 //   1. Bare token (setDeviceToken writes `<token>\n` — current path).
 //   2. Dotenv-style (step-5b writes `COMPANION_API_KEY=<token>\n
 //      COMPANION_API_URL=<url>\n` — legacy path for pre-1.4.2 installs
 //      whose device-code flow never completed).
-// Returns the extracted token, or the raw value if neither format
-// matches (defensive — preserves prior behavior for unknown inputs).
-function normalizeStoredTokenValue(raw: string): string {
+// The paired URL matters for staging installs whose COMPANION_API_URL
+// only lives in the project-scoped credentials file (step-5b moved it
+// out of .env). Without recovering it here, a rescued msd_ token would
+// be sent to the production host and 401 anyway. Codex P2 follow-up.
+function normalizeStoredTokenValue(raw: string): { token: string; apiUrl: string | null } {
   // Bare-token shortcut: no newline AND no equals → return as-is.
-  if (!raw.includes('\n') && !raw.includes('=')) return raw;
-  // Dotenv shape: extract the COMPANION_API_KEY line value.
-  const match = raw.match(/^COMPANION_API_KEY=(.+)$/m);
-  if (match !== null && match[1] !== undefined) return match[1].trim();
-  return raw;
+  if (!raw.includes('\n') && !raw.includes('=')) {
+    return { token: raw, apiUrl: null };
+  }
+  let token = raw;
+  let apiUrl: string | null = null;
+  const tokenMatch = raw.match(/^COMPANION_API_KEY=(.+)$/m);
+  if (tokenMatch !== null && tokenMatch[1] !== undefined) {
+    token = tokenMatch[1].trim();
+  }
+  const urlMatch = raw.match(/^COMPANION_API_URL=(.+)$/m);
+  if (urlMatch !== null && urlMatch[1] !== undefined) {
+    apiUrl = urlMatch[1].trim();
+  }
+  return { token, apiUrl };
 }
 
 // v1.4.4 legacy-key warning state. Module-scoped so a single process only
@@ -192,7 +204,12 @@ export function buildContext(flags: ParsedFlags): CommandContext {
 
   loadDotenv(rootDir);
 
-  const apiBase = process.env.COMPANION_API_URL ?? 'https://app.mysecond.ai';
+  // apiBase precedence: process.env COMPANION_API_URL > rescued-from-keychain
+  // dotenv URL > production default. The "rescued-from-keychain" slot is
+  // filled below if the keychain-rescue branch fires; declare it as `let`
+  // and finalize after resolution so the rescue can override.
+  let apiBase = process.env.COMPANION_API_URL ?? 'https://app.mysecond.ai';
+  const apiBaseFromEnv = process.env.COMPANION_API_URL !== undefined;
 
   // Codex P0-1: load device token from keychain at context-build time.
   // The previous design read the token in step 15, but the runner skips
@@ -246,12 +263,21 @@ export function buildContext(flags: ParsedFlags): CommandContext {
       // whose first init never completed device-code stay stuck in a
       // re-auth loop even though a valid msd_ token exists on disk.
       // Codex P2 follow-up on PR #28.
-      const normalizedKeychainToken =
+      const normalized =
         fromKeychain !== null ? normalizeStoredTokenValue(fromKeychain) : null;
-      if (normalizedKeychainToken !== null && normalizedKeychainToken.startsWith('msd_')) {
-        apiKey = normalizedKeychainToken;
+      if (normalized !== null && normalized.token.startsWith('msd_')) {
+        apiKey = normalized.token;
         apiKeySource = 'keychain';
         keychainRescue = true;
+        // Recover the paired COMPANION_API_URL when shell env didn't
+        // already supply one. Without this, staging-tier installs whose
+        // apiBase only lived in step-5b's project-scoped credentials
+        // would send the rescued msd_ token to the production host and
+        // 401 anyway. Shell env wins if both are set — explicit user
+        // override of staging targeting stays intact.
+        if (!apiBaseFromEnv && normalized.apiUrl !== null) {
+          apiBase = normalized.apiUrl;
+        }
       }
     }
   }

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -284,8 +284,18 @@ export function buildContext(flags: ParsedFlags): CommandContext {
   if (apiKey.length === 0) {
     const fromKeychain = loadKeychainToken();
     if (fromKeychain !== null) {
-      apiKey = fromKeychain;
+      // Normalize the stored value here too, for symmetry with the
+      // rescue branch above. Without this, a customer who follows the
+      // rescue warning and unsets COMPANION_API_KEY would fall into this
+      // branch, get the raw step-5b dotenv blob assigned to ctx.apiKey,
+      // and end up sending a malformed bearer to /whoami. Codex pass-4
+      // P2 — the rescue advice itself was breaking the next-run path.
+      const normalized = normalizeStoredTokenValue(fromKeychain);
+      apiKey = normalized.token;
       apiKeySource = 'keychain';
+      if (!apiBaseFromEnv && normalized.apiUrl !== null) {
+        apiBase = normalized.apiUrl;
+      }
     }
   }
 

--- a/src/lib/keychain.ts
+++ b/src/lib/keychain.ts
@@ -29,6 +29,7 @@ import {
   getProjectScopedCredsDir,
 } from './creds-path.js';
 import { mkdirSync } from 'node:fs';
+import { projectHash } from './project-hash.js';
 
 /** Where the token came from on a successful read. */
 export type TokenStorage = 'keychain' | 'file_fallback';
@@ -82,11 +83,13 @@ function accountFor(absoluteProjectDir: string): string {
   // One keychain entry per project so multiple projects on the same machine
   // can each hold their own device token. Hash via the same project-hash
   // function the rest of the cli uses for path scoping.
-  // We import lazily inside this function to keep the module's top-level
-  // import graph minimal for non-keychain callers.
-
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { projectHash } = require('./project-hash.js') as typeof import('./project-hash.js');
+  // project-hash is imported at module top — was previously a dynamic
+  // require() to keep the import graph minimal, but vitest's TS loader
+  // can't resolve dynamic requires with `.js` extensions inside `.ts`
+  // sources, so unit tests that exercise getDeviceToken/setDeviceToken
+  // would throw MODULE_NOT_FOUND. The top-level import has effectively
+  // zero startup cost (project-hash only imports node:crypto, which is
+  // already loaded by every other code path that hits this file).
   return `device-token-${projectHash(absoluteProjectDir)}`;
 }
 

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -133,12 +133,17 @@ export const step15: StepFn = async ({ ctx, shared }) => {
       };
     }
     // Existing key didn't validate (revoked, expired, or unauthenticatable).
-    // Clear it and fall through to device-code flow.
+    // Snapshot the rejected key before the clear so the message branch can
+    // distinguish "legacy companion_api_key retired" (non-msd_) from a
+    // genuine device-token revoke/expire (msd_). v1.4.4 — server PR3b
+    // stops accepting legacy keys; this messaging tells the customer why.
+    const rejectedKey = ctx.apiKey;
     (ctx as { apiKey: string }).apiKey = '';
     if (!ctx.silent) {
-      process.stdout.write(
-        'step 15: existing credential rejected by server — re-authenticating\n'
-      );
+      const message = rejectedKey.startsWith('msd_')
+        ? 'step 15: existing credential rejected by server — re-authenticating\n'
+        : 'step 15: your legacy team key has been retired — re-authenticating with the device-code flow\n';
+      process.stdout.write(message);
     }
   }
 

--- a/tests/lib/context.test.ts
+++ b/tests/lib/context.test.ts
@@ -404,6 +404,45 @@ describe('buildContext — v1.4.4 keychain rescue', () => {
     expect(stderrBuf).not.toContain('keychain-rescue=true');
   });
 
+  it('rescues when the stored credential is in legacy step-5b dotenv format', () => {
+    // step-5b writes `COMPANION_API_KEY=msd_xxx\nCOMPANION_API_URL=...` to
+    // the SAME project-scoped path keychain.ts's fileGet reads. If
+    // setDeviceToken never overwrote that file (first init aborted on
+    // device-code prompt), the file-fallback rescue would have failed
+    // because `startsWith('msd_')` doesn't match the dotenv envelope.
+    // Codex P2 follow-up on PR #28 — normalize before the prefix check.
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    process.env.COMPANION_API_KEY = 'companion_legacy_abc123';
+    plantKeychainTokenForTest(
+      tmp,
+      tmp,
+      'COMPANION_API_KEY=msd_dotenv_format_xyz\nCOMPANION_API_URL=https://app.mysecond.ai\n'
+    );
+    const ctx = buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(ctx.apiKey).toBe('msd_dotenv_format_xyz');
+    expect(stderrBuf).toContain('[mysecond:legacy-key-detected] source=env keychain-rescue=true');
+  });
+
+  it('does NOT rescue when stored dotenv contents extract to a non-msd_ value', () => {
+    // Belt-and-suspenders: a stored dotenv file that itself encodes a
+    // legacy COMPANION_API_KEY (e.g., user upgraded step-5b but never
+    // ran device-code) must NOT be treated as a rescue source — the
+    // stored value is just as stale as the env var. Original
+    // legacy-key warning fires, not the rescue variant.
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    process.env.COMPANION_API_KEY = 'companion_legacy_abc123';
+    plantKeychainTokenForTest(
+      tmp,
+      tmp,
+      'COMPANION_API_KEY=companion_legacy_stored\nCOMPANION_API_URL=https://app.mysecond.ai\n'
+    );
+    buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(stderrBuf).toContain('[mysecond:legacy-key-detected] source=env');
+    expect(stderrBuf).not.toContain('keychain-rescue=true');
+  });
+
   it('rescue marker suppresses prose under --silent but emits the marker', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
     process.env.HOME = tmp;

--- a/tests/lib/context.test.ts
+++ b/tests/lib/context.test.ts
@@ -1,10 +1,25 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { buildContext, parseGlobalFlags, _legacyKeyWarningResetForTests } from '../../src/lib/context.js';
+import { projectHash } from '../../src/lib/project-hash.js';
+
+// Plant a project-scoped credentials file at the path getProjectScopedCredsPath
+// would resolve to under an isolated $HOME. On macOS, getDeviceToken first
+// probes the system keychain via `security`, but the account name is
+// derived from projectHash(projectDir) — a tmp dir hash has effectively
+// zero probability of colliding with a real keychain entry, so the probe
+// returns null and the lookup falls through to this file.
+function plantKeychainTokenForTest(home: string, projectDir: string, token: string): void {
+  const credsDir = join(home, '.mysecond', 'projects', projectHash(projectDir));
+  mkdirSync(credsDir, { recursive: true });
+  const credsFile = join(credsDir, 'credentials');
+  writeFileSync(credsFile, token, { encoding: 'utf-8', mode: 0o600 });
+  chmodSync(credsFile, 0o600);
+}
 
 describe('parseGlobalFlags', () => {
   it('parses no args as defaults', () => {
@@ -267,5 +282,135 @@ describe('buildContext — v1.4.4 legacy-key warning', () => {
     process.env.HOME = tmp;
     buildContext(parseGlobalFlags(['--project-dir', tmp]));
     expect(stderrBuf).toBe('');
+  });
+});
+
+// v1.4.4 keychain-rescue — codex review #28 [P1] follow-up.
+//
+// The original v1.4.4 warning told customers with a legacy COMPANION_API_KEY
+// to "re-authenticate", but after re-auth the env var still wins over the
+// newly minted msd_ token in keychain, so they'd warn-and-re-auth on every
+// run forever. Fix: when the env-supplied value is non-msd_ AND keychain
+// has a valid msd_ token, prefer the keychain token and emit a distinct
+// `keychain-rescue=true` marker so the customer knows to unset the env var.
+//
+// --api-key flag is an explicit override and is NEVER rescued — passing a
+// legacy flag value means the user wants that value, even if it 401s.
+describe('buildContext — v1.4.4 keychain rescue', () => {
+  let savedKey: string | undefined;
+  let savedHome: string | undefined;
+  let savedClaudeDir: string | undefined;
+  let stderrBuf: string;
+  let origWrite: typeof process.stderr.write;
+
+  function captureStderr(): void {
+    origWrite = process.stderr.write.bind(process.stderr);
+    (process.stderr.write as unknown) = ((chunk: string | Uint8Array) => {
+      stderrBuf += typeof chunk === 'string' ? chunk : chunk.toString();
+      return true;
+    }) as typeof process.stderr.write;
+  }
+
+  beforeEach(() => {
+    savedKey = process.env.COMPANION_API_KEY;
+    savedHome = process.env.HOME;
+    savedClaudeDir = process.env.CLAUDE_PROJECT_DIR;
+    delete process.env.COMPANION_API_KEY;
+    delete process.env.CLAUDE_PROJECT_DIR;
+    stderrBuf = '';
+    captureStderr();
+    _legacyKeyWarningResetForTests();
+  });
+
+  afterEach(() => {
+    process.stderr.write = origWrite;
+    if (savedKey === undefined) delete process.env.COMPANION_API_KEY;
+    else process.env.COMPANION_API_KEY = savedKey;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedClaudeDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = savedClaudeDir;
+  });
+
+  it('prefers keychain msd_ token over legacy COMPANION_API_KEY env value', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    process.env.COMPANION_API_KEY = 'companion_legacy_abc123';
+    plantKeychainTokenForTest(tmp, tmp, 'msd_fresh_device_token_xyz');
+    const ctx = buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(ctx.apiKey).toBe('msd_fresh_device_token_xyz');
+  });
+
+  it('emits the keychain-rescue marker when rescuing a legacy env value', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    process.env.COMPANION_API_KEY = 'companion_legacy_abc123';
+    plantKeychainTokenForTest(tmp, tmp, 'msd_fresh_device_token_xyz');
+    buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(stderrBuf).toContain('[mysecond:legacy-key-detected] source=env keychain-rescue=true');
+    expect(stderrBuf).toContain('Unset COMPANION_API_KEY in your shell');
+  });
+
+  it('never echoes any portion of either token during rescue', () => {
+    // The rescue path touches both the legacy env value and the rescued
+    // msd_ token. Neither should appear in stderr.
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    process.env.COMPANION_API_KEY = 'companion_legacy_secret_envvalue';
+    plantKeychainTokenForTest(tmp, tmp, 'msd_secret_keychain_value');
+    buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(stderrBuf).not.toContain('companion_legacy_secret_envvalue');
+    expect(stderrBuf).not.toContain('msd_secret_keychain_value');
+    expect(stderrBuf).not.toContain('secret');
+  });
+
+  it('does NOT rescue when --api-key flag supplies the legacy value (explicit override)', () => {
+    // Flag is documented user override. If a customer passes
+    // --api-key companion_legacy explicitly, they want that value used
+    // even though keychain has a fresher msd_ token. Emit the original
+    // warning (source=flag), not the rescue variant.
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    plantKeychainTokenForTest(tmp, tmp, 'msd_fresh_device_token_xyz');
+    const ctx = buildContext(
+      parseGlobalFlags(['--project-dir', tmp, '--api-key', 'companion_legacy_abc123'])
+    );
+    expect(ctx.apiKey).toBe('companion_legacy_abc123');
+    expect(stderrBuf).toContain('[mysecond:legacy-key-detected] source=flag');
+    expect(stderrBuf).not.toContain('keychain-rescue=true');
+  });
+
+  it('does NOT rescue when env value is already a valid msd_ token', () => {
+    // An msd_-prefixed env value is legitimate (e.g., test fixture, CI).
+    // Keep the env value, do not switch to keychain, emit nothing.
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    process.env.COMPANION_API_KEY = 'msd_env_token_abc';
+    plantKeychainTokenForTest(tmp, tmp, 'msd_keychain_token_xyz');
+    const ctx = buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(ctx.apiKey).toBe('msd_env_token_abc');
+    expect(stderrBuf).toBe('');
+  });
+
+  it('falls back to the original legacy-key warning when keychain has no token', () => {
+    // No keychain entry → no rescue possible. Original v1.4.4 warning
+    // fires with source=env (not keychain-rescue=true).
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    process.env.COMPANION_API_KEY = 'companion_legacy_abc123';
+    const ctx = buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(ctx.apiKey).toBe('companion_legacy_abc123');
+    expect(stderrBuf).toContain('[mysecond:legacy-key-detected] source=env');
+    expect(stderrBuf).not.toContain('keychain-rescue=true');
+  });
+
+  it('rescue marker suppresses prose under --silent but emits the marker', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    process.env.COMPANION_API_KEY = 'companion_legacy_abc123';
+    plantKeychainTokenForTest(tmp, tmp, 'msd_fresh_device_token_xyz');
+    buildContext(parseGlobalFlags(['--project-dir', tmp, '--silent']));
+    expect(stderrBuf).toContain('[mysecond:legacy-key-detected] source=env keychain-rescue=true');
+    expect(stderrBuf).not.toContain('Unset COMPANION_API_KEY in your shell');
   });
 });

--- a/tests/lib/context.test.ts
+++ b/tests/lib/context.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { buildContext, parseGlobalFlags } from '../../src/lib/context.js';
+import { buildContext, parseGlobalFlags, _legacyKeyWarningResetForTests } from '../../src/lib/context.js';
 
 describe('parseGlobalFlags', () => {
   it('parses no args as defaults', () => {
@@ -129,5 +129,143 @@ describe('buildContext', () => {
       parseGlobalFlags(['--project-dir', tmp, '--silent', '--strategy', 'local-wins'])
     );
     expect(ctx.strategy).toBe('local-wins');
+  });
+});
+
+// v1.4.4 — legacy companion_api_key deprecation warning.
+//
+// Source-based gating: keychain-sourced tokens are msd_-prefixed by
+// construction. Flag/env-sourced tokens that don't start with msd_ are
+// the legacy team-shared keys server-side PR3b will stop accepting. The
+// warning fires once per process to give pre-1.4.2 customers a heads-up.
+//
+// The structured marker `[mysecond:legacy-key-detected] source=...` is a
+// stable public contract (semver gates format changes).
+describe('buildContext — v1.4.4 legacy-key warning', () => {
+  let savedKey: string | undefined;
+  let savedHome: string | undefined;
+  let savedClaudeDir: string | undefined;
+  let stderrBuf: string;
+  let stderrSpy: ReturnType<typeof captureStderr>;
+
+  function captureStderr(): { restore: () => void } {
+    const origWrite = process.stderr.write.bind(process.stderr);
+    // Vitest's process.stderr.write has overloads; the cast keeps the test
+    // simple while still capturing every byte the warning helper writes.
+    (process.stderr.write as unknown) = ((chunk: string | Uint8Array) => {
+      stderrBuf += typeof chunk === 'string' ? chunk : chunk.toString();
+      return true;
+    }) as typeof process.stderr.write;
+    return {
+      restore: () => {
+        process.stderr.write = origWrite;
+      },
+    };
+  }
+
+  beforeEach(() => {
+    savedKey = process.env.COMPANION_API_KEY;
+    savedHome = process.env.HOME;
+    savedClaudeDir = process.env.CLAUDE_PROJECT_DIR;
+    delete process.env.COMPANION_API_KEY;
+    delete process.env.CLAUDE_PROJECT_DIR;
+    stderrBuf = '';
+    stderrSpy = captureStderr();
+    _legacyKeyWarningResetForTests();
+  });
+
+  afterEach(() => {
+    stderrSpy.restore();
+    if (savedKey === undefined) delete process.env.COMPANION_API_KEY;
+    else process.env.COMPANION_API_KEY = savedKey;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedClaudeDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = savedClaudeDir;
+  });
+
+  it('emits marker + prose for a non-msd_ COMPANION_API_KEY env value', () => {
+    process.env.COMPANION_API_KEY = 'companion_legacy_abc123';
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(stderrBuf).toContain('[mysecond:legacy-key-detected] source=env');
+    expect(stderrBuf).toContain('looks like a legacy team key');
+  });
+
+  it('emits marker + prose for a non-msd_ --api-key flag value', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    buildContext(
+      parseGlobalFlags(['--project-dir', tmp, '--api-key', 'companion_legacy_abc123'])
+    );
+    expect(stderrBuf).toContain('[mysecond:legacy-key-detected] source=flag');
+    expect(stderrBuf).toContain('looks like a legacy team key');
+  });
+
+  it('never echoes any portion of the token value in the warning', () => {
+    // Bash-tool stderr is captured into model context and persisted in
+    // transcripts — token bytes there are a leak class. Source label only.
+    process.env.COMPANION_API_KEY = 'companion_legacy_secrettoken_xyz';
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(stderrBuf).not.toContain('companion_legacy_secrettoken_xyz');
+    expect(stderrBuf).not.toContain('secrettoken');
+    expect(stderrBuf).not.toContain('xyz');
+  });
+
+  it('stays silent for an msd_-prefixed COMPANION_API_KEY env value', () => {
+    process.env.COMPANION_API_KEY = 'msd_validdevicetoken_abc';
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(stderrBuf).toBe('');
+  });
+
+  it('stays silent for an msd_-prefixed --api-key flag value', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    buildContext(
+      parseGlobalFlags(['--project-dir', tmp, '--api-key', 'msd_validdevicetoken_abc'])
+    );
+    expect(stderrBuf).toBe('');
+  });
+
+  it('stays silent when no token is configured', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    // HOME isolated so the keychain/file fallback can't pick up a real
+    // device token from the developer running the tests.
+    process.env.HOME = tmp;
+    buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(stderrBuf).toBe('');
+  });
+
+  it('emits marker but suppresses prose under --silent', () => {
+    process.env.COMPANION_API_KEY = 'companion_legacy_abc123';
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    buildContext(parseGlobalFlags(['--project-dir', tmp, '--silent']));
+    expect(stderrBuf).toContain('[mysecond:legacy-key-detected] source=env');
+    expect(stderrBuf).not.toContain('looks like a legacy team key');
+  });
+
+  it('fires only once per process even on repeated buildContext calls', () => {
+    process.env.COMPANION_API_KEY = 'companion_legacy_abc123';
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    const markerMatches = stderrBuf.match(/\[mysecond:legacy-key-detected\]/g) ?? [];
+    expect(markerMatches.length).toBe(1);
+  });
+
+  it('honors source-based gating — does not warn on a keychain-sourced value', () => {
+    // Regression guard: if a future refactor accidentally regresses to
+    // a prefix-only check (without the source gate), keychain-sourced
+    // non-msd_ values would trigger false warnings. setDeviceToken is the
+    // only keychain writer and only writes msd_ today, but the source gate
+    // is the durable invariant.
+    //
+    // We can't easily plant a synthetic non-msd_ keychain value without
+    // mocking keychain.ts internals. Instead assert structurally: with no
+    // env and no flag, the warning helper is unreachable.
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(stderrBuf).toBe('');
   });
 });

--- a/tests/lib/context.test.ts
+++ b/tests/lib/context.test.ts
@@ -298,6 +298,7 @@ describe('buildContext — v1.4.4 legacy-key warning', () => {
 // legacy flag value means the user wants that value, even if it 401s.
 describe('buildContext — v1.4.4 keychain rescue', () => {
   let savedKey: string | undefined;
+  let savedUrl: string | undefined;
   let savedHome: string | undefined;
   let savedClaudeDir: string | undefined;
   let stderrBuf: string;
@@ -312,10 +313,16 @@ describe('buildContext — v1.4.4 keychain rescue', () => {
   }
 
   beforeEach(() => {
+    // Codex pass-4 P3: COMPANION_API_URL must be saved/cleared/restored
+    // here. The "shell URL wins" test below sets it explicitly, and
+    // without the restore it leaks into later cases (shuffled or in this
+    // file) and silently masks default/recovered URL behavior.
     savedKey = process.env.COMPANION_API_KEY;
+    savedUrl = process.env.COMPANION_API_URL;
     savedHome = process.env.HOME;
     savedClaudeDir = process.env.CLAUDE_PROJECT_DIR;
     delete process.env.COMPANION_API_KEY;
+    delete process.env.COMPANION_API_URL;
     delete process.env.CLAUDE_PROJECT_DIR;
     stderrBuf = '';
     captureStderr();
@@ -326,6 +333,8 @@ describe('buildContext — v1.4.4 keychain rescue', () => {
     process.stderr.write = origWrite;
     if (savedKey === undefined) delete process.env.COMPANION_API_KEY;
     else process.env.COMPANION_API_KEY = savedKey;
+    if (savedUrl === undefined) delete process.env.COMPANION_API_URL;
+    else process.env.COMPANION_API_URL = savedUrl;
     if (savedHome === undefined) delete process.env.HOME;
     else process.env.HOME = savedHome;
     if (savedClaudeDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
@@ -402,6 +411,31 @@ describe('buildContext — v1.4.4 keychain rescue', () => {
     expect(ctx.apiKey).toBe('companion_legacy_abc123');
     expect(stderrBuf).toContain('[mysecond:legacy-key-detected] source=env');
     expect(stderrBuf).not.toContain('keychain-rescue=true');
+  });
+
+  it('normalizes stored dotenv credentials in the empty-env fallback path too', () => {
+    // Codex pass-4 P2. The rescue branch handles env-sourced legacy
+    // values, but the empty-credential keychain fallback (when both
+    // --api-key and COMPANION_API_KEY are absent) was assigning the raw
+    // file contents verbatim. The rescue warning explicitly tells the
+    // customer to "unset COMPANION_API_KEY in your shell" — once they
+    // do, the next run lands HERE. Without normalization, ctx.apiKey
+    // becomes the multi-line dotenv blob and /whoami gets a malformed
+    // Authorization header.
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    // No COMPANION_API_KEY in env (already deleted in beforeEach).
+    plantKeychainTokenForTest(
+      tmp,
+      tmp,
+      'COMPANION_API_KEY=msd_unset_path_token_xyz\nCOMPANION_API_URL=https://staging.mysecond.ai\n'
+    );
+    const ctx = buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(ctx.apiKey).toBe('msd_unset_path_token_xyz');
+    expect(ctx.apiBase).toBe('https://staging.mysecond.ai');
+    // No warning in this branch — keychain-sourced, source-based gating
+    // means no warning fires regardless of whether we normalized.
+    expect(stderrBuf).toBe('');
   });
 
   it('recovers paired COMPANION_API_URL from step-5b dotenv credentials during rescue', () => {

--- a/tests/lib/context.test.ts
+++ b/tests/lib/context.test.ts
@@ -404,6 +404,47 @@ describe('buildContext — v1.4.4 keychain rescue', () => {
     expect(stderrBuf).not.toContain('keychain-rescue=true');
   });
 
+  it('recovers paired COMPANION_API_URL from step-5b dotenv credentials during rescue', () => {
+    // Staging customer installed pre-1.4.2 against a non-production host.
+    // step-5b moved both COMPANION_API_KEY and COMPANION_API_URL out of
+    // .env into the project-scoped credentials file. Their shell rc still
+    // has the legacy COMPANION_API_KEY exported but NO COMPANION_API_URL.
+    // Without recovering the URL during rescue, the freshly rescued msd_
+    // token would be sent to https://app.mysecond.ai (production default)
+    // and 401-loop. Codex pass-3 P2.
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    process.env.COMPANION_API_KEY = 'companion_legacy_abc123';
+    delete process.env.COMPANION_API_URL; // ensure file fallback wins
+    plantKeychainTokenForTest(
+      tmp,
+      tmp,
+      'COMPANION_API_KEY=msd_staging_token_xyz\nCOMPANION_API_URL=https://staging.mysecond.ai\n'
+    );
+    const ctx = buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(ctx.apiKey).toBe('msd_staging_token_xyz');
+    expect(ctx.apiBase).toBe('https://staging.mysecond.ai');
+  });
+
+  it('shell COMPANION_API_URL wins over the rescued-from-keychain URL', () => {
+    // Explicit shell env overrides should never be silently overridden
+    // by stored credentials — a developer pointing at a local dev API
+    // via `export COMPANION_API_URL=http://localhost:3000` expects that
+    // to stick even if the keychain holds a staging URL.
+    const tmp = mkdtempSync(join(tmpdir(), 'mysecond-ctx-'));
+    process.env.HOME = tmp;
+    process.env.COMPANION_API_KEY = 'companion_legacy_abc123';
+    process.env.COMPANION_API_URL = 'http://localhost:3000';
+    plantKeychainTokenForTest(
+      tmp,
+      tmp,
+      'COMPANION_API_KEY=msd_staging_token_xyz\nCOMPANION_API_URL=https://staging.mysecond.ai\n'
+    );
+    const ctx = buildContext(parseGlobalFlags(['--project-dir', tmp]));
+    expect(ctx.apiKey).toBe('msd_staging_token_xyz');
+    expect(ctx.apiBase).toBe('http://localhost:3000');
+  });
+
   it('rescues when the stored credential is in legacy step-5b dotenv format', () => {
     // step-5b writes `COMPANION_API_KEY=msd_xxx\nCOMPANION_API_URL=...` to
     // the SAME project-scoped path keychain.ts's fileGet reads. If

--- a/tests/lib/step-15-legacy-deprecation.test.ts
+++ b/tests/lib/step-15-legacy-deprecation.test.ts
@@ -1,0 +1,76 @@
+// v1.4.4 — step 15 deprecation-aware rejection message.
+//
+// When /whoami rejects an existing credential, step 15 clears ctx.apiKey
+// and emits a re-auth log line. The message must distinguish two cases:
+//
+//   1. The rejected key was a legacy team-shared companion_api_key
+//      (not msd_-prefixed). Server-side PR3b stops accepting these;
+//      the customer needs to know *why* their key was retired, not just
+//      that "something was wrong."
+//   2. The rejected key was a genuine msd_ device token (revoked via
+//      dashboard, expired, or unauthenticatable). The existing generic
+//      message is correct here.
+//
+// Structural assertions matching the established pattern in
+// reauth-on-revoked.test.ts. Behavioral coverage of the runner would
+// require mocking step 15's /whoami call, keychain I/O, and pending-auth
+// state — out of scope for a one-branch message split.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const STEP15_PATH = join(
+  import.meta.dirname ?? __dirname,
+  '..',
+  '..',
+  'src',
+  'lib',
+  'steps',
+  'step-15.ts'
+);
+
+describe('v1.4.4 — step 15 deprecation-aware rejection message', () => {
+  const source = readFileSync(STEP15_PATH, 'utf8');
+
+  it('snapshots the rejected key before clearing ctx.apiKey', () => {
+    // The rejection branch must capture ctx.apiKey into rejectedKey
+    // BEFORE the (ctx as { apiKey: string }).apiKey = '' clear, so the
+    // message branch can read the prefix. If the snapshot moves after
+    // the clear, the prefix check always sees '' and the legacy message
+    // never fires.
+    const snapshotIdx = source.indexOf('const rejectedKey = ctx.apiKey');
+    expect(snapshotIdx).toBeGreaterThan(0);
+    // The clear we care about is the one in the rejection branch, AFTER
+    // the snapshot. step-15 has an earlier clear in the --resume path
+    // (line ~98); using lastIndexOf or scanning past the snapshot avoids
+    // a false positive against that one.
+    const clearIdxAfterSnapshot = source.indexOf(
+      "(ctx as { apiKey: string }).apiKey = ''",
+      snapshotIdx
+    );
+    expect(clearIdxAfterSnapshot).toBeGreaterThan(snapshotIdx);
+  });
+
+  it('branches the rejection message on the msd_ prefix', () => {
+    // Source-based gating at context-build catches legacy keys at startup;
+    // step 15's rejection message is the second-line safety net. If a
+    // legacy key slips past the warning (silent mode, missed env capture),
+    // the rejection line must still tell the customer their team key was
+    // retired, not just that "something was rejected."
+    expect(source).toMatch(/rejectedKey\.startsWith\(['"]msd_['"]\)/);
+  });
+
+  it('emits a deprecation-aware message for non-msd_ rejected keys', () => {
+    expect(source).toContain('your legacy team key has been retired');
+  });
+
+  it('preserves the generic message for genuine msd_ token revoke/expire', () => {
+    // Regression guard: a future refactor must not collapse both branches
+    // into the legacy-deprecation wording. Customers whose msd_ tokens
+    // were revoked via the dashboard would get a confusing "legacy team
+    // key" message that doesn't match their situation.
+    expect(source).toContain('existing credential rejected by server — re-authenticating');
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the legacy `companion_api_key` deprecation to two pre-1.4.2 customer populations before mysecond-app server PR 3a/3b lands. CLI is already on device-code OAuth (v1.4.2+) — this is UX polish, not a state-machine rewrite.

- **context.ts:** source-tagged token resolution. Non-`msd_` token from `--api-key` flag or `COMPANION_API_KEY` env triggers a one-shot stderr warning: structured marker `[mysecond:legacy-key-detected] source=flag|env` always, human prose unless `--silent`.
- **step-15.ts:** snapshot `ctx.apiKey` before the clear in the `/whoami` rejection branch; branch re-auth message on `^msd_` prefix. Legacy keys see "your legacy team key has been retired"; genuine `msd_` revoke/expire keeps the existing generic message.
- **Keychain rescue (codex pass-1 P1):** when `COMPANION_API_KEY` is a non-`msd_` value and keychain has a valid `msd_` device token, prefer the keychain token and emit a distinct marker `[mysecond:legacy-key-detected] source=env keychain-rescue=true`. Without this, customers with the legacy key exported in their shell rc would 401-loop on every run after server PR 3b. `--api-key` flag is never rescued (explicit user override stays authoritative).
- **Dotenv normalization (codex pass-2 + pass-3 P2):** keychain.ts's `fileGet` returns whatever's at the project-scoped credentials path verbatim. step-5b legacy installs wrote dotenv-format (`COMPANION_API_KEY=…\nCOMPANION_API_URL=…`) to that same path. `normalizeStoredTokenValue` parses both formats; paired URL is recovered into `ctx.apiBase` when shell env doesn't supply one. Applied to both the rescue branch and the empty-env fallback.
- **Test hygiene (codex pass-4 P3):** save/restore `COMPANION_API_URL` in the keychain-rescue describe to prevent env leakage into later cases.
- **package.json:** `1.4.3` → `1.4.4`.

Source-based gating (not prefix-only) is the durable signal — keychain tokens are `msd_` by construction. Hard rule in the warning path: never echo any portion of the token value, prefix, or truncation. Bash-tool stderr is captured into model context and persisted in transcripts.

`[mysecond:legacy-key-detected]` is a **stable public contract**. Customers and agent harnesses may parse this marker (including the `keychain-rescue=true` field). Any format change (source labels, additional fields) is a breaking change and follows semver.

## Why this shape

The orchestrator session in `mysecond-app` initially scoped this as a CLI state-machine rewrite to handle a new `/api/companion/join` response shape. That premise was stale — this CLI hasn't called `/api/companion/join` since v1.4.2. After CTO + CAIO review, the plan reduced to messaging polish; codex review then added the rescue + dotenv normalization to make the migration actually self-heal.

- ❌ **Cut: headless `process.exit` hard-fail.** CAIO confirmed `process.stdin.isTTY === false` whenever the CLI is invoked from inside Claude Code's Bash tool (no PTY — [docs.claude.com/.../bash-tool](https://docs.claude.com/en/docs/agents-and-tools/tool-use/bash-tool), [PTY request #9881](https://github.com/anthropics/claude-code/issues/9881)). A `!isTTY` gate would misfire for the dominant interactive population.
- ❌ **Cut: `source=dotenv` distinction.** `loadDotenv` mutates `process.env`; the two sources are indistinguishable post-load. Collapsed to `flag | env`.

## Known limitation (codex pass-5 P2, deferred)

**Scope:** macOS users who installed pre-1.4.2 *with a manually-set non-production* `COMPANION_API_URL` (e.g., `staging.mysecond.ai`, `localhost:3000`), then later completed device-code on v1.4.2+, then unset the env var. On those installs, `getDeviceToken()` returns only the bare token from the macOS system keychain — the dotenv-format URL in the project-scoped credentials file is never surfaced — so `ctx.apiBase` falls back to the production default and the rescued staging token gets sent to the wrong host.

**Affected population:** none of mysecond's paying customers. Verified three ways:
1. Default `apiBase` has always been `https://app.mysecond.ai` (every historical revision of context.ts).
2. step-5b writes `COMPANION_API_URL=${ctx.apiBase}` ([step-5b.ts:174](src/lib/steps/step-5b.ts:174)) — only takes a non-prod value if the customer manually exported one.
3. No shipped CLI code or copy ever instructed customers to set a non-prod URL. `grep -rn "staging\|dev\.mysecond\|localhost"` in `src/` confirms.

Population reduces to **mysecond's internal staging team**, who are reachable and know how to re-set the env var if needed.

**Workaround:** `export COMPANION_API_URL=https://staging.mysecond.ai` in shell rc — wins over everything.

**Architectural fix:** the underlying step-5b ↔ keychain.ts contract (two writers, one path, two formats) deserves its own focused PR. Tracked as follow-up after v1.4.4 ships.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run build` — `dist/mysecond.mjs` 140.1kb.
- [x] `npx vitest run` — **327/327 passing across 28 files**. Includes 17 new context.test.ts cases (warning emission, source paths, `--silent` semantics, token-leak audit, one-shot guard, source-gating regression, rescue swap, marker emission, flag-no-rescue, msd_-no-rescue, fallback-no-keychain, dotenv normalization, paired-URL recovery, shell-URL-wins, empty-env normalization) and a new `step-15-legacy-deprecation.test.ts` following the structural-assertion pattern.
- [x] Token-leak audit: `grep` of built bundle confirms only literal source labels (`flag`/`env`, `keychain-rescue=true`) are interpolated into stderr; no token-value echo anywhere.
- [ ] Manual: `COMPANION_API_KEY=companion_legacy_test npx ./dist/mysecond.mjs init` from a real terminal → marker + warning fire once, step 15 hits 401, deprecation-aware rejection line prints, device-code mint persists `msd_` token, subsequent `sync` does NOT re-fire.
- [ ] Manual: `COMPANION_API_KEY=msd_valid_token …` → no marker, no warning.
- [ ] Manual: `COMPANION_API_KEY=companion_legacy_test … --silent init` → marker only, prose suppressed.

## Codex review history

5 passes total. Each pass surfaced a real failure mode (initially in this PR's new code, later in the pre-existing step-5b ↔ keychain.ts contract):

| Pass | Finding | Resolution |
|------|---------|------------|
| 1 | [P1] env value clobbers fresh msd_ token | Keychain rescue branch |
| 2 | [P2] rescue fails on step-5b dotenv format | normalizeStoredTokenValue |
| 3 | [P2] rescue loses paired URL | apiUrl recovery into ctx.apiBase |
| 4 | [P2] empty-env fallback skipped normalization; [P3] test env leak | Symmetric normalization + URL restore in afterEach |
| 5 | [P2] macOS keychain win path loses dotenv URL | Deferred — see Known limitation above |

## Coordination

Auth surface ⇒ **codex review hard-gate**. Do not self-merge.

Release sequencing:
- **Soft:** v1.4.4 should publish to npm before `mysecond-app` PR 3a merges (clean migration UX, not a breaking change — legacy keys continue to work via `validate-api-key.ts:62-86`).
- **Hard:** v1.4.4 *must* be on npm before `mysecond-app` PR 3b merges (legacy-key acceptance ends; the actual breakage gate).

Server-side confirmed by orchestrator: `/api/companion/whoami` continues to return clean 401 for legacy `companion_api_key` post-PR-3a, with rejections routed through Sentry (mysecond-app PR 1). The CLI's step-15 rejection branch keys off `response.status !== 200`, so the contract is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)