### PR TITLE
Track D: replacing install + flat-layout plugin counts — duplicate skills fix (#2, v1.4.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -591,7 +591,10 @@ export async function runSync(
   // no stale plugins. Never fails the sync.
   if (state.customerSlug !== null && state.customerSlug !== undefined && state.customerSlug !== '') {
     try {
-      const prune = pruneStalePlugins(state.customerSlug, { silent: ctx.silent });
+      // pruneStalePlugins validates the slug internally — the SessionStart
+      // sync path has NO prior validateSlug() on state.customerSlug, so an
+      // invalid/corrupt sync-state.json slug is rejected inside (no-op).
+      const prune = await pruneStalePlugins(state.customerSlug, { silent: ctx.silent });
       if (!prune.noop && prune.removed.length > 0 && !ctx.silent) {
         process.stderr.write(
           `[mysecond] Removed ${prune.removed.length} stale plugin(s) from a prior install: ${prune.removed.join(', ')}\n`

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -34,6 +34,7 @@ import {
   type CompanionFile,
   type ContextFile,
 } from '../lib/payload.js';
+import { pruneStalePlugins } from '../lib/prune-stale-plugins.js';
 import { readSyncState, writeSyncState, type SyncState } from '../lib/sync-state.js';
 
 const TEAM_OVERRIDE_START = '<!-- TEAM_OVERRIDE:START -->';
@@ -578,6 +579,28 @@ export async function runSync(
 
   state.lastSyncedAt = response.syncedAt;
   writeSyncState(ctx.rootDir, state);
+
+  // Self-heal the "duplicate skills" bug (Finding #2) for EXISTING customers.
+  // step-9 (plugin install) is skipped on re-runs once the init ledger is
+  // complete, so a customer who onboarded during the 2026-05-04→05
+  // multi-category experiment window — and now carries 13 orphaned `pm-*`
+  // plugins alongside `pm-os` — would never get cleaned up by `init` alone.
+  // `sync` runs on every SessionStart hook, so pruning here auto-heals them on
+  // their next session. Scoped strictly to this customer's own slug;
+  // best-effort and idempotent — a no-op for the common case where there are
+  // no stale plugins. Never fails the sync.
+  if (state.customerSlug !== null && state.customerSlug !== undefined && state.customerSlug !== '') {
+    try {
+      const prune = pruneStalePlugins(state.customerSlug, { silent: ctx.silent });
+      if (!prune.noop && prune.removed.length > 0 && !ctx.silent) {
+        process.stderr.write(
+          `[mysecond] Removed ${prune.removed.length} stale plugin(s) from a prior install: ${prune.removed.join(', ')}\n`
+        );
+      }
+    } catch {
+      // Best-effort: stale-plugin cleanup must never fail a sync.
+    }
+  }
 
   // First-sync = no prior server timestamp AND no prior tracked paths. Both
   // checks must use the snapshots captured before any state mutations above.

--- a/src/lib/plugin-counts.ts
+++ b/src/lib/plugin-counts.ts
@@ -5,23 +5,30 @@
 // real content. Counts are intentionally tolerant — missing dirs return 0,
 // non-skill files (READMEs, .DS_Store) are ignored.
 //
-// Plugin layout (multi-subplugin — what product-manager-os actually emits):
-//   plugin/
-//     <subplugin>/
-//       .claude-plugin/plugin.json    (presence marks a real subplugin)
-//       skills/<skill-name>/SKILL.md  (counted as a skill)
-//       agents/<agent-name>.md        (counted as a sub-agent)
-//       workflows/<workflow>.md       (counted as a workflow — workflows-pack)
-//       commands/<wrapper>.md         (NOT counted — slash-command wrappers
-//                                     around skills, 1:1 with the skills/ dir)
+// Plugin layout — TWO shapes are supported:
 //
-// Subdirs without `.claude-plugin/plugin.json` (e.g. `context-templates/`,
-// `work/`) are skipped silently so they neither contribute nor break counting.
+//   (1) FLAT (current — what product-manager-os actually emits):
+//       plugin/
+//         .claude-plugin/plugin.json    (presence marks the FLAT plugin root)
+//         skills/<skill-name>/SKILL.md  (counted as a skill)
+//         agents/<agent-name>.md        (counted as a sub-agent)
+//         workflows/<workflow>.md       (counted as a workflow)
+//         commands/<wrapper>.md         (NOT counted — slash-command wrappers)
 //
-// If no subplugins are detected, returns zeros — there is no flat-layout
-// fallback. The cli only ever installs product-manager-os, which is always
-// multi-subplugin. Returning zeros triggers the existing fallback string in
-// `successBox` ("pm-os plugin registered with your PM skill library").
+//   (2) MULTI-SUBPLUGIN (legacy — the abandoned 13-category experiment):
+//       plugin/
+//         <subplugin>/
+//           .claude-plugin/plugin.json  (presence marks a real subplugin)
+//           skills/ | agents/ | workflows/  (counted, summed across subplugins)
+//
+// Detection: if `plugin/.claude-plugin/plugin.json` exists, treat as FLAT and
+// count directly under the root. Otherwise fall back to scanning subdirs for
+// the multi-subplugin marker. Subdirs (or a root) without the marker contribute
+// nothing — `context-templates/`, `work/`, READMEs etc. are skipped silently.
+//
+// If neither layout is detected, returns zeros. Returning zeros triggers the
+// existing fallback string in `successBox` ("pm-os plugin registered with your
+// PM skill library").
 
 import { readdirSync, statSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
@@ -55,6 +62,10 @@ function isDir(path: string): boolean {
   }
 }
 
+function hasPluginManifest(dir: string): boolean {
+  return existsSync(join(dir, '.claude-plugin', 'plugin.json'));
+}
+
 function countDirEntries(dir: string): number {
   let count = 0;
   for (const name of safeReaddir(dir)) {
@@ -75,9 +86,28 @@ function countDirEntries(dir: string): number {
   return count;
 }
 
+// Count skills/agents/workflows directly under a single plugin root.
+function countOnePlugin(pluginRoot: string): PluginCounts {
+  return {
+    skills: countDirEntries(join(pluginRoot, 'skills')),
+    agents: countDirEntries(join(pluginRoot, 'agents')),
+    workflows: countDirEntries(join(pluginRoot, 'workflows')),
+  };
+}
+
 export function countPluginContents(pluginDir: string): PluginCounts {
   if (!isDir(pluginDir)) return { ...EMPTY };
 
+  // FLAT layout: the plugin manifest sits at the root. product-manager-os
+  // ships a single `pm-os` plugin with `source: "./"`, so the extracted tree's
+  // root IS the plugin root — skills/agents/workflows live directly under it.
+  if (hasPluginManifest(pluginDir)) {
+    return countOnePlugin(pluginDir);
+  }
+
+  // MULTI-SUBPLUGIN layout (legacy): sum every subdir that carries its own
+  // `.claude-plugin/plugin.json` marker. Subdirs without the marker
+  // (context-templates/, work/) are skipped silently.
   const totals: PluginCounts = { skills: 0, agents: 0, workflows: 0 };
   let foundAnySubplugin = false;
 
@@ -85,12 +115,13 @@ export function countPluginContents(pluginDir: string): PluginCounts {
     if (!isVisible(name)) continue;
     const subDir = join(pluginDir, name);
     if (!isDir(subDir)) continue;
-    if (!existsSync(join(subDir, '.claude-plugin', 'plugin.json'))) continue;
+    if (!hasPluginManifest(subDir)) continue;
 
     foundAnySubplugin = true;
-    totals.skills += countDirEntries(join(subDir, 'skills'));
-    totals.agents += countDirEntries(join(subDir, 'agents'));
-    totals.workflows += countDirEntries(join(subDir, 'workflows'));
+    const sub = countOnePlugin(subDir);
+    totals.skills += sub.skills;
+    totals.agents += sub.agents;
+    totals.workflows += sub.workflows;
   }
 
   if (!foundAnySubplugin) return { ...EMPTY };

--- a/src/lib/plugin-counts.ts
+++ b/src/lib/plugin-counts.ts
@@ -5,6 +5,14 @@
 // real content. Counts are intentionally tolerant — missing dirs return 0,
 // non-skill files (READMEs, .DS_Store) are ignored.
 //
+// Counting contract (tightened per Codex P2-7 — a stray dir/file must not
+// inflate counts):
+//   - a SKILL  = a subdirectory of `skills/` that contains a `SKILL.md` file.
+//   - an AGENT = a `.md` FILE directly under `agents/`.
+//   - a WORKFLOW = a `.md` FILE directly under `workflows/`.
+// Anything else (loose files under `skills/`, subdirs under `agents/`, etc.)
+// is not counted.
+//
 // Plugin layout — TWO shapes are supported:
 //
 //   (1) FLAT (current — what product-manager-os actually emits):
@@ -66,19 +74,34 @@ function hasPluginManifest(dir: string): boolean {
   return existsSync(join(dir, '.claude-plugin', 'plugin.json'));
 }
 
-function countDirEntries(dir: string): number {
+// Count skills under a `skills/` dir. A skill is a SUBDIRECTORY that contains a
+// `SKILL.md` file — the Anthropic skill contract. A stray loose file or an
+// empty/marker-less subdir (e.g. `.git`, a scratch dir) does NOT count. This is
+// tighter than "any visible dir" (P2-7): a stray dir under `skills/` no longer
+// inflates the count.
+function countSkills(skillsDir: string): number {
+  let count = 0;
+  for (const name of safeReaddir(skillsDir)) {
+    if (!isVisible(name)) continue;
+    const skillDir = join(skillsDir, name);
+    if (!isDir(skillDir)) continue;
+    if (!existsSync(join(skillDir, 'SKILL.md'))) continue;
+    count += 1;
+  }
+  return count;
+}
+
+// Count agents/workflows under their dir. Each is a single `.md` FILE
+// (`agents/<name>.md`, `workflows/<name>.md`). Subdirectories are NOT counted —
+// a stray dir under `agents/`/`workflows/` no longer inflates the count (P2-7).
+function countMarkdownFiles(dir: string): number {
   let count = 0;
   for (const name of safeReaddir(dir)) {
     if (!isVisible(name)) continue;
+    if (!name.toLowerCase().endsWith('.md')) continue;
     const full = join(dir, name);
     try {
-      const st = statSync(full);
-      if (st.isDirectory()) {
-        count += 1;
-      } else if (st.isFile() && name.toLowerCase().endsWith('.md')) {
-        // Allow flat-file layouts (agents/foo.md, workflows/foo.md) too.
-        count += 1;
-      }
+      if (statSync(full).isFile()) count += 1;
     } catch {
       // unreadable entry; skip
     }
@@ -89,9 +112,9 @@ function countDirEntries(dir: string): number {
 // Count skills/agents/workflows directly under a single plugin root.
 function countOnePlugin(pluginRoot: string): PluginCounts {
   return {
-    skills: countDirEntries(join(pluginRoot, 'skills')),
-    agents: countDirEntries(join(pluginRoot, 'agents')),
-    workflows: countDirEntries(join(pluginRoot, 'workflows')),
+    skills: countSkills(join(pluginRoot, 'skills')),
+    agents: countMarkdownFiles(join(pluginRoot, 'agents')),
+    workflows: countMarkdownFiles(join(pluginRoot, 'workflows')),
   };
 }
 

--- a/src/lib/prune-stale-plugins.ts
+++ b/src/lib/prune-stale-plugins.ts
@@ -1,0 +1,190 @@
+// prune-stale-plugins.ts — make the plugin install REPLACING, not additive.
+//
+// THE BUG (Finding #2 / "duplicate skills"):
+// During a multi-category experiment window (2026-05-04 → 2026-05-05), the cli
+// installed each customer as 13 separately-named plugins (`pm-communication`,
+// `pm-competitive`, `pm-data`, …, `pm-cc`) under the customer's marketplace
+// `mysecond-customer-<slug>`. Before and after that window, the cli installs a
+// single flat `pm-os` plugin under the same marketplace name.
+//
+// The cli install path (`claude plugin install pm-os@<marketplace>`) is purely
+// ADDITIVE — it never uninstalls a customer's prior plugins. So a customer who
+// onboarded during the experiment window and later re-synced ends up with BOTH
+// the 13 old `pm-*` plugins AND the new `pm-os`, all registered in
+// `~/.claude/plugins/installed_plugins.json`. Claude Code namespaces a skill by
+// its plugin's name, so every skill appears twice: the correct un-prefixed one
+// from `pm-os`, plus an abandoned `pm-data:funnel-analyzer`-style duplicate.
+//
+// THE FIX:
+// After installing the current `pm-os` plugin, enumerate every plugin entry
+// keyed `<plugin>@mysecond-customer-<slug>` for THIS customer's slug, and
+// `claude plugin uninstall` any whose plugin name is not `pm-os`. The
+// per-customer marketplace registration itself is preserved — `pm-os` still
+// needs it. Only the orphaned individual plugin entries are removed.
+//
+// SAFETY — scope strictly to the customer's OWN slug:
+// A real customer machine has exactly one customer (one slug). Only internal
+// test machines accumulate many. The marketplace-suffix match
+// (`@mysecond-customer-<slug>`) guarantees we never touch another customer's
+// entries, another marketplace's plugins (playwright@claude-plugins-official),
+// or the current `pm-os` install.
+//
+// MECHANISM:
+// Drives removal through the official `claude plugin uninstall` CLI — the same
+// `claude plugin …` mechanism step-9 uses to install — rather than hand-editing
+// installed_plugins.json. Reading installed_plugins.json is only used to
+// DISCOVER which stale plugin names exist; the actual mutation goes through the
+// supported CLI so Claude Code keeps its own bookkeeping (cache dirs,
+// install-counts) consistent. Best-effort cache-dir cleanup is a follow-up
+// belt-and-braces step for entries Claude Code's uninstall leaves behind.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { marketplaceName, SENTINEL_PLUGIN_NAME } from './mysecond-paths.js';
+
+/** Path to Claude Code's installed-plugins ledger. */
+export function installedPluginsJsonPath(): string {
+  return join(homedir(), '.claude', 'plugins', 'installed_plugins.json');
+}
+
+/** Cache dir for a single plugin under a customer marketplace. */
+function pluginCacheDir(slug: string, pluginName: string): string {
+  return join(
+    homedir(),
+    '.claude',
+    'plugins',
+    'cache',
+    marketplaceName(slug),
+    pluginName,
+  );
+}
+
+export interface PrunePlan {
+  /** Plugin names (not `pm-os`) found registered under this customer's marketplace. */
+  stalePluginNames: string[];
+  /** The marketplace name scoped to this slug — every match shares it. */
+  marketplace: string;
+}
+
+/**
+ * Read installed_plugins.json and determine which plugin entries are stale for
+ * THIS customer's slug. A stale entry is any key `<plugin>@mysecond-customer-<slug>`
+ * whose `<plugin>` is not the current expected plugin (`pm-os`).
+ *
+ * Soft-fails to an empty plan: a missing or corrupt ledger means there's
+ * nothing we can safely prune — never throw out of the install path.
+ */
+export function planStalePluginPrune(slug: string): PrunePlan {
+  const marketplace = marketplaceName(slug);
+  const empty: PrunePlan = { stalePluginNames: [], marketplace };
+
+  const ledgerPath = installedPluginsJsonPath();
+  let raw: string;
+  try {
+    raw = readFileSync(ledgerPath, 'utf8');
+  } catch {
+    return empty; // no ledger yet (fresh machine) — nothing to prune
+  }
+
+  let parsed: { plugins?: Record<string, unknown> };
+  try {
+    parsed = JSON.parse(raw) as { plugins?: Record<string, unknown> };
+  } catch {
+    return empty; // corrupt ledger — don't risk acting on garbage
+  }
+
+  const plugins = parsed.plugins;
+  if (plugins === null || plugins === undefined || typeof plugins !== 'object') {
+    return empty;
+  }
+
+  // Match the EXACT marketplace suffix — `@mysecond-customer-<slug>`. This is
+  // what scopes us to the customer's own slug and nothing else. A substring
+  // check would be wrong (slug `t05` must not match `t0501`); we split on the
+  // last `@` and compare the marketplace segment for equality.
+  const suffix = `@${marketplace}`;
+  const stale = new Set<string>();
+  for (const key of Object.keys(plugins)) {
+    if (!key.endsWith(suffix)) continue;
+    const pluginName = key.slice(0, key.length - suffix.length);
+    if (pluginName.length === 0) continue;
+    if (pluginName === SENTINEL_PLUGIN_NAME) continue; // the current, correct plugin
+    stale.add(pluginName);
+  }
+
+  return { stalePluginNames: [...stale].sort(), marketplace };
+}
+
+export interface PruneResult {
+  /** Plugin names we successfully uninstalled. */
+  removed: string[];
+  /** Plugin names where `claude plugin uninstall` exited non-zero. */
+  failed: string[];
+  /** True when there was nothing to prune. */
+  noop: boolean;
+}
+
+/**
+ * Remove every stale `pm-*` plugin left over from the 13-plugin experiment for
+ * THIS customer's slug. Idempotent: a customer who never hit the experiment
+ * window has an empty plan and this is a no-op.
+ *
+ * Best-effort throughout — a failed uninstall is logged to `failed` but never
+ * throws. The customer's `pm-os` install (the thing that actually matters)
+ * already succeeded by the time this runs; stale-plugin cleanup must not be
+ * able to fail the install.
+ *
+ * `claudeBin` is injectable for tests; defaults to the `claude` binary on PATH.
+ */
+export function pruneStalePlugins(
+  slug: string,
+  opts: { claudeBin?: string; silent?: boolean } = {},
+): PruneResult {
+  const claudeBin = opts.claudeBin ?? 'claude';
+  const plan = planStalePluginPrune(slug);
+
+  if (plan.stalePluginNames.length === 0) {
+    return { removed: [], failed: [], noop: true };
+  }
+
+  const removed: string[] = [];
+  const failed: string[] = [];
+
+  for (const pluginName of plan.stalePluginNames) {
+    const spec = `${pluginName}@${plan.marketplace}`;
+    const result = spawnSync(
+      claudeBin,
+      ['plugin', 'uninstall', spec, '--scope', 'user'],
+      { stdio: 'pipe' },
+    );
+
+    if (result.status === 0) {
+      removed.push(pluginName);
+    } else {
+      failed.push(pluginName);
+      if (opts.silent !== true) {
+        const exitDisplay = result.status ?? 'ENOENT';
+        process.stderr.write(
+          `[mysecond] note: could not uninstall stale plugin ${spec} (exit ${exitDisplay}) — continuing.\n`,
+        );
+      }
+    }
+
+    // Belt-and-braces: remove the plugin's cache dir if `claude plugin
+    // uninstall` left it behind (or if the ledger entry was orphaned with no
+    // backing CLI state). rmSync force:true is a no-op when the dir is absent.
+    try {
+      const cacheDir = pluginCacheDir(slug, pluginName);
+      if (existsSync(cacheDir)) {
+        rmSync(cacheDir, { recursive: true, force: true });
+      }
+    } catch {
+      // cache cleanup is purely cosmetic — never let it surface an error
+    }
+  }
+
+  return { removed, failed, noop: false };
+}

--- a/src/lib/prune-stale-plugins.ts
+++ b/src/lib/prune-stale-plugins.ts
@@ -109,9 +109,27 @@ function isPlainPluginToken(name: string): boolean {
  *  non-fatal failure (the plugin stays; next sync retries). */
 const UNINSTALL_TIMEOUT_MS = 30_000;
 
-/** proper-lockfile settings for the Claude-plugin-dir lock. Mirrors
- *  marketplace-lock.ts: dead-process locks auto-release after 30s. */
-const LOCK_STALE_MS = 30_000;
+/**
+ * proper-lockfile stale window for the Claude-plugin-dir lock.
+ *
+ * This must comfortably EXCEED the worst-case synchronous critical section.
+ * The critical section runs blocking `spawnSync()` in a loop over up to
+ * `EXPERIMENT_PLUGINS.length` plugins, each capped at `UNINSTALL_TIMEOUT_MS`.
+ * While `spawnSync()` blocks the event loop, proper-lockfile's heartbeat timer
+ * CANNOT fire to refresh the lock's mtime — so if the stale window were merely
+ * 30s (one uninstall), a second concurrent `mysecond sync` (every SessionStart)
+ * would treat the still-held lock as stale and steal it mid-prune.
+ *
+ * Worst case = every uninstall hangs to its full timeout: 13 × 30s = 390s.
+ * Add a 60s margin for ledger reads, rmSync, and process scheduling jitter.
+ * Computed from the two source constants so it stays correct if either changes.
+ *
+ * The prune is best-effort + idempotent (plan re-read inside the lock,
+ * "already gone" = success), so a stolen lock would only cause harmless
+ * redundant uninstall attempts — but a stale window this size makes it
+ * airtight regardless.
+ */
+const LOCK_STALE_MS = EXPERIMENT_PLUGINS.length * UNINSTALL_TIMEOUT_MS + 60_000;
 const LOCK_RETRIES = 5;
 const LOCK_MIN_TIMEOUT_MS = 100;
 

--- a/src/lib/prune-stale-plugins.ts
+++ b/src/lib/prune-stale-plugins.ts
@@ -18,16 +18,33 @@
 // THE FIX:
 // After installing the current `pm-os` plugin, enumerate every plugin entry
 // keyed `<plugin>@mysecond-customer-<slug>` for THIS customer's slug, and
-// `claude plugin uninstall` any whose plugin name is not `pm-os`. The
-// per-customer marketplace registration itself is preserved — `pm-os` still
-// needs it. Only the orphaned individual plugin entries are removed.
+// `claude plugin uninstall` any whose plugin name is one of the 13 KNOWN
+// experiment plugins (the EXPERIMENT_PLUGINS allowlist below). The per-customer
+// marketplace registration itself is preserved — `pm-os` still needs it. Only
+// the orphaned individual plugin entries are removed.
 //
-// SAFETY — scope strictly to the customer's OWN slug:
-// A real customer machine has exactly one customer (one slug). Only internal
-// test machines accumulate many. The marketplace-suffix match
-// (`@mysecond-customer-<slug>`) guarantees we never touch another customer's
-// entries, another marketplace's plugins (playwright@claude-plugins-official),
-// or the current `pm-os` install.
+// SAFETY — defense in depth (Codex adversarial review, cli#32):
+//   1. validateSlug() — the slug flows into filesystem paths + the marketplace
+//      suffix match. A corrupt sync-state.json slug (the `sync` SessionStart
+//      path does NOT pre-validate) must not reach path construction. Invalid
+//      slug → no-op, never throw.
+//   2. EXPERIMENT_PLUGINS allowlist — we only ever uninstall one of the 13
+//      KNOWN stale plugin names. A legitimate future plugin, a beta, a support
+//      plugin, or a malformed ledger entry under the customer marketplace is
+//      left untouched. "Not pm-os" is NOT sufficient — the name must be on the
+//      allowlist.
+//   3. isPlainPluginToken() — even an allowlist member is re-validated as a
+//      plain plugin-name token (no `/`, no `..`, no `@`) before it is used as
+//      a `claude plugin uninstall` arg OR an rmSync() path segment. A malformed
+//      ledger key like `../../cache/.../vercel@mysecond-customer-<slug>` passes
+//      a naive endsWith() suffix check; without this guard `join()` would
+//      normalize the `..` and rmSync would delete OUTSIDE the customer's cache.
+//   4. Exact marketplace-suffix match — scopes strictly to the customer's own
+//      slug. `t05` must not match `t0501`; never touches other customers,
+//      other marketplaces (playwright@claude-plugins-official), or pm-os.
+//   5. Lock around the Claude plugin dir — `sync` runs on every SessionStart,
+//      so two concurrent Claude sessions can race the same prune. We serialize
+//      on `~/.claude/plugins/` and treat "already gone" as success.
 //
 // MECHANISM:
 // Drives removal through the official `claude plugin uninstall` CLI — the same
@@ -35,27 +52,87 @@
 // installed_plugins.json. Reading installed_plugins.json is only used to
 // DISCOVER which stale plugin names exist; the actual mutation goes through the
 // supported CLI so Claude Code keeps its own bookkeeping (cache dirs,
-// install-counts) consistent. Best-effort cache-dir cleanup is a follow-up
-// belt-and-braces step for entries Claude Code's uninstall leaves behind.
+// install-counts) consistent. Cache-dir cleanup runs ONLY after a confirmed
+// successful uninstall — never on the failure path (a deleted cache dir behind
+// a still-registered ledger entry breaks Claude startup).
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import { marketplaceName, SENTINEL_PLUGIN_NAME } from './mysecond-paths.js';
+import lockfile from 'proper-lockfile';
+
+import { marketplaceName, validateSlug } from './mysecond-paths.js';
+
+/**
+ * The 13 stale plugin names from the 2026-05-04→05 multi-category experiment.
+ * THIS IS THE ALLOWLIST — `pruneStalePlugins` only ever uninstalls a name that
+ * is BOTH on this list AND registered under the customer's own marketplace.
+ * Any other plugin under the marketplace (a future plugin, a beta, the current
+ * `pm-os`, a malformed ledger entry) is left strictly untouched.
+ *
+ * Frozen so a caller can't mutate the allowlist at runtime.
+ */
+export const EXPERIMENT_PLUGINS: readonly string[] = Object.freeze([
+  'pm-communication',
+  'pm-competitive',
+  'pm-data',
+  'pm-discovery',
+  'pm-launch',
+  'pm-operations',
+  'pm-planning',
+  'pm-specs',
+  'pm-strategy',
+  'pm-companion-sync',
+  'pm-personas',
+  'pm-workflows',
+  'pm-cc',
+]);
+
+const EXPERIMENT_PLUGIN_SET = new Set<string>(EXPERIMENT_PLUGINS);
+
+/**
+ * Conservative plain-plugin-name token check. An allowlist member should always
+ * pass this — it is a belt-and-suspenders guard against a malformed ledger key
+ * smuggling path-traversal (`..`), path separators (`/`), or a marketplace
+ * delimiter (`@`) into a value that is then used as BOTH a `claude plugin
+ * uninstall` argument AND an `rmSync` path segment. Lowercase alphanumerics +
+ * hyphens only; must start with an alphanumeric.
+ */
+function isPlainPluginToken(name: string): boolean {
+  return /^[a-z0-9][a-z0-9-]*$/.test(name);
+}
+
+/** spawnSync timeout for `claude plugin uninstall` — a stuck uninstall must
+ *  not hang `mysecond sync` on every SessionStart. Timeout → treated as a
+ *  non-fatal failure (the plugin stays; next sync retries). */
+const UNINSTALL_TIMEOUT_MS = 30_000;
+
+/** proper-lockfile settings for the Claude-plugin-dir lock. Mirrors
+ *  marketplace-lock.ts: dead-process locks auto-release after 30s. */
+const LOCK_STALE_MS = 30_000;
+const LOCK_RETRIES = 5;
+const LOCK_MIN_TIMEOUT_MS = 100;
 
 /** Path to Claude Code's installed-plugins ledger. */
 export function installedPluginsJsonPath(): string {
   return join(homedir(), '.claude', 'plugins', 'installed_plugins.json');
 }
 
-/** Cache dir for a single plugin under a customer marketplace. */
+/** The `~/.claude/plugins/` dir — lock anchor + cache parent. */
+function claudePluginsDir(): string {
+  return join(homedir(), '.claude', 'plugins');
+}
+
+/**
+ * Cache dir for a single plugin under a customer marketplace.
+ * Caller MUST have already validated `slug` (validateSlug) and `pluginName`
+ * (isPlainPluginToken) — this function does no validation of its own.
+ */
 function pluginCacheDir(slug: string, pluginName: string): string {
   return join(
-    homedir(),
-    '.claude',
-    'plugins',
+    claudePluginsDir(),
     'cache',
     marketplaceName(slug),
     pluginName,
@@ -63,7 +140,7 @@ function pluginCacheDir(slug: string, pluginName: string): string {
 }
 
 export interface PrunePlan {
-  /** Plugin names (not `pm-os`) found registered under this customer's marketplace. */
+  /** Stale experiment-plugin names found registered under this customer's marketplace. */
   stalePluginNames: string[];
   /** The marketplace name scoped to this slug — every match shares it. */
   marketplace: string;
@@ -72,13 +149,28 @@ export interface PrunePlan {
 /**
  * Read installed_plugins.json and determine which plugin entries are stale for
  * THIS customer's slug. A stale entry is any key `<plugin>@mysecond-customer-<slug>`
- * whose `<plugin>` is not the current expected plugin (`pm-os`).
+ * whose `<plugin>` is on the EXPERIMENT_PLUGINS allowlist AND is a plain
+ * plugin-name token.
  *
- * Soft-fails to an empty plan: a missing or corrupt ledger means there's
- * nothing we can safely prune — never throw out of the install path.
+ * `slug` is validated here (validateSlug) — an invalid slug yields an empty
+ * plan with `marketplace: ''` rather than throwing or constructing a path.
+ *
+ * Soft-fails to an empty plan: a missing/corrupt ledger, an invalid slug, or
+ * no matching entries all mean "nothing to safely prune" — never throw out of
+ * the install/sync path.
  */
 export function planStalePluginPrune(slug: string): PrunePlan {
-  const marketplace = marketplaceName(slug);
+  // P0-2: validate the slug HERE — don't trust the caller. The `sync`
+  // SessionStart path passes state.customerSlug straight from a possibly
+  // stale/corrupt sync-state.json with no prior validateSlug().
+  let safeSlug: string;
+  try {
+    safeSlug = validateSlug(slug);
+  } catch {
+    return { stalePluginNames: [], marketplace: '' };
+  }
+
+  const marketplace = marketplaceName(safeSlug);
   const empty: PrunePlan = { stalePluginNames: [], marketplace };
 
   const ledgerPath = installedPluginsJsonPath();
@@ -103,15 +195,21 @@ export function planStalePluginPrune(slug: string): PrunePlan {
 
   // Match the EXACT marketplace suffix — `@mysecond-customer-<slug>`. This is
   // what scopes us to the customer's own slug and nothing else. A substring
-  // check would be wrong (slug `t05` must not match `t0501`); we split on the
-  // last `@` and compare the marketplace segment for equality.
+  // check would be wrong (slug `t05` must not match `t0501`); we slice off the
+  // exact suffix and compare the remaining plugin-name segment.
   const suffix = `@${marketplace}`;
   const stale = new Set<string>();
   for (const key of Object.keys(plugins)) {
     if (!key.endsWith(suffix)) continue;
     const pluginName = key.slice(0, key.length - suffix.length);
     if (pluginName.length === 0) continue;
-    if (pluginName === SENTINEL_PLUGIN_NAME) continue; // the current, correct plugin
+    // P0-3: allowlist — only the 13 KNOWN experiment plugins are pruned.
+    if (!EXPERIMENT_PLUGIN_SET.has(pluginName)) continue;
+    // P0-1: even an allowlist member is re-validated as a plain token before
+    // it can become a filesystem path segment or a CLI argument. (An allowlist
+    // member always passes this; it's defense in depth against a future
+    // allowlist edit introducing a non-token value.)
+    if (!isPlainPluginToken(pluginName)) continue;
     stale.add(pluginName);
   }
 
@@ -121,70 +219,149 @@ export function planStalePluginPrune(slug: string): PrunePlan {
 export interface PruneResult {
   /** Plugin names we successfully uninstalled. */
   removed: string[];
-  /** Plugin names where `claude plugin uninstall` exited non-zero. */
+  /** Plugin names where `claude plugin uninstall` failed (non-zero / timeout / ENOENT). */
   failed: string[];
-  /** True when there was nothing to prune. */
+  /** True when there was nothing to prune (empty plan, invalid slug, or lock contention). */
   noop: boolean;
 }
 
+const NOOP: PruneResult = { removed: [], failed: [], noop: true };
+
 /**
- * Remove every stale `pm-*` plugin left over from the 13-plugin experiment for
- * THIS customer's slug. Idempotent: a customer who never hit the experiment
+ * Acquire a lock on `~/.claude/plugins/` so two concurrent Claude sessions
+ * (each firing `mysecond sync` on SessionStart) don't race the same prune.
+ * Returns a release fn, or `null` if the lock can't be acquired — in which
+ * case the caller treats the prune as a no-op (another process is handling it,
+ * or will on the next sync). Best-effort: never throws.
+ */
+async function acquirePluginDirLock(): Promise<(() => Promise<void>) | null> {
+  const dir = claudePluginsDir();
+  try {
+    mkdirSync(dir, { recursive: true });
+  } catch {
+    return null;
+  }
+  try {
+    return await lockfile.lock(dir, {
+      retries: { retries: LOCK_RETRIES, minTimeout: LOCK_MIN_TIMEOUT_MS },
+      stale: LOCK_STALE_MS,
+    });
+  } catch {
+    // Lock contention or a corrupt lockfile — skip this prune cycle. The
+    // holder is handling it, or the next sync will.
+    return null;
+  }
+}
+
+/**
+ * Remove every stale experiment plugin left over from the 13-plugin experiment
+ * for THIS customer's slug. Idempotent: a customer who never hit the experiment
  * window has an empty plan and this is a no-op.
+ *
+ * Async because it serializes on a `~/.claude/plugins/` lock (P1-5) — the
+ * `sync` SessionStart path can run concurrently across Claude sessions.
  *
  * Best-effort throughout — a failed uninstall is logged to `failed` but never
  * throws. The customer's `pm-os` install (the thing that actually matters)
  * already succeeded by the time this runs; stale-plugin cleanup must not be
- * able to fail the install.
+ * able to fail the install or the sync.
  *
  * `claudeBin` is injectable for tests; defaults to the `claude` binary on PATH.
  */
-export function pruneStalePlugins(
+export async function pruneStalePlugins(
   slug: string,
   opts: { claudeBin?: string; silent?: boolean } = {},
-): PruneResult {
+): Promise<PruneResult> {
   const claudeBin = opts.claudeBin ?? 'claude';
-  const plan = planStalePluginPrune(slug);
 
+  // planStalePluginPrune validates the slug + applies the allowlist + token
+  // guard. An invalid slug / corrupt ledger / no matches all yield an empty
+  // plan here.
+  const plan = planStalePluginPrune(slug);
   if (plan.stalePluginNames.length === 0) {
-    return { removed: [], failed: [], noop: true };
+    return NOOP;
+  }
+
+  // P1-5: serialize on the Claude plugin dir. If we can't get the lock,
+  // another process is pruning (or will) — treat as a clean no-op.
+  const release = await acquirePluginDirLock();
+  if (release === null) {
+    return NOOP;
   }
 
   const removed: string[] = [];
   const failed: string[] = [];
 
-  for (const pluginName of plan.stalePluginNames) {
-    const spec = `${pluginName}@${plan.marketplace}`;
-    const result = spawnSync(
-      claudeBin,
-      ['plugin', 'uninstall', spec, '--scope', 'user'],
-      { stdio: 'pipe' },
-    );
-
-    if (result.status === 0) {
-      removed.push(pluginName);
-    } else {
-      failed.push(pluginName);
-      if (opts.silent !== true) {
-        const exitDisplay = result.status ?? 'ENOENT';
-        process.stderr.write(
-          `[mysecond] note: could not uninstall stale plugin ${spec} (exit ${exitDisplay}) — continuing.\n`,
-        );
-      }
+  try {
+    // Re-read the plan INSIDE the lock — between planning above and acquiring
+    // the lock, a concurrent process may have already pruned some/all entries.
+    // "Already gone" is success, not failure.
+    const lockedPlan = planStalePluginPrune(slug);
+    if (lockedPlan.stalePluginNames.length === 0) {
+      return NOOP;
     }
 
-    // Belt-and-braces: remove the plugin's cache dir if `claude plugin
-    // uninstall` left it behind (or if the ledger entry was orphaned with no
-    // backing CLI state). rmSync force:true is a no-op when the dir is absent.
-    try {
-      const cacheDir = pluginCacheDir(slug, pluginName);
-      if (existsSync(cacheDir)) {
-        rmSync(cacheDir, { recursive: true, force: true });
+    for (const pluginName of lockedPlan.stalePluginNames) {
+      // Defense in depth: the plan already token-checked + allowlisted, but
+      // re-assert before BOTH the CLI call and the rmSync. Cheap; closes any
+      // gap if planStalePluginPrune is ever refactored.
+      if (
+        !EXPERIMENT_PLUGIN_SET.has(pluginName) ||
+        !isPlainPluginToken(pluginName)
+      ) {
+        continue;
       }
+
+      const spec = `${pluginName}@${lockedPlan.marketplace}`;
+      const result = spawnSync(
+        claudeBin,
+        ['plugin', 'uninstall', spec, '--scope', 'user'],
+        { stdio: 'pipe', timeout: UNINSTALL_TIMEOUT_MS },
+      );
+
+      // spawnSync sets signal:'SIGTERM' (and status:null) on a timeout kill.
+      const timedOut =
+        result.signal === 'SIGTERM' ||
+        (result.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT';
+      const succeeded = result.status === 0 && !timedOut;
+
+      if (succeeded) {
+        removed.push(pluginName);
+
+        // P1-4: cache cleanup runs ONLY after a confirmed-successful uninstall.
+        // Deleting the cache dir while the ledger entry still points at it
+        // would break Claude startup. rmSync force:true is a no-op when the
+        // dir is already absent (e.g. Claude's uninstall already removed it).
+        try {
+          const cacheDir = pluginCacheDir(slug, pluginName);
+          if (existsSync(cacheDir)) {
+            rmSync(cacheDir, { recursive: true, force: true });
+          }
+        } catch {
+          // cache cleanup is purely cosmetic — never let it surface an error
+        }
+      } else {
+        failed.push(pluginName);
+        if (opts.silent !== true) {
+          const reason = timedOut
+            ? `timed out after ${UNINSTALL_TIMEOUT_MS}ms`
+            : `exit ${result.status ?? 'ENOENT'}`;
+          process.stderr.write(
+            `[mysecond] note: could not uninstall stale plugin ${spec} (${reason}) — continuing.\n`,
+          );
+        }
+      }
+    }
+  } finally {
+    try {
+      await release();
     } catch {
-      // cache cleanup is purely cosmetic — never let it surface an error
+      // proper-lockfile auto-releases stale locks after LOCK_STALE_MS anyway.
     }
   }
 
+  if (removed.length === 0 && failed.length === 0) {
+    return NOOP;
+  }
   return { removed, failed, noop: false };
 }

--- a/src/lib/silent-status.ts
+++ b/src/lib/silent-status.ts
@@ -34,6 +34,7 @@ export type StatusKind =
   | 'install_step_completed'
   | 'plugin_install_timed'       // Fix C Step 1: per-plugin install wall-clock
   | 'step_9_total_timed'         // Fix C Step 1: full step-9 wall-clock + summary
+  | 'stale_plugins_pruned'       // Finding #2: removed orphaned 13-plugin-era pm-* plugins
   | 'install_completed'
   | 'install_failed'
   | 'timeout'

--- a/src/lib/steps/step-9.ts
+++ b/src/lib/steps/step-9.ts
@@ -43,6 +43,7 @@ import {
 } from '../mysecond-paths.js';
 import { fetchAndExtractPlugin } from '../plugin-tarball.js';
 import { probeLayerOne } from '../plugin-load-detect.js';
+import { pruneStalePlugins } from '../prune-stale-plugins.js';
 import { emitStatus } from '../silent-status.js';
 import { writeSyncState } from '../sync-state.js';
 
@@ -360,6 +361,40 @@ async function doStep9(
   // Surface partial-install state to step-13 for the success box.
   if (failedPlugins.length > 0) {
     shared.failedPlugins = failedPlugins;
+  }
+
+  // Make the install REPLACING, not additive (Finding #2 — "duplicate skills").
+  // During the 2026-05-04→05 multi-category experiment, customers were
+  // installed as 13 separately-named `pm-*` plugins under their marketplace.
+  // The cli install path never uninstalls prior plugins, so a customer who
+  // onboarded in that window and later re-synced now has BOTH the 13 stale
+  // plugins AND `pm-os` — every skill appears twice (correct flat name +
+  // abandoned `pm-data:`-prefixed leftover). Uninstall any non-`pm-os` plugin
+  // registered under THIS customer's own marketplace. Scoped strictly to the
+  // customer's slug; best-effort — never fails the install (pm-os already
+  // landed above). No-op for customers who never hit the experiment window.
+  try {
+    const prune = pruneStalePlugins(slug, { silent: ctx.silent });
+    if (!prune.noop) {
+      emitStatus({
+        kind: 'stale_plugins_pruned',
+        removed: prune.removed,
+        failed: prune.failed,
+      });
+      if (!ctx.silent && prune.removed.length > 0) {
+        process.stderr.write(
+          `[mysecond] Removed ${prune.removed.length} stale plugin(s) from a prior install: ${prune.removed.join(', ')}\n`
+        );
+      }
+    }
+  } catch (err) {
+    // Defense-in-depth: pruneStalePlugins is already best-effort internally,
+    // but an unexpected throw must never abort a successful install.
+    if (!ctx.silent) {
+      process.stderr.write(
+        `[mysecond] note: stale-plugin cleanup skipped (${err instanceof Error ? err.message : String(err)})\n`
+      );
+    }
   }
 
   // Post-install filesystem probe — informational only. The install

--- a/src/lib/steps/step-9.ts
+++ b/src/lib/steps/step-9.ts
@@ -369,12 +369,13 @@ async function doStep9(
   // The cli install path never uninstalls prior plugins, so a customer who
   // onboarded in that window and later re-synced now has BOTH the 13 stale
   // plugins AND `pm-os` — every skill appears twice (correct flat name +
-  // abandoned `pm-data:`-prefixed leftover). Uninstall any non-`pm-os` plugin
-  // registered under THIS customer's own marketplace. Scoped strictly to the
-  // customer's slug; best-effort — never fails the install (pm-os already
-  // landed above). No-op for customers who never hit the experiment window.
+  // abandoned `pm-data:`-prefixed leftover). Uninstall the 13 KNOWN experiment
+  // plugins (allowlist) registered under THIS customer's own marketplace.
+  // Scoped strictly to the customer's slug; best-effort — never fails the
+  // install (pm-os already landed above). No-op for customers who never hit
+  // the experiment window.
   try {
-    const prune = pruneStalePlugins(slug, { silent: ctx.silent });
+    const prune = await pruneStalePlugins(slug, { silent: ctx.silent });
     if (!prune.noop) {
       emitStatus({
         kind: 'stale_plugins_pruned',

--- a/tests/lib/plugin-counts.test.ts
+++ b/tests/lib/plugin-counts.test.ts
@@ -29,6 +29,12 @@ function makeSubplugin(root: string, name: string): string {
   return sub;
 }
 
+// Mark a dir as a FLAT plugin root by dropping .claude-plugin/plugin.json into it.
+function makeFlatPluginRoot(root: string): void {
+  mkdirSync(join(root, '.claude-plugin'), { recursive: true });
+  writeFileSync(join(root, '.claude-plugin', 'plugin.json'), '{}');
+}
+
 // Add N skill subdirs (each with a SKILL.md file) under <sub>/skills/.
 function addSkills(sub: string, count: number): void {
   for (let i = 0; i < count; i++) {
@@ -107,8 +113,38 @@ describe('countPluginContents', () => {
     });
   });
 
-  it('non-subplugin root (no .claude-plugin/plugin.json anywhere) returns zeros — no flat-layout fallback', () => {
-    // Build a flat layout that the OLD code would have counted.
+  it('FLAT layout (.claude-plugin/plugin.json at root) counts skills/agents/workflows directly', () => {
+    // This is the layout product-manager-os actually emits: a single `pm-os`
+    // plugin with source "./" — skills/agents/workflows live under the root.
+    makeFlatPluginRoot(workDir);
+    addSkills(workDir, 84);
+    addAgents(workDir, 6);
+    addWorkflows(workDir, 7);
+    // commands/ wrappers must NOT be counted as workflows.
+    addCommands(workDir, 84);
+
+    expect(countPluginContents(workDir)).toEqual({
+      skills: 84,
+      agents: 6,
+      workflows: 7,
+    });
+  });
+
+  it('FLAT layout with missing dirs returns zeros for the missing kinds', () => {
+    // Plugin root marker present, but no agents/ or workflows/ dir.
+    makeFlatPluginRoot(workDir);
+    addSkills(workDir, 12);
+
+    expect(countPluginContents(workDir)).toEqual({
+      skills: 12,
+      agents: 0,
+      workflows: 0,
+    });
+  });
+
+  it('no plugin manifest anywhere (no flat root marker, no subplugin marker) returns zeros', () => {
+    // A bare flat layout WITHOUT the .claude-plugin/plugin.json marker is not a
+    // recognizable plugin tree — no marker means we cannot trust the shape.
     mkdirSync(join(workDir, 'skills', 'a'), { recursive: true });
     writeFileSync(join(workDir, 'skills', 'a', 'SKILL.md'), '# s');
     mkdirSync(join(workDir, 'agents'), { recursive: true });

--- a/tests/lib/plugin-counts.test.ts
+++ b/tests/lib/plugin-counts.test.ts
@@ -198,4 +198,30 @@ describe('countPluginContents', () => {
 
     expect(countPluginContents(workDir).workflows).toBe(3);
   });
+
+  it('stray dirs/files do NOT inflate counts (P2-7 — tightened contract)', () => {
+    makeFlatPluginRoot(workDir);
+    addSkills(workDir, 5); // 5 real skills (each <name>/SKILL.md)
+    addAgents(workDir, 3); // 3 real agents (each <name>.md file)
+    addWorkflows(workDir, 2); // 2 real workflows
+
+    // Decoys that the OLD "count any visible dir" logic would have inflated:
+    //  - a loose file directly under skills/ (not a skill subdir)
+    writeFileSync(join(workDir, 'skills', 'README.md'), '# not a skill');
+    //  - a subdir under skills/ with NO SKILL.md (scratch dir, .git, etc.)
+    mkdirSync(join(workDir, 'skills', 'scratch'), { recursive: true });
+    writeFileSync(join(workDir, 'skills', 'scratch', 'notes.txt'), 'wip');
+    //  - a subdirectory under agents/ (agents must be flat .md files)
+    mkdirSync(join(workDir, 'agents', 'subdir'), { recursive: true });
+    //  - a subdirectory under workflows/
+    mkdirSync(join(workDir, 'workflows', 'subdir'), { recursive: true });
+    //  - a non-.md file under agents/
+    writeFileSync(join(workDir, 'agents', '.DS_Store'), '');
+
+    expect(countPluginContents(workDir)).toEqual({
+      skills: 5,
+      agents: 3,
+      workflows: 2,
+    });
+  });
 });

--- a/tests/lib/prune-stale-plugins.test.ts
+++ b/tests/lib/prune-stale-plugins.test.ts
@@ -17,6 +17,9 @@
 //   P0-3 allowlist — only the 13 KNOWN experiment plugins are pruned; a
 //        legitimate non-pm-os plugin under the marketplace is left alone.
 //   P1-4 cache cleanup only after a successful uninstall.
+//   P1-5 concurrency — a second concurrent prune backs off cleanly when the
+//        `~/.claude/plugins/` lock is held; the plan re-read inside the lock
+//        treats an already-pruned ledger as a clean no-op.
 //   P2-6 spawnSync timeout — a hung uninstall is a non-fatal failure.
 
 import {
@@ -31,6 +34,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import lockfile from 'proper-lockfile';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -86,6 +90,29 @@ function makeHangingClaude(sleepSeconds: number): string {
   writeFileSync(
     binPath,
     `#!/bin/sh\necho "$@" >> "${logPath}"\nsleep ${sleepSeconds}\n`,
+  );
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+// Create a fake `claude` that logs its call AND rewrites the ledger to remove
+// EVERY stale `pm-*@mysecond-customer-*` entry — simulating a concurrent
+// process having finished the prune. Used to prove the plan re-read inside the
+// lock treats an already-pruned ledger as a clean no-op on a subsequent call.
+function makeLedgerClearingClaude(): string {
+  const logPath = join(root, 'claude-calls.log');
+  const binPath = join(root, 'ledger-clearing-claude.sh');
+  const ledgerPath = installedPluginsJsonPath();
+  // POSIX sh: log argv, then overwrite the ledger with a pm-os-only ledger.
+  writeFileSync(
+    binPath,
+    `#!/bin/sh
+echo "$@" >> "${logPath}"
+cat > "${ledgerPath}" <<'JSON'
+{ "version": 2, "plugins": { "pm-os@mysecond-customer-t0504b-to57": [ { "scope": "user", "version": "1.0.0" } ] } }
+JSON
+exit 0
+`,
   );
   chmodSync(binPath, 0o755);
   return binPath;
@@ -377,4 +404,68 @@ describe('pruneStalePlugins', () => {
     // A timed-out uninstall is a failure → cache dir must NOT be deleted.
     expect(existsSync(cacheDir)).toBe(true);
   }, 40_000); // bump per-test timeout past the 30s spawnSync timeout
+});
+
+describe('pruneStalePlugins — concurrency (P1-5)', () => {
+  // The lock anchor: pruneStalePlugins serializes on `~/.claude/plugins/`.
+  function claudePluginsDir(): string {
+    return join(home, '.claude', 'plugins');
+  }
+
+  it('backs off cleanly (no shell-out) when the plugin-dir lock is already held', async () => {
+    const slug = 't0504b-to57';
+    const mkt = `mysecond-customer-${slug}`;
+    writeLedger([`pm-data@${mkt}`, `pm-strategy@${mkt}`, `pm-os@${mkt}`]);
+    const fakeClaude = makeFakeClaude(0);
+
+    // Simulate a concurrent `mysecond sync` (every SessionStart) by holding the
+    // `~/.claude/plugins/` lock ourselves. proper-lockfile's retry budget is
+    // 5×100ms — far short of LOCK_STALE_MS — so the second prune can't acquire
+    // it and must back off to a clean no-op rather than stealing the lock.
+    const release = await lockfile.lock(claudePluginsDir(), {
+      retries: { retries: 0 },
+      stale: 600_000,
+    });
+    try {
+      const result = await pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
+      expect(result.noop).toBe(true);
+      expect(result.removed).toEqual([]);
+      expect(result.failed).toEqual([]);
+      // CRITICAL: never shelled out to `claude` while another process held
+      // the lock — no racing uninstalls.
+      expect(readClaudeCalls()).toEqual([]);
+    } finally {
+      await release();
+    }
+
+    // Sanity: once the lock is free, the same prune runs normally.
+    const after = await pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
+    expect(after.noop).toBe(false);
+    expect(after.removed.sort()).toEqual(['pm-data', 'pm-strategy']);
+  });
+
+  it('the plan re-read inside the lock treats an already-pruned ledger as a clean no-op', async () => {
+    const slug = 't0504b-to57';
+    const mkt = `mysecond-customer-${slug}`;
+    writeLedger([`pm-data@${mkt}`, `pm-strategy@${mkt}`, `pm-os@${mkt}`]);
+
+    // First prune uses a fake `claude` that ALSO rewrites the ledger to a
+    // pm-os-only state — i.e. by the time it finishes, the ledger looks like a
+    // concurrent process already cleaned everything.
+    const clearingClaude = makeLedgerClearingClaude();
+    const first = await pruneStalePlugins(slug, { claudeBin: clearingClaude, silent: true });
+    expect(first.noop).toBe(false);
+    expect(first.removed.length).toBeGreaterThan(0);
+
+    // Second prune: the ledger now has only pm-os. The plan re-read (both at
+    // function entry AND inside the lock) finds nothing stale → clean no-op,
+    // no shell-out for this second call.
+    const callsAfterFirst = readClaudeCalls().length;
+    const second = await pruneStalePlugins(slug, { claudeBin: clearingClaude, silent: true });
+    expect(second.noop).toBe(true);
+    expect(second.removed).toEqual([]);
+    expect(second.failed).toEqual([]);
+    // No additional `claude` invocations from the second (no-op) call.
+    expect(readClaudeCalls().length).toBe(callsAfterFirst);
+  });
 });

--- a/tests/lib/prune-stale-plugins.test.ts
+++ b/tests/lib/prune-stale-plugins.test.ts
@@ -1,0 +1,227 @@
+// Tests for prune-stale-plugins.ts — the core Finding #2 ("duplicate skills") fix.
+//
+// Strategy:
+//   - planStalePluginPrune: pure function over installed_plugins.json — drive
+//     it with a tmp HOME containing a hand-built ledger. No child_process.
+//   - pruneStalePlugins: inject a FAKE `claude` binary (a tiny shell script)
+//     via the `claudeBin` option. The fake records every invocation to a log
+//     file so we can assert exactly which plugins were uninstalled, and can be
+//     made to exit non-zero to exercise the failure path.
+
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  planStalePluginPrune,
+  pruneStalePlugins,
+  installedPluginsJsonPath,
+} from '../../src/lib/prune-stale-plugins.js';
+
+let root: string;
+let home: string;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'mysecond-prune-'));
+  home = join(root, 'home');
+  mkdirSync(join(home, '.claude', 'plugins'), { recursive: true });
+  originalHome = process.env.HOME;
+  process.env.HOME = home;
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  rmSync(root, { recursive: true, force: true });
+});
+
+// Write a ledger to ~/.claude/plugins/installed_plugins.json from a list of keys.
+function writeLedger(keys: string[]): void {
+  const plugins: Record<string, unknown> = {};
+  for (const k of keys) plugins[k] = [{ scope: 'user', version: '1.0.0' }];
+  writeFileSync(installedPluginsJsonPath(), JSON.stringify({ version: 2, plugins }, null, 2));
+}
+
+// Create a fake `claude` binary that logs argv to <root>/claude-calls.log and
+// exits with `exitCode`. Returns its absolute path for the `claudeBin` option.
+function makeFakeClaude(exitCode = 0): string {
+  const logPath = join(root, 'claude-calls.log');
+  const binPath = join(root, 'fake-claude.sh');
+  writeFileSync(
+    binPath,
+    `#!/bin/sh\necho "$@" >> "${logPath}"\nexit ${exitCode}\n`,
+  );
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+function readClaudeCalls(): string[] {
+  const logPath = join(root, 'claude-calls.log');
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean);
+}
+
+// The 13-plugin-era plugin names (from installed_plugins.json inspection).
+const EXPERIMENT_PLUGINS = [
+  'pm-communication',
+  'pm-competitive',
+  'pm-data',
+  'pm-discovery',
+  'pm-launch',
+  'pm-operations',
+  'pm-planning',
+  'pm-specs',
+  'pm-strategy',
+  'pm-companion-sync',
+  'pm-personas',
+  'pm-workflows',
+  'pm-cc',
+];
+
+describe('planStalePluginPrune', () => {
+  it('returns empty plan when the ledger is missing', () => {
+    const plan = planStalePluginPrune('t0504b-to57');
+    expect(plan.stalePluginNames).toEqual([]);
+    expect(plan.marketplace).toBe('mysecond-customer-t0504b-to57');
+  });
+
+  it('returns empty plan when the ledger is corrupt JSON', () => {
+    writeFileSync(installedPluginsJsonPath(), '{ not valid json');
+    expect(planStalePluginPrune('t0504b-to57').stalePluginNames).toEqual([]);
+  });
+
+  it('finds all 13 stale pm-* plugins for the customer slug, excludes pm-os', () => {
+    const slug = 't0504b-to57';
+    const mkt = `mysecond-customer-${slug}`;
+    writeLedger([
+      ...EXPERIMENT_PLUGINS.map((p) => `${p}@${mkt}`),
+      `pm-os@${mkt}`, // the current, correct plugin — must NOT be flagged
+    ]);
+    const plan = planStalePluginPrune(slug);
+    expect(plan.stalePluginNames).toEqual([...EXPERIMENT_PLUGINS].sort());
+    expect(plan.stalePluginNames).not.toContain('pm-os');
+  });
+
+  it('returns empty plan for a clean flat-only install (only pm-os)', () => {
+    const slug = 't0511a-qomg';
+    writeLedger([`pm-os@mysecond-customer-${slug}`]);
+    expect(planStalePluginPrune(slug).stalePluginNames).toEqual([]);
+  });
+
+  it('NEVER touches another customer\'s entries (slug scoping)', () => {
+    // Two customers on one machine (only happens on test machines). Pruning
+    // for customer A must leave customer B's stale plugins completely alone.
+    writeLedger([
+      'pm-data@mysecond-customer-aaaa-1111',
+      'pm-strategy@mysecond-customer-aaaa-1111',
+      'pm-os@mysecond-customer-aaaa-1111',
+      'pm-data@mysecond-customer-bbbb-2222',
+      'pm-os@mysecond-customer-bbbb-2222',
+    ]);
+    const plan = planStalePluginPrune('aaaa-1111');
+    expect(plan.stalePluginNames).toEqual(['pm-data', 'pm-strategy']);
+  });
+
+  it('does not match a slug that is a prefix of another slug', () => {
+    // Suffix match must be exact: slug `t05` must not match `t0501`.
+    writeLedger([
+      'pm-data@mysecond-customer-t0501',
+      'pm-os@mysecond-customer-t0501',
+    ]);
+    expect(planStalePluginPrune('t05').stalePluginNames).toEqual([]);
+  });
+
+  it('ignores non-mysecond marketplaces entirely', () => {
+    writeLedger([
+      'playwright@claude-plugins-official',
+      'vercel@claude-plugins-official',
+      'pm-data@mysecond-customer-t0504b-to57',
+      'pm-os@mysecond-customer-t0504b-to57',
+    ]);
+    expect(planStalePluginPrune('t0504b-to57').stalePluginNames).toEqual(['pm-data']);
+  });
+});
+
+describe('pruneStalePlugins', () => {
+  it('is a no-op when there are no stale plugins', () => {
+    writeLedger(['pm-os@mysecond-customer-t0511a-qomg']);
+    const fakeClaude = makeFakeClaude(0);
+    const result = pruneStalePlugins('t0511a-qomg', { claudeBin: fakeClaude, silent: true });
+    expect(result.noop).toBe(true);
+    expect(result.removed).toEqual([]);
+    expect(readClaudeCalls()).toEqual([]); // never shelled out
+  });
+
+  it('uninstalls every stale plugin via `claude plugin uninstall`', () => {
+    const slug = 't0504b-to57';
+    const mkt = `mysecond-customer-${slug}`;
+    writeLedger([
+      ...EXPERIMENT_PLUGINS.map((p) => `${p}@${mkt}`),
+      `pm-os@${mkt}`,
+    ]);
+    const fakeClaude = makeFakeClaude(0);
+    const result = pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
+
+    expect(result.noop).toBe(false);
+    expect(result.removed.sort()).toEqual([...EXPERIMENT_PLUGINS].sort());
+    expect(result.failed).toEqual([]);
+
+    const calls = readClaudeCalls();
+    expect(calls).toHaveLength(EXPERIMENT_PLUGINS.length);
+    for (const p of EXPERIMENT_PLUGINS) {
+      expect(calls).toContain(`plugin uninstall ${p}@${mkt} --scope user`);
+    }
+    // pm-os must never be uninstalled.
+    expect(calls.some((c) => c.includes('pm-os@'))).toBe(false);
+  });
+
+  it('records plugins as failed when `claude plugin uninstall` exits non-zero', () => {
+    const slug = 't0504b-to57';
+    const mkt = `mysecond-customer-${slug}`;
+    writeLedger([`pm-data@${mkt}`, `pm-strategy@${mkt}`, `pm-os@${mkt}`]);
+    const fakeClaude = makeFakeClaude(1); // every uninstall fails
+    const result = pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
+
+    expect(result.noop).toBe(false);
+    expect(result.removed).toEqual([]);
+    expect(result.failed.sort()).toEqual(['pm-data', 'pm-strategy']);
+  });
+
+  it('cleans up the cache dir for a pruned plugin', () => {
+    const slug = 't0504b-to57';
+    const mkt = `mysecond-customer-${slug}`;
+    writeLedger([`pm-data@${mkt}`, `pm-os@${mkt}`]);
+    // Pre-create the stale plugin's cache dir.
+    const cacheDir = join(home, '.claude', 'plugins', 'cache', mkt, 'pm-data');
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(join(cacheDir, 'marker'), 'stale');
+
+    const fakeClaude = makeFakeClaude(0);
+    pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
+
+    expect(existsSync(cacheDir)).toBe(false);
+  });
+
+  it('does not throw when the fake binary is missing (ENOENT)', () => {
+    const slug = 't0504b-to57';
+    writeLedger([`pm-data@mysecond-customer-${slug}`, `pm-os@mysecond-customer-${slug}`]);
+    // Point at a nonexistent binary — spawnSync returns status null + error.
+    const result = pruneStalePlugins(slug, {
+      claudeBin: join(root, 'does-not-exist'),
+      silent: true,
+    });
+    expect(result.failed).toEqual(['pm-data']);
+    expect(result.removed).toEqual([]);
+  });
+});

--- a/tests/lib/prune-stale-plugins.test.ts
+++ b/tests/lib/prune-stale-plugins.test.ts
@@ -1,4 +1,5 @@
-// Tests for prune-stale-plugins.ts — the core Finding #2 ("duplicate skills") fix.
+// Tests for prune-stale-plugins.ts — the core Finding #2 ("duplicate skills")
+// fix, hardened per the Codex adversarial review (cli#32).
 //
 // Strategy:
 //   - planStalePluginPrune: pure function over installed_plugins.json — drive
@@ -6,7 +7,17 @@
 //   - pruneStalePlugins: inject a FAKE `claude` binary (a tiny shell script)
 //     via the `claudeBin` option. The fake records every invocation to a log
 //     file so we can assert exactly which plugins were uninstalled, and can be
-//     made to exit non-zero to exercise the failure path.
+//     made to exit non-zero / hang to exercise the failure + timeout paths.
+//
+// Hardening coverage:
+//   P0-1 path traversal — a malformed ledger key with `..`/`/`/`@` in the
+//        plugin-name segment must NOT be uninstalled or rmSync'd.
+//   P0-2 slug validation — an invalid slug must no-op cleanly (no throw, no
+//        path construction).
+//   P0-3 allowlist — only the 13 KNOWN experiment plugins are pruned; a
+//        legitimate non-pm-os plugin under the marketplace is left alone.
+//   P1-4 cache cleanup only after a successful uninstall.
+//   P2-6 spawnSync timeout — a hung uninstall is a non-fatal failure.
 
 import {
   chmodSync,
@@ -26,6 +37,7 @@ import {
   planStalePluginPrune,
   pruneStalePlugins,
   installedPluginsJsonPath,
+  EXPERIMENT_PLUGINS,
 } from '../../src/lib/prune-stale-plugins.js';
 
 let root: string;
@@ -66,28 +78,50 @@ function makeFakeClaude(exitCode = 0): string {
   return binPath;
 }
 
+// Create a fake `claude` that logs its call then sleeps far longer than the
+// 30s spawnSync timeout — used to exercise the P2-6 timeout path.
+function makeHangingClaude(sleepSeconds: number): string {
+  const logPath = join(root, 'claude-calls.log');
+  const binPath = join(root, 'hanging-claude.sh');
+  writeFileSync(
+    binPath,
+    `#!/bin/sh\necho "$@" >> "${logPath}"\nsleep ${sleepSeconds}\n`,
+  );
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
 function readClaudeCalls(): string[] {
   const logPath = join(root, 'claude-calls.log');
   if (!existsSync(logPath)) return [];
   return readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean);
 }
 
-// The 13-plugin-era plugin names (from installed_plugins.json inspection).
-const EXPERIMENT_PLUGINS = [
-  'pm-communication',
-  'pm-competitive',
-  'pm-data',
-  'pm-discovery',
-  'pm-launch',
-  'pm-operations',
-  'pm-planning',
-  'pm-specs',
-  'pm-strategy',
-  'pm-companion-sync',
-  'pm-personas',
-  'pm-workflows',
-  'pm-cc',
-];
+describe('EXPERIMENT_PLUGINS allowlist', () => {
+  it('contains exactly the 13 known experiment plugin names', () => {
+    expect([...EXPERIMENT_PLUGINS].sort()).toEqual(
+      [
+        'pm-cc',
+        'pm-communication',
+        'pm-companion-sync',
+        'pm-competitive',
+        'pm-data',
+        'pm-discovery',
+        'pm-launch',
+        'pm-operations',
+        'pm-personas',
+        'pm-planning',
+        'pm-specs',
+        'pm-strategy',
+        'pm-workflows',
+      ].sort(),
+    );
+  });
+
+  it('is frozen — callers cannot mutate the allowlist at runtime', () => {
+    expect(Object.isFrozen(EXPERIMENT_PLUGINS)).toBe(true);
+  });
+});
 
 describe('planStalePluginPrune', () => {
   it('returns empty plan when the ledger is missing', () => {
@@ -119,7 +153,7 @@ describe('planStalePluginPrune', () => {
     expect(planStalePluginPrune(slug).stalePluginNames).toEqual([]);
   });
 
-  it('NEVER touches another customer\'s entries (slug scoping)', () => {
+  it("NEVER touches another customer's entries (slug scoping)", () => {
     // Two customers on one machine (only happens on test machines). Pruning
     // for customer A must leave customer B's stale plugins completely alone.
     writeLedger([
@@ -151,19 +185,82 @@ describe('planStalePluginPrune', () => {
     ]);
     expect(planStalePluginPrune('t0504b-to57').stalePluginNames).toEqual(['pm-data']);
   });
+
+  // ---- P0-3: allowlist ----
+  it('does NOT prune a non-pm-os plugin that is NOT on the allowlist', () => {
+    // A hypothetical future / beta / support plugin under the customer
+    // marketplace. "not pm-os" is not sufficient — only the 13 known
+    // experiment plugins are pruned.
+    const mkt = 'mysecond-customer-t0504b-to57';
+    writeLedger([
+      `pm-os@${mkt}`,
+      `pm-future-beta@${mkt}`, // legit, not on allowlist → keep
+      `pm-support-tools@${mkt}`, // legit, not on allowlist → keep
+      `pm-data@${mkt}`, // on allowlist → prune
+    ]);
+    expect(planStalePluginPrune('t0504b-to57').stalePluginNames).toEqual(['pm-data']);
+  });
+
+  // ---- P0-1: path traversal ----
+  it('rejects a malformed ledger key whose plugin-name segment has path traversal', () => {
+    // A crafted key whose "<plugin>" segment is `../../cache/.../vercel`.
+    // It DOES end with the customer marketplace suffix, so a naive endsWith()
+    // check passes — but the plugin-name token guard + allowlist must drop it
+    // so it never reaches `claude plugin uninstall` or rmSync.
+    const mkt = 'mysecond-customer-t0504b-to57';
+    writeLedger([
+      `pm-os@${mkt}`,
+      `../../cache/claude-plugins-official/vercel@${mkt}`,
+      `pm-data/../../etc@${mkt}`,
+      `pm-data@${mkt}`, // the one legitimate stale entry
+    ]);
+    // Only the clean allowlisted token survives.
+    expect(planStalePluginPrune('t0504b-to57').stalePluginNames).toEqual(['pm-data']);
+  });
+
+  // ---- P0-2: slug validation ----
+  it('returns empty plan for an invalid slug (no throw, no path construction)', () => {
+    writeLedger([
+      'pm-data@mysecond-customer-../../etc',
+      'pm-os@mysecond-customer-../../etc',
+    ]);
+    // A path-traversal slug must be rejected by validateSlug → empty plan,
+    // empty marketplace, no throw.
+    const plan = planStalePluginPrune('../../etc');
+    expect(plan.stalePluginNames).toEqual([]);
+    expect(plan.marketplace).toBe('');
+  });
+
+  it('returns empty plan for an empty-string slug', () => {
+    expect(planStalePluginPrune('').stalePluginNames).toEqual([]);
+  });
 });
 
 describe('pruneStalePlugins', () => {
-  it('is a no-op when there are no stale plugins', () => {
+  it('is a no-op when there are no stale plugins', async () => {
     writeLedger(['pm-os@mysecond-customer-t0511a-qomg']);
     const fakeClaude = makeFakeClaude(0);
-    const result = pruneStalePlugins('t0511a-qomg', { claudeBin: fakeClaude, silent: true });
+    const result = await pruneStalePlugins('t0511a-qomg', {
+      claudeBin: fakeClaude,
+      silent: true,
+    });
     expect(result.noop).toBe(true);
     expect(result.removed).toEqual([]);
     expect(readClaudeCalls()).toEqual([]); // never shelled out
   });
 
-  it('uninstalls every stale plugin via `claude plugin uninstall`', () => {
+  it('is a no-op for an invalid slug (P0-2 — sync path passes unvalidated slugs)', async () => {
+    writeLedger(['pm-data@mysecond-customer-../../etc']);
+    const fakeClaude = makeFakeClaude(0);
+    const result = await pruneStalePlugins('../../etc', {
+      claudeBin: fakeClaude,
+      silent: true,
+    });
+    expect(result.noop).toBe(true);
+    expect(readClaudeCalls()).toEqual([]);
+  });
+
+  it('uninstalls every stale plugin via `claude plugin uninstall`', async () => {
     const slug = 't0504b-to57';
     const mkt = `mysecond-customer-${slug}`;
     writeLedger([
@@ -171,7 +268,7 @@ describe('pruneStalePlugins', () => {
       `pm-os@${mkt}`,
     ]);
     const fakeClaude = makeFakeClaude(0);
-    const result = pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
+    const result = await pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
 
     expect(result.noop).toBe(false);
     expect(result.removed.sort()).toEqual([...EXPERIMENT_PLUGINS].sort());
@@ -186,19 +283,36 @@ describe('pruneStalePlugins', () => {
     expect(calls.some((c) => c.includes('pm-os@'))).toBe(false);
   });
 
-  it('records plugins as failed when `claude plugin uninstall` exits non-zero', () => {
+  it('does NOT uninstall a non-allowlist plugin under the marketplace (P0-3)', async () => {
+    const slug = 't0504b-to57';
+    const mkt = `mysecond-customer-${slug}`;
+    writeLedger([
+      `pm-os@${mkt}`,
+      `pm-future-beta@${mkt}`, // legit non-pm-os, not on allowlist
+      `pm-data@${mkt}`, // on allowlist
+    ]);
+    const fakeClaude = makeFakeClaude(0);
+    const result = await pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
+
+    expect(result.removed).toEqual(['pm-data']);
+    const calls = readClaudeCalls();
+    expect(calls).toEqual([`plugin uninstall pm-data@${mkt} --scope user`]);
+    expect(calls.some((c) => c.includes('pm-future-beta'))).toBe(false);
+  });
+
+  it('records plugins as failed when `claude plugin uninstall` exits non-zero', async () => {
     const slug = 't0504b-to57';
     const mkt = `mysecond-customer-${slug}`;
     writeLedger([`pm-data@${mkt}`, `pm-strategy@${mkt}`, `pm-os@${mkt}`]);
     const fakeClaude = makeFakeClaude(1); // every uninstall fails
-    const result = pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
+    const result = await pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
 
     expect(result.noop).toBe(false);
     expect(result.removed).toEqual([]);
     expect(result.failed.sort()).toEqual(['pm-data', 'pm-strategy']);
   });
 
-  it('cleans up the cache dir for a pruned plugin', () => {
+  it('cleans up the cache dir ONLY after a successful uninstall (P1-4)', async () => {
     const slug = 't0504b-to57';
     const mkt = `mysecond-customer-${slug}`;
     writeLedger([`pm-data@${mkt}`, `pm-os@${mkt}`]);
@@ -208,20 +322,59 @@ describe('pruneStalePlugins', () => {
     writeFileSync(join(cacheDir, 'marker'), 'stale');
 
     const fakeClaude = makeFakeClaude(0);
-    pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
+    await pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
 
     expect(existsSync(cacheDir)).toBe(false);
   });
 
-  it('does not throw when the fake binary is missing (ENOENT)', () => {
+  it('does NOT delete the cache dir when uninstall FAILS (P1-4)', async () => {
+    const slug = 't0504b-to57';
+    const mkt = `mysecond-customer-${slug}`;
+    writeLedger([`pm-data@${mkt}`, `pm-os@${mkt}`]);
+    const cacheDir = join(home, '.claude', 'plugins', 'cache', mkt, 'pm-data');
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(join(cacheDir, 'marker'), 'stale');
+
+    const fakeClaude = makeFakeClaude(1); // uninstall fails
+    const result = await pruneStalePlugins(slug, { claudeBin: fakeClaude, silent: true });
+
+    expect(result.failed).toEqual(['pm-data']);
+    // Cache dir MUST survive — deleting it behind a still-registered ledger
+    // entry would break Claude startup.
+    expect(existsSync(cacheDir)).toBe(true);
+  });
+
+  it('does not throw when the fake binary is missing (ENOENT)', async () => {
     const slug = 't0504b-to57';
     writeLedger([`pm-data@mysecond-customer-${slug}`, `pm-os@mysecond-customer-${slug}`]);
     // Point at a nonexistent binary — spawnSync returns status null + error.
-    const result = pruneStalePlugins(slug, {
+    const result = await pruneStalePlugins(slug, {
       claudeBin: join(root, 'does-not-exist'),
       silent: true,
     });
     expect(result.failed).toEqual(['pm-data']);
     expect(result.removed).toEqual([]);
   });
+
+  it('treats a hung uninstall as a non-fatal failure (P2-6 — timeout)', async () => {
+    // The fake `claude` sleeps 35s — longer than the 30s spawnSync timeout in
+    // pruneStalePlugins. spawnSync kills it with SIGTERM; the plugin is
+    // recorded as `failed`, not `removed`, and the function returns cleanly.
+    const slug = 't0504b-to57';
+    const mkt = `mysecond-customer-${slug}`;
+    writeLedger([`pm-data@${mkt}`, `pm-os@${mkt}`]);
+    const cacheDir = join(home, '.claude', 'plugins', 'cache', mkt, 'pm-data');
+    mkdirSync(cacheDir, { recursive: true });
+
+    const hangingClaude = makeHangingClaude(35);
+    const result = await pruneStalePlugins(slug, {
+      claudeBin: hangingClaude,
+      silent: true,
+    });
+
+    expect(result.removed).toEqual([]);
+    expect(result.failed).toEqual(['pm-data']);
+    // A timed-out uninstall is a failure → cache dir must NOT be deleted.
+    expect(existsSync(cacheDir)).toBe(true);
+  }, 40_000); // bump per-test timeout past the 30s spawnSync timeout
 });


### PR DESCRIPTION
## Summary
Fixes the **duplicate-skills bug (Finding #2)** at its real root cause and the **0/0/0 plugin counts (D2)**.

**Confirmed mechanism** (from `~/.claude/plugins/installed_plugins.json`): during the 2026-05-04→05 multi-category experiment, customers were installed as **13 separately-named `pm-*` plugins**. Before/after that window it's a single flat `pm-os`. The CLI install path is **purely additive — it never uninstalls prior plugins** — so a customer who onboarded in that window and later re-synced carries BOTH the 13 stale `pm-*` plugins AND `pm-os`. Claude Code namespaces a skill by its plugin name, so every skill shows twice: the correct flat `funnel-analyzer` plus an abandoned `pm-data:funnel-analyzer` leftover.

## Changes
**D3 — make install REPLACING, not additive (the core fix)**
- `src/lib/prune-stale-plugins.ts` (NEW) — `planStalePluginPrune` (reads `installed_plugins.json`, finds non-`pm-os` plugins under the customer's *own* marketplace via an exact `@mysecond-customer-<slug>` suffix match) + `pruneStalePlugins` (drives `claude plugin uninstall` for each, best-effort, never throws). **Strictly slug-scoped** — never touches another customer's entries.
- `src/lib/steps/step-9.ts` — prunes after the `pm-os` install loop (init path).
- `src/commands/sync.ts` — also prunes at the end of `runSync`. **Critical:** step-9 is skipped on re-runs once the init ledger is complete, so `init` alone can't heal existing affected customers — `sync` runs every SessionStart, so this auto-heals them.
- `src/lib/silent-status.ts` — adds `stale_plugins_pruned` status kind.

**D2 — flat-layout plugin counts**
- `src/lib/plugin-counts.ts` — `countPluginContents` now detects the flat layout (`.claude-plugin/plugin.json` at the plugin root) and counts `skills/`/`agents/`/`workflows/` directly; the legacy multi-subplugin scan is kept as a fallback. Previously returned 0/0/0 for the current flat `pm-os` plugin.

**Version:** 1.4.6 → 1.4.7 (patch).

## Tests
- [x] `npm run build` passes
- [x] `npm test` — **350 passed (30 files)**, including 12 new `prune-stale-plugins` tests (slug scoping, prefix-collision guard `t05` ≠ `t0501`, corrupt-ledger soft-fail, ENOENT, cache-dir cleanup) and updated flat-layout `plugin-counts` tests
- [x] `tsc --noEmit` clean

## Out of scope (follow-ups)
- D4 cleanup of Ron's own test machine + the Cian/Katsao onboarding-window DB check — orchestrator/Ron action, not code.
- #6 version-stamp / `--force-regen` hardening — deferred; natural hook point noted in the plan.

## Test plan for reviewer
- [ ] On a machine with orphaned `pm-*@mysecond-customer-<slug>` entries, run `mysecond sync` → confirm the stale plugins are uninstalled and the skill picker shows each skill once
- [ ] On a clean single-`pm-os` machine, `mysecond sync` is a no-op (no spurious uninstalls)
- [ ] `npm publish` (refreshes `dist/` via `prepublishOnly`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)