### PR TITLE
ci: explicit publish-workflow steps + auto-issue on publish failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write # for the failure-notification step below
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -18,8 +19,45 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
       - run: npm ci
-      # Early-fail on type errors before the slower test+build that prepublishOnly runs.
+      # Explicit gates, in the same order as PR CI (test.yml). Previously these
+      # were hidden inside npm's prepublishOnly lifecycle hook, which made the
+      # tag-push run silently diverge from PR CI and blocked v1.3.6, v1.3.7,
+      # and v1.4.4 from reaching npm. Keeping them explicit here is the source
+      # of truth — package.json no longer carries prepublishOnly.
       - run: npm run typecheck
+      - run: npm run build
+      - run: npm test
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Auto-file a tracking issue when this workflow fails so silent publish
+      # breakage can't accumulate across multiple releases again. GitHub's
+      # default email notification only reaches the workflow author; an issue
+      # is visible to anyone watching the repo.
+      - name: Open issue on publish failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `npm publish failed for ${tag}`,
+              body: [
+                `The publish workflow failed while trying to ship \`${tag}\` to npm.`,
+                '',
+                `**Failed run:** ${runUrl}`,
+                `**Commit:** ${context.sha}`,
+                '',
+                'Triage steps:',
+                '1. Inspect the failed job logs at the link above.',
+                '2. Confirm whether `dist/mysecond.mjs` exists in the build step output (regression of the v1.3.6–v1.4.4 issue).',
+                '3. If the fix lands on a separate PR, re-tag (e.g., `v1.4.6`) once merged.',
+                '',
+                '_Auto-filed by `.github/workflows/publish.yml`._',
+              ].join('\n'),
+              labels: ['ci', 'release-blocker'],
+            });

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "scripts": {
     "build": "node esbuild.config.mjs",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run typecheck && npm run build && npm run test"
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/node": "^20.12.0",


### PR DESCRIPTION
## Summary

Same-day follow-up to [PR #29](https://github.com/mysecond-ai/mysecond-cli/pull/29). Addresses the architectural issue the CTO review flagged: `prepublishOnly` is a foot-gun, and the publish workflow's reliance on it caused the v1.3.6 → v1.4.4 silent breakage.

### Three changes:

**1. `.github/workflows/publish.yml` — explicit gates**
Adds `typecheck`, `build`, `test` as explicit steps before `npm publish --access public`. Same order as `.github/workflows/test.yml`. The publish workflow is now the single source of truth for what gates a release; nothing hides inside an npm lifecycle hook.

**2. `package.json` — remove `prepublishOnly`**
Deletes the hook entirely. A local `npm publish` from a dirty laptop now succeeds or fails based on what's actually on disk — no implicit `npm run build` step buried in lifecycle. CI continues to gate properly because publish.yml now runs the same checks explicitly.

**3. `.github/workflows/publish.yml` — failure notification**
New `if: failure()` step uses `actions/github-script@v7` to auto-file a tracking issue (labels: `ci`, `release-blocker`) whenever publish fails. GitHub's default email notifications only reach the workflow author; an issue is visible to anyone watching the repo and would have caught the v1.3.6 → v1.4.4 silent breakage a month sooner.

Issue body links to the failed run, identifies the tag and commit, and includes a 3-step triage checklist. Requires `issues: write` on the job's permissions block (added).

## Why this shape (per CTO review on PR #29)

> "`prepublishOnly` is a foot-gun. It runs on every `npm publish`, including from a dirty laptop, and it silently passes locally because `dist/` is stale (exactly how this slipped for 3 releases). The publish workflow should explicitly run `npm ci && npm run typecheck && npm run build && npm run test && npm publish` and `prepublishOnly` should be deleted."

Three releases failed publish silently with this exact symptom:
- v1.3.6 — [run 25255925998](https://github.com/mysecond-ai/mysecond-cli/actions/runs/25255925998)
- v1.3.7 — [run 25260868039](https://github.com/mysecond-ai/mysecond-cli/actions/runs/25260868039)
- v1.4.4 — [run 25772459323](https://github.com/mysecond-ai/mysecond-cli/actions/runs/25772459323)

v1.4.5 ([run 25776515153](https://github.com/mysecond-ai/mysecond-cli/actions/runs/25776515153)) shipped to npm after PR #29 swapped the script order. This PR removes the underlying foot-gun so the symptom can't reappear in a different form.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run build` — `dist/mysecond.mjs` 140.1kb.
- [x] PR CI on this branch should land green (same order as already-passing test.yml).
- [ ] Next tag (v1.4.6 or later) will exercise the new explicit publish flow. If the publish step fails, the new `if: failure()` step should auto-create an issue — visible by checking the repo's open issues after the failed run.
- [ ] (Optional) Verify failure-notification by temporarily inserting `- run: exit 1` before `npm publish` on a throwaway tag, confirming an issue is filed, then revert.

## Not in this PR

- PR CI workflow (`test.yml`) — already runs the canonical order (`typecheck → build → test`) so no parity gap remains. `actions/checkout@v4` guarantees a fresh tree; no `rm -rf dist/` needed.
- Migration to npm Trusted Publishing OIDC — already tracked in CLAUDE.md as a post-first-publish follow-up; separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)