### PR TITLE
fix(sync): send team_id explicitly from `mysecond sync` (P1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -372,6 +372,38 @@ function maybeNudgeCredsMigration(ctx: CommandContext): void {
   );
 }
 
+/**
+ * Reads `MYSECOND_TEAM_ID` from the project-scoped credentials file, if
+ * present. step-5b writes this line for invited-PM team-joins; it is absent
+ * for Solo customers, team owners, and upgrade customers whose creds file
+ * predates the team-id write. When absent we return null and `cliSync` omits
+ * `team_id` — the server auto-derives it from the credential, so omitting it
+ * is a safe no-op. Synchronous, local-only read; no network.
+ *
+ * Parsing mirrors step-5b's `readProjectScopedCreds` (same trim + quote-strip).
+ */
+export function readTeamIdFromCreds(rootDir: string): string | null {
+  const credsPath = getProjectScopedCredsPath(rootDir);
+  if (!existsSync(credsPath)) return null;
+  try {
+    const raw = readFileSync(credsPath, 'utf8');
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('MYSECOND_TEAM_ID=')) {
+        const eqIdx = trimmed.indexOf('=');
+        const value = trimmed
+          .slice(eqIdx + 1)
+          .replace(/^["']|["']$/g, '')
+          .trim();
+        return value.length > 0 ? value : null;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export async function runSync(
   _args: readonly string[],
   ctx: CommandContext
@@ -409,6 +441,7 @@ export async function runSync(
     response = await cliSync(ctx, previousPaths, {
       ...cliSyncOpts,
       clientBasePluginVersion: installState.base_plugin_version,
+      teamId: readTeamIdFromCreds(ctx.rootDir),
     });
   } catch (err) {
     const httpCode = err instanceof MysecondError ? err.exitCode : -1;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -88,9 +88,22 @@ async function companionFetch(
 export async function cliSync(
   ctx: CommandContext,
   previousPaths: readonly string[],
-  opts: { timeoutMs?: number; clientBasePluginVersion?: string | null } = {}
+  opts: {
+    timeoutMs?: number;
+    clientBasePluginVersion?: string | null;
+    teamId?: string | null;
+  } = {}
 ): Promise<CliSyncResponse> {
   const query: Record<string, string | undefined> = {};
+  // Explicit client-side tenant scoping: send the team_id the install flow
+  // recorded in the project-scoped credentials file, when present. The server
+  // auto-derives team_id from the credential when this is omitted (see
+  // mysecond-app#257 / cli-sync route), so omitting it is a safe no-op for
+  // Solo customers, team owners, and upgrade customers whose creds file
+  // predates the team-id line.
+  if (opts.teamId) {
+    query['team_id'] = opts.teamId;
+  }
   if (previousPaths.length > 0) {
     query['previous_paths'] = previousPaths.join(',');
   }

--- a/tests/commands/sync-team-id.test.ts
+++ b/tests/commands/sync-team-id.test.ts
@@ -1,0 +1,77 @@
+// Tests for readTeamIdFromCreds — the `mysecond sync` command's local read of
+// MYSECOND_TEAM_ID from the project-scoped credentials file (P1, mysecond-app#257).
+//
+// Isolates HOME per test so ~/.mysecond/projects/ writes don't escape into the
+// real user dir — mirrors the step-5b.test.ts pattern.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readTeamIdFromCreds } from '../../src/commands/sync.js';
+import {
+  getProjectScopedCredsDir,
+  getProjectScopedCredsPath,
+} from '../../src/lib/creds-path.js';
+
+let originalHome: string;
+let tmpHome: string;
+let projectDir: string;
+
+beforeEach(() => {
+  originalHome = process.env.HOME ?? homedir();
+  tmpHome = mkdtempSync(join(tmpdir(), 'cli-team-id-home-'));
+  process.env.HOME = tmpHome;
+  projectDir = mkdtempSync(join(tmpdir(), 'cli-team-id-proj-'));
+});
+
+afterEach(() => {
+  process.env.HOME = originalHome;
+  try {
+    rmSync(tmpHome, { recursive: true, force: true });
+  } catch {}
+  try {
+    rmSync(projectDir, { recursive: true, force: true });
+  } catch {}
+});
+
+function writeCreds(content: string): void {
+  const dir = getProjectScopedCredsDir(projectDir);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(getProjectScopedCredsPath(projectDir), content);
+}
+
+describe('readTeamIdFromCreds', () => {
+  it('returns the team id when the creds file has a MYSECOND_TEAM_ID line', () => {
+    writeCreds(
+      'COMPANION_API_KEY=key123\n' +
+        'COMPANION_API_URL=https://app.mysecond.ai\n' +
+        'MYSECOND_TEAM_ID=e8c3e0ac-f1c2-45f9-b614-f5c63c995a6a\n'
+    );
+    expect(readTeamIdFromCreds(projectDir)).toBe(
+      'e8c3e0ac-f1c2-45f9-b614-f5c63c995a6a'
+    );
+  });
+
+  it('returns null when the creds file has no MYSECOND_TEAM_ID line (Solo / team owner / upgrade customer)', () => {
+    writeCreds(
+      'COMPANION_API_KEY=key123\nCOMPANION_API_URL=https://app.mysecond.ai\n'
+    );
+    expect(readTeamIdFromCreds(projectDir)).toBeNull();
+  });
+
+  it('returns null when the creds file does not exist', () => {
+    expect(readTeamIdFromCreds(projectDir)).toBeNull();
+  });
+
+  it('strips surrounding quotes and whitespace from the value', () => {
+    writeCreds('MYSECOND_TEAM_ID="team-quoted-42"\n');
+    expect(readTeamIdFromCreds(projectDir)).toBe('team-quoted-42');
+  });
+
+  it('returns null when MYSECOND_TEAM_ID is present but empty', () => {
+    writeCreds('COMPANION_API_KEY=key123\nMYSECOND_TEAM_ID=\n');
+    expect(readTeamIdFromCreds(projectDir)).toBeNull();
+  });
+});

--- a/tests/lib/api.test.ts
+++ b/tests/lib/api.test.ts
@@ -5,7 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { contextFilesPush } from '../../src/lib/api.js';
+import { cliSync, contextFilesPush } from '../../src/lib/api.js';
 import type { CommandContext } from '../../src/lib/context.js';
 import type { ContextFilePayload } from '../../src/lib/payload.js';
 
@@ -136,5 +136,62 @@ describe('contextFilesPush', () => {
     await expect(
       contextFilesPush(ctx(), [file('context/a.md', 'a')], { timeoutMs: 50 })
     ).rejects.toThrow(/Cannot reach mysecond\.ai/);
+  });
+});
+
+// P1 (mysecond-app#257): the CLI now sends team_id explicitly when the install
+// flow recorded it in the project-scoped credentials file. Assert the outgoing
+// wire format so a regression that drops the param surfaces here.
+describe('cliSync — team_id query param', () => {
+  let originalFetch: typeof fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('includes team_id in the query when opts.teamId is set', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ context_files: [], syncedAt: 'now' }));
+    await cliSync(ctx(), [], { teamId: 'team-abc-123' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe('/api/companion/cli-sync');
+    expect(url.searchParams.get('team_id')).toBe('team-abc-123');
+  });
+
+  it('omits team_id from the query when opts.teamId is null', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ context_files: [], syncedAt: 'now' }));
+    await cliSync(ctx(), [], { teamId: null });
+
+    const [url] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.searchParams.has('team_id')).toBe(false);
+  });
+
+  it('omits team_id from the query when opts.teamId is absent', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ context_files: [], syncedAt: 'now' }));
+    await cliSync(ctx(), []);
+
+    const [url] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.searchParams.has('team_id')).toBe(false);
+  });
+
+  it('sends team_id alongside previous_paths and client_base_plugin_version', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ context_files: [], syncedAt: 'now' }));
+    await cliSync(ctx(), ['context/a.md', 'context/b.md'], {
+      teamId: 'team-xyz',
+      clientBasePluginVersion: 'sha123',
+    });
+
+    const [url] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.searchParams.get('team_id')).toBe('team-xyz');
+    expect(url.searchParams.get('previous_paths')).toBe('context/a.md,context/b.md');
+    expect(url.searchParams.get('client_base_plugin_version')).toBe('sha123');
   });
 });


### PR DESCRIPTION
## P1 — CLI-side defense-in-depth for the cli-sync HTTP 400

Companion to [mysecond-app#257](https://github.com/mysecond-ai/mysecond-app/pull/257) (the P0 server fix). **P0 alone unblocks every Team-tier customer** — this PR is optional polish: explicit client-side tenant scoping. Non-blocking, ships independently.

## What changed

The `mysecond sync` command now sends `team_id` as a query param when the install flow recorded it:

1. **`src/commands/sync.ts`** — new exported `readTeamIdFromCreds(rootDir)`: a synchronous, local-only read of `MYSECOND_TEAM_ID` from the project-scoped credentials file (`getProjectScopedCredsPath`). Parsing mirrors step-5b's `readProjectScopedCreds`. Wired into the `cliSync()` call in `runSync`.
2. **`src/lib/api.ts`** — `cliSync()` `opts` gains `teamId?: string | null`; when truthy it's added as `query['team_id']`.
3. **`package.json`** — version bump `1.4.5` → `1.4.6` (patch — scoped bugfix).

When the credentials file has no `MYSECOND_TEAM_ID` line — Solo customers, team owners, and upgrade customers whose creds file predates the team-id write — `team_id` is omitted and the server auto-derives it from the credential (P0). So omitting it is a safe no-op.

## Scope (fenced — deliberately minimal)

- `sync` command only. **`artifact-sync` untouched**, **`buildContext` untouched.**
- No `async` signature changes, no `/whoami` calls, no caches. (Those were rev 1-4 over-engineering that rev 5 explicitly cut.)
- `artifact-sync` imports only `artifactsSync` / `contextFilesPush` from `api.ts` — it never touches `cliSync` or whoami, so it issues zero `/whoami` calls. Confirmed unchanged.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean (`dist/mysecond.mjs` 140.8kb)
- [x] `npm test` — full suite **29 files / 336 tests pass**
- [x] New: `tests/lib/api.test.ts` — `cliSync` includes `team_id` when `opts.teamId` set; omits it when `null` or absent; sends it alongside `previous_paths` + `client_base_plugin_version`
- [x] New: `tests/commands/sync-team-id.test.ts` — `readTeamIdFromCreds` returns the value when the creds file has the line; `null` when absent / file missing / value empty; strips quotes + whitespace

Plan: `~/.claude/plans/you-are-running-autonomously-typed-coral.md` (REV 5, P1 section).

Do **not** publish to npm from this PR — publish is handled separately.

🤖 Generated with Claude Code