### PR TITLE
fix(install): invited PM install-complete message points to /prd-generator (v1.4.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/lib/copy.ts
+++ b/src/lib/copy.ts
@@ -169,10 +169,32 @@ function formatCountsLine(counts: PostInstallCounts | undefined): string {
 export function successBox(
   pmName: string,
   companyName: string,
-  counts?: PostInstallCounts
+  counts?: PostInstallCounts,
+  isInvitedPm: boolean = false
 ): string {
   const pm = sanitizeName(pmName, 'you');
   const company = sanitizeName(companyName, 'your company');
+
+  // Invited-PM variant: the Head-of-Product (HoP) already ran /welcome and
+  // built the team context. An invited PM landing here has already had their
+  // context synced (step 11), so running /welcome would be redundant — point
+  // them at /prd-generator as a meaningful first action instead.
+  if (isInvitedPm) {
+    const skills = counts?.skills ?? 0;
+    const agents = counts?.agents ?? 0;
+    const workflows = counts?.workflows ?? 0;
+    const lines = [
+      `✓ mySecond PM OS installed for ${pm} at ${company}`,
+      '',
+      `Installation complete. ${skills} ${skills === 1 ? 'skill' : 'skills'}, ${agents} ${agents === 1 ? 'sub-agent' : 'sub-agents'}, and ${workflows} ${workflows === 1 ? 'workflow' : 'workflows'} are installed, and your context synced successfully.`,
+      '',
+      'Quit and reopen Claude Code to load mySecond, then try running /prd-generator to run your first skill.',
+      '',
+      'Need help? Reply at hello@mysecond.ai or open mysecond.ai/dashboard',
+    ];
+    return lines.join('\n');
+  }
+
   const lines = [
     `✓ mySecond PM OS installed for ${pm} at ${company}`,
     '',

--- a/src/lib/steps/step-13.ts
+++ b/src/lib/steps/step-13.ts
@@ -32,7 +32,7 @@ export const step13: StepFn = async ({ ctx, shared }) => {
   }
 
   if (!ctx.silent) {
-    process.stdout.write('\n' + successBox(pmName, companyName, shared.pluginCounts) + '\n\n');
+    process.stdout.write('\n' + successBox(pmName, companyName, shared.pluginCounts, shared.isInvitedPm ?? false) + '\n\n');
   }
 
   // Emit install_completed JSON status event (Item 5B). Calls

--- a/src/lib/steps/step-15.ts
+++ b/src/lib/steps/step-15.ts
@@ -124,6 +124,7 @@ export const step15: StepFn = async ({ ctx, shared }) => {
     const whoami = await fetchWhoami(ctx);
     if (whoami.ok) {
       if (whoami.email) shared.userEmail = whoami.email;
+      shared.isInvitedPm = whoami.isInvitedPm;
       return {
         step: 15,
         outcome: { kind: 'completed' },
@@ -165,7 +166,7 @@ export const step15: StepFn = async ({ ctx, shared }) => {
  */
 async function fetchWhoami(
   ctx: CommandContext,
-): Promise<{ ok: boolean; email: string | null; networkError?: boolean }> {
+): Promise<{ ok: boolean; email: string | null; isInvitedPm: boolean; networkError?: boolean }> {
   try {
     const url = new URL('/api/companion/whoami', ctx.apiBase);
     const response = await fetch(url, {
@@ -175,13 +176,21 @@ async function fetchWhoami(
       },
       signal: AbortSignal.timeout(WHOAMI_TIMEOUT_MS),
     });
-    if (response.status !== 200) return { ok: false, email: null };
-    const body = (await response.json().catch(() => null)) as { email?: string | null } | null;
-    return { ok: true, email: body?.email ?? null };
+    if (response.status !== 200) return { ok: false, email: null, isInvitedPm: false };
+    const body = (await response.json().catch(() => null)) as
+      | { email?: string | null; is_invited_pm?: boolean }
+      | null;
+    return {
+      ok: true,
+      email: body?.email ?? null,
+      isInvitedPm: body?.is_invited_pm ?? false,
+    };
   } catch {
     // Network error / timeout — trust the existing key (preserves prior
     // validateExistingKey behavior). Email unknown; step-13 falls back.
-    return { ok: true, email: null, networkError: true };
+    // isInvitedPm defaults false → step-13 shows the HoP /welcome variant
+    // (idempotent + the safer fallback when role is unknown).
+    return { ok: true, email: null, isInvitedPm: false, networkError: true };
   }
 }
 
@@ -397,6 +406,7 @@ async function runPollOnly(
   if (whoami.email) {
     shared.userEmail = whoami.email;
   }
+  shared.isInvitedPm = whoami.isInvitedPm;
 
   if (
     setResult.fallbackReason === 'roundtrip_failed' ||
@@ -510,6 +520,7 @@ async function runDeviceCodeFlow(
   if (whoami.email) {
     shared.userEmail = whoami.email;
   }
+  shared.isInvitedPm = whoami.isInvitedPm;
 
   if (
     setResult.fallbackReason === 'roundtrip_failed' ||

--- a/src/lib/steps/types.ts
+++ b/src/lib/steps/types.ts
@@ -26,6 +26,13 @@ export interface StepContext {
     // Used by step-13 to emit the install_completed JSON status event with
     // the customer's email in the message field.
     userEmail?: string;
+    // Step 15 populates from /whoami `is_invited_pm` field — true when the
+    // authenticated user is a `pm`-role team member (Head-of-Product already
+    // ran /welcome on their behalf). Step-13 branches the success-box copy:
+    // invited PMs should NOT be told to run /welcome again. Defaults to false
+    // on network error / missing field — HoP variant is the safer fallback
+    // (recommends /welcome, which is idempotent).
+    isInvitedPm?: boolean;
     // Step 9 populates these from /plugin-tarball + extraction.
     pluginVersion?: string;
     pluginSha256?: string;

--- a/tests/lib/post-install-message.test.ts
+++ b/tests/lib/post-install-message.test.ts
@@ -141,3 +141,39 @@ describe('successBox: red-team — malicious / missing names', () => {
     expect(out).toContain('for you at your company');
   });
 });
+
+// v1.4.8 — invited-PM variant. HoP already ran /welcome on team's behalf, so
+// the invited PM should be pointed at /prd-generator as a first action rather
+// than told to redo /welcome.
+describe('successBox: invited-PM variant (v1.4.8)', () => {
+  it('directs invited PM to /prd-generator (not /welcome)', () => {
+    const out = successBox('Bob', 'Acme', { skills: 91, agents: 6, workflows: 4 }, true);
+    expect(out).toContain('/prd-generator');
+    expect(out).not.toContain('/welcome');
+  });
+
+  it('mentions installed counts and synced context', () => {
+    const out = successBox('Bob', 'Acme', { skills: 91, agents: 6, workflows: 4 }, true);
+    expect(out).toContain('91 skills');
+    expect(out).toContain('6 sub-agents');
+    expect(out).toContain('4 workflows');
+    expect(out).toContain('context synced successfully');
+  });
+
+  it('still personalizes the lead line with pm + company', () => {
+    const out = successBox('Bob', 'Acme', { skills: 1, agents: 1, workflows: 1 }, true);
+    expect(out).toContain('for Bob at Acme');
+  });
+
+  it('HoP variant (isInvitedPm=false) still recommends /welcome', () => {
+    const out = successBox('Alice', 'Acme', { skills: 1, agents: 1, workflows: 1 }, false);
+    expect(out).toContain('/welcome');
+    expect(out).not.toContain('/prd-generator');
+  });
+
+  it('defaults to HoP variant when 4th param omitted (back-compat)', () => {
+    const out = successBox('Alice', 'Acme', { skills: 1, agents: 1, workflows: 1 });
+    expect(out).toContain('/welcome');
+    expect(out).not.toContain('/prd-generator');
+  });
+});

--- a/tests/lib/whoami-invited-pm.test.ts
+++ b/tests/lib/whoami-invited-pm.test.ts
@@ -1,0 +1,112 @@
+// v1.4.8 — `is_invited_pm` propagation through step-15.
+//
+// Structural source-level assertions (matching the established pattern in
+// reauth-on-revoked.test.ts + auth-only-invariants.test.ts). `fetchWhoami`
+// is private to step-15.ts, so we verify the contract at the source level
+// rather than mocking the global `fetch` + AbortSignal stack.
+//
+// Contract being defended:
+//   1. fetchWhoami's return type includes `isInvitedPm: boolean`.
+//   2. The response body is parsed for `is_invited_pm` and defaulted to false.
+//   3. The network-error catch defaults `isInvitedPm: false`.
+//   4. The non-200 branch defaults `isInvitedPm: false`.
+//   5. All THREE fetchWhoami call sites in step-15 capture isInvitedPm into
+//      shared.isInvitedPm — full device-code flow, runPollOnly, and the
+//      existing-credential-validated path. Missing any one means the invited
+//      PM whose token was minted via that path gets the wrong success copy.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const STEP15_PATH = join(
+  import.meta.dirname ?? __dirname,
+  '..',
+  '..',
+  'src',
+  'lib',
+  'steps',
+  'step-15.ts'
+);
+
+const STEP13_PATH = join(
+  import.meta.dirname ?? __dirname,
+  '..',
+  '..',
+  'src',
+  'lib',
+  'steps',
+  'step-13.ts'
+);
+
+const TYPES_PATH = join(
+  import.meta.dirname ?? __dirname,
+  '..',
+  '..',
+  'src',
+  'lib',
+  'steps',
+  'types.ts'
+);
+
+describe('v1.4.8 — fetchWhoami extends return with isInvitedPm', () => {
+  const source = readFileSync(STEP15_PATH, 'utf8');
+
+  it('declares isInvitedPm in the fetchWhoami return type', () => {
+    expect(source).toMatch(/isInvitedPm:\s*boolean/);
+  });
+
+  it('parses body.is_invited_pm with a false default', () => {
+    expect(source).toMatch(/body\?\.is_invited_pm\s*\?\?\s*false/);
+  });
+
+  it('returns isInvitedPm: false on non-200 response', () => {
+    // The non-200 branch must include isInvitedPm: false so the type stays
+    // consistent across all return paths.
+    expect(source).toMatch(
+      /response\.status\s*!==\s*200[\s\S]{0,200}isInvitedPm:\s*false/
+    );
+  });
+
+  it('returns isInvitedPm: false on network error (catch branch)', () => {
+    expect(source).toMatch(/networkError:\s*true[\s\S]{0,200}?}|isInvitedPm:\s*false[\s\S]{0,200}?networkError:\s*true/);
+    // Belt-and-suspenders: ensure the catch return literally contains both.
+    const catchBlock = source.slice(source.indexOf('} catch {'));
+    expect(catchBlock).toMatch(/isInvitedPm:\s*false/);
+    expect(catchBlock).toMatch(/networkError:\s*true/);
+  });
+});
+
+describe('v1.4.8 — all three fetchWhoami call sites capture isInvitedPm', () => {
+  const source = readFileSync(STEP15_PATH, 'utf8');
+
+  it('every fetchWhoami call is followed by a shared.isInvitedPm assignment', () => {
+    // There are exactly THREE fetchWhoami invocations in step-15.ts (full
+    // device-code flow, runPollOnly, existing-credential-validated path).
+    // Each must propagate isInvitedPm into shared — otherwise the invited
+    // PM whose token came through the un-instrumented path sees the wrong
+    // success message.
+    const callMatches = source.match(/await fetchWhoami\(ctx\)/g) ?? [];
+    expect(callMatches.length).toBe(3);
+
+    const assignMatches = source.match(/shared\.isInvitedPm\s*=\s*whoami\.isInvitedPm/g) ?? [];
+    expect(assignMatches.length).toBe(3);
+  });
+});
+
+describe('v1.4.8 — StepContext.shared exposes isInvitedPm', () => {
+  const source = readFileSync(TYPES_PATH, 'utf8');
+
+  it('declares isInvitedPm?: boolean on shared', () => {
+    expect(source).toMatch(/isInvitedPm\?:\s*boolean/);
+  });
+});
+
+describe('v1.4.8 — step-13 forwards isInvitedPm into successBox', () => {
+  const source = readFileSync(STEP13_PATH, 'utf8');
+
+  it('passes shared.isInvitedPm (defaulting false) as the 4th successBox arg', () => {
+    expect(source).toMatch(/successBox\([^)]*shared\.isInvitedPm\s*\?\?\s*false\s*\)/);
+  });
+});


### PR DESCRIPTION
## Customer impact

An invited PM (joined via team invite) completing \`mysecond init\` was being told to run \`/welcome\` — but the Head-of-Product (HoP) already ran \`/welcome\` on the team's behalf. The PM's context was already synced by step 11. Running /welcome again would be redundant work that re-derives context the HoP already curated.

After this PR, an invited PM sees:

> Installation complete. N skills, N sub-agents, and N workflows are installed, and your context synced successfully.
>
> Quit and reopen Claude Code to load mySecond, then try running /prd-generator to run your first skill.

The HoP variant is **unchanged** (still \`/welcome\` — the right first step when there's no context yet).

## What changed

The \`/whoami\` endpoint at \`src/app/api/companion/whoami/route.ts:175\` already returns \`is_invited_pm: boolean\` (derived from \`team_membership_role === 'pm'\`). No server change needed — this PR plumbs that field through the CLI:

- \`src/lib/copy.ts\` — \`successBox()\` gains a 4th \`isInvitedPm\` parameter (defaults to \`false\` → HoP copy unchanged). PM branch swaps the count line + trailing CTA.
- \`src/lib/steps/step-15.ts\` — \`fetchWhoami()\` return type extended with \`isInvitedPm: boolean\`. All **three** call sites (full device-code flow, \`runPollOnly\`, existing-credential-validated path) capture into \`shared.isInvitedPm\`.
- \`src/lib/steps/types.ts\` — \`StepContext.shared.isInvitedPm?: boolean\`.
- \`src/lib/steps/step-13.ts\` — forwards \`shared.isInvitedPm ?? false\` to \`successBox\`.
- \`package.json\` — 1.4.7 → 1.4.8.

## Safety / fallback

On network error or missing field, \`isInvitedPm\` defaults to \`false\` → HoP variant. That's the safer fallback when role is unknown — \`/welcome\` is idempotent, so even a misclassified PM running it again does no damage.

## Tests

- \`tests/lib/post-install-message.test.ts\` — 5 new tests for the PM variant + HoP back-compat (existing snapshot stays valid: 4th arg defaults to false).
- \`tests/lib/whoami-invited-pm.test.ts\` (new) — 7 structural assertions covering the \`fetchWhoami\` contract extension, all three call-site captures, the shared-type addition, and step-13 forwarding. Matches the project's established source-level pattern for step-15 internals (\`reauth-on-revoked.test.ts\`, \`step-15-legacy-deprecation.test.ts\`).

## Verification

- \`npx tsc --noEmit\` — clean
- \`npm run build\` — exit 0, \`dist/mysecond.mjs 148.0kb\`
- \`npm test\` — **31 files, 375 tests passing** (was 363 + 12 new)

## Out of scope / follow-ups

None. Single-purpose copy-fix + plumbing change. No DB, no API, no server.