### PR TITLE
feat(sync): surface synced base SHA (Phase 7)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -540,11 +540,15 @@ export async function runSync(
   // file shape is stable.
   if (typeof response.base_plugin_version === 'string') {
     installState.base_plugin_version = response.base_plugin_version;
+    // Surface the base SHA in the sync summary (observability — Phase 7 of
+    // plan i-create-a-deeper-witty-dawn). Set ONLY from a SHA this response
+    // actually returned — never from the persisted installState value. On a
+    // server soft-fail (base files present, base_plugin_version null/absent)
+    // the persisted value is stale; tagging it would point at the wrong base
+    // for files just updated from an unknown newer one (codex review). When
+    // no SHA comes back, the summary simply omits the base tag.
+    summary.basePluginVersion = response.base_plugin_version;
   }
-  // Surface the base SHA in the sync summary (observability — Phase 7 of plan
-  // i-create-a-deeper-witty-dawn). Reflects the current synced base whether or
-  // not it advanced this round.
-  summary.basePluginVersion = installState.base_plugin_version;
   if (
     skillsResult.updated > 0 ||
     agentsResult.updated > 0 ||

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -68,6 +68,11 @@ interface SyncSummary {
   baseAgentsUpdated: number;
   baseWorkflowsUpdated: number;
   baseSkippedDueToCustomization: number;
+  // The product-manager-os base SHA this project is now synced to. Surfaced
+  // so a customer/support can see which base a session is running — a cheap
+  // substitute for version pinning, and the signal for spotting a base-SHA
+  // shift mid-workflow. Null when the server didn't return one this round.
+  basePluginVersion: string | null;
 }
 
 function emptySummary(): SyncSummary {
@@ -91,6 +96,7 @@ function emptySummary(): SyncSummary {
     baseAgentsUpdated: 0,
     baseWorkflowsUpdated: 0,
     baseSkippedDueToCustomization: 0,
+    basePluginVersion: null,
   };
 }
 
@@ -301,8 +307,14 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
       if (summary.baseSkillsUpdated > 0) baseParts.push(`${summary.baseSkillsUpdated} skills`);
       if (summary.baseAgentsUpdated > 0) baseParts.push(`${summary.baseAgentsUpdated} agents`);
       if (summary.baseWorkflowsUpdated > 0) baseParts.push(`${summary.baseWorkflowsUpdated} workflows`);
+      // Tag the new base SHA — this is the signal for spotting a base-SHA
+      // shift between sessions (a multi-session workflow can otherwise observe
+      // steps written by different base versions with no way to tell).
+      const baseTag = summary.basePluginVersion
+        ? ` (base ${summary.basePluginVersion.slice(0, 7)})`
+        : '';
       out.write(
-        `mysecond: ${baseParts.join(', ')} updated — see https://app.mysecond.ai/changelog\n`,
+        `mysecond: ${baseParts.join(', ')} updated${baseTag} — see https://app.mysecond.ai/changelog\n`,
       );
     }
     return;
@@ -331,6 +343,10 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
   if (parts.length === 0) parts.push('nothing changed');
 
   out.write(`✓ Sync complete: ${parts.join(', ')}.\n`);
+  if (summary.basePluginVersion) {
+    // Short SHA — which product-manager-os base this project is synced to.
+    out.write(`  Base plugin: ${summary.basePluginVersion.slice(0, 7)} (mysecond.ai)\n`);
+  }
   if (summary.conflictsCloudKept > 0 || summary.conflictsLocalKept > 0) {
     out.write(`  Recover backed-up versions from .claude/sync-conflicts/ if needed.\n`);
   }
@@ -525,6 +541,10 @@ export async function runSync(
   if (typeof response.base_plugin_version === 'string') {
     installState.base_plugin_version = response.base_plugin_version;
   }
+  // Surface the base SHA in the sync summary (observability — Phase 7 of plan
+  // i-create-a-deeper-witty-dawn). Reflects the current synced base whether or
+  // not it advanced this round.
+  summary.basePluginVersion = installState.base_plugin_version;
   if (
     skillsResult.updated > 0 ||
     agentsResult.updated > 0 ||

--- a/tests/commands/base-sync.test.ts
+++ b/tests/commands/base-sync.test.ts
@@ -337,6 +337,40 @@ describe('Workstream H — base plugin update sync', () => {
     expect(out).toContain(`(base ${SHA_NEW.slice(0, 7)})`);
   });
 
+  it('omits the base SHA tag when the response returns no base_plugin_version (codex review)', async () => {
+    // Server soft-fail shape: base files present, base_plugin_version absent.
+    // The tag must NOT fall back to a stale persisted SHA — better no tag
+    // than a wrong one.
+    const root = tmpProject();
+    seedState(root);
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        context_files: [],
+        custom_skills: [],
+        custom_agents: [],
+        custom_workflows: [],
+        // base_plugin_version intentionally omitted
+        base_skills: [
+          {
+            file_path: '.claude/skills/prd-generator/SKILL.md',
+            content: '# PRD',
+            current_hash: shortHash('# PRD'),
+          },
+        ],
+        syncedAt: new Date().toISOString(),
+      }),
+    );
+
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runSync([], ctx(root));
+    const out = writeSpy.mock.calls.map((c) => String(c[0])).join('');
+    writeSpy.mockRestore();
+
+    expect(out).toMatch(/1 skills updated/);
+    expect(out).not.toContain('(base ');
+  });
+
   it('graceful initialization: no install-state.json yet → first sync writes it without crashing', async () => {
     const root = tmpProject();
     seedState(root);

--- a/tests/commands/base-sync.test.ts
+++ b/tests/commands/base-sync.test.ts
@@ -306,6 +306,37 @@ describe('Workstream H — base plugin update sync', () => {
     expect(out).toContain('app.mysecond.ai/changelog');
   });
 
+  it('tags the base-update one-liner with the synced base SHA (Phase 7 observability)', async () => {
+    const root = tmpProject();
+    seedState(root);
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        context_files: [],
+        custom_skills: [],
+        custom_agents: [],
+        custom_workflows: [],
+        base_plugin_version: SHA_NEW,
+        base_skills: [
+          {
+            file_path: '.claude/skills/prd-generator/SKILL.md',
+            content: '# PRD',
+            current_hash: shortHash('# PRD'),
+          },
+        ],
+        syncedAt: new Date().toISOString(),
+      }),
+    );
+
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runSync([], ctx(root));
+    const out = writeSpy.mock.calls.map((c) => String(c[0])).join('');
+    writeSpy.mockRestore();
+
+    // Short SHA tag lets a customer/support spot a base-version shift.
+    expect(out).toContain(`(base ${SHA_NEW.slice(0, 7)})`);
+  });
+
   it('graceful initialization: no install-state.json yet → first sync writes it without crashing', async () => {
     const root = tmpProject();
     seedState(root);


### PR DESCRIPTION
## What & why

Observability for live-HEAD delivery (plan `i-create-a-deeper-witty-dawn`, Phase 7).

Since the thin-plugin migration ([mysecond-app#292](https://github.com/mysecond-ai/mysecond-app/pull/292)), skills/agents/workflows reach customers from `product-manager-os` HEAD **live every session** — there's no pinned version. Nothing showed the customer *which* base SHA they were on, so a multi-session workflow could observe steps written by different base versions with no way to tell. CAIO review flagged this as a required guardrail.

## Changes

- **Interactive `mysecond sync`** — adds a `Base plugin: <sha7>` line to the summary.
- **Silent path** (the SessionStart hook) — tags the existing base-update one-liner with `(base <sha7>)`, so a base-SHA shift between sessions is visible in the session-start context Claude reads.
- `mysecond doctor` already prints the full `base_plugin_version` — unchanged.
- Adds `basePluginVersion` to `SyncSummary` (+ `emptySummary`), set from `installState.base_plugin_version` after the base sync.

## Customer impact

A customer or support can now see, in routine `sync` output, exactly which `product-manager-os` base the project is running — a cheap substitute for true version pinning.

## Verification

- `tsc --noEmit` clean.
- `tests/commands/base-sync.test.ts` — 8/8 pass, including a new test asserting the base SHA tag appears.
- Full suite: 391/392. The one failure is a pre-existing `--version` string test in an untouched file — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)