### PR TITLE
fix(ci): reorder prepublishOnly so build runs before tests; cut v1.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
     "build": "node esbuild.config.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run typecheck && npm run test && npm run build"
+    "prepublishOnly": "npm run typecheck && npm run build && npm run test"
   },
   "devDependencies": {
     "@types/node": "^20.12.0",


### PR DESCRIPTION
## Summary

The publish workflow has failed silently on **every release since v1.3.6** (early May 2026) because `prepublishOnly` runs tests before build, but [tests/cli.test.ts:74](tests/cli.test.ts:74) requires `dist/mysecond.mjs` to exist (it exec's the bundled CLI to assert shape). Local dev works because a stale `dist/` is lying around from prior builds; CI's fresh checkout doesn't, so the test throws, `prepublishOnly` exits non-zero, and `npm publish` never runs.

**Three runs failed publish with this exact symptom:**
- v1.3.6 — [run 25255925998](https://github.com/mysecond-ai/mysecond-cli/actions/runs/25255925998)
- v1.3.7 — [run 25260868039](https://github.com/mysecond-ai/mysecond-cli/actions/runs/25260868039)
- v1.4.4 — [run 25772459323](https://github.com/mysecond-ai/mysecond-cli/actions/runs/25772459323)

## Fix

One-line change in package.json:

```diff
- "prepublishOnly": "npm run typecheck && npm run test && npm run build"
+ "prepublishOnly": "npm run typecheck && npm run build && npm run test"
```

`typecheck` still runs first (fail fast on type errors before spending time on a build). `build` now runs second so the bundle exists when `cli.test.ts` looks for it. `test` runs last as the final gate before publish.

## Version bump

Also bumps `1.4.4` → `1.4.5`. The `v1.4.4` git tag exists at f40a158 but never made it to npm. `v1.4.5` will be the first npm-published release of:
- Legacy `companion_api_key` deprecation messaging (PR #28)
- This CI fix

Skipping v1.4.4 on npm is invisible to customers — they'd never see it anyway since it didn't publish.

## Test plan

- [x] Local CI simulation: `rm -rf dist/ && npm run typecheck && npm run build && npm run test` — **327/327 passing**.
- [x] Verified the failure mode: with the OLD order, the same `rm -rf dist/` simulation would have thrown at `cli.test.ts:74`. (Confirmed in publish run 25772459323's log.)
- [ ] Merge → tag `v1.4.5` → publish CI run should land green and `@mysecond/cli@1.4.5` should appear on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)