### PR TITLE
chore(release): bump to v1.4.10 (ships Track C — data-driven CLAUDE.md)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.0",
+  "version": "1.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mysecond/cli",
-      "version": "1.4.0",
+      "version": "1.4.10",
       "license": "UNLICENSED",
       "dependencies": {
         "proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why

Track C (#37) landed on main as 8051cf1 but is not on npm — publish.yml triggers on `v*` tag push, not main merges. v1.4.9 was already published five days ago (pre-Track-C). Customers running `mysecond sync` are still pulling the Track-C-less version.

## What

`package.json` + `package-lock.json` bump from `1.4.9` → `1.4.10`. Zero code change.

## Ships when

After merge → tag `v1.4.10` from main → push tag → publish workflow fires → npm publishes @mysecond/cli@1.4.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)