### PR TITLE
fix(doctor): normalize stored credentials in getDeviceToken (Item 2)

### DIFF
--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -124,34 +124,12 @@ function loadDotenv(rootDir: string): void {
   }
 }
 
-// v1.4.4 — extract the bare token (and paired API URL, if present)
-// from whatever keychain.ts fileGet returned. Two formats live at the
-// same project-scoped path:
-//   1. Bare token (setDeviceToken writes `<token>\n` — current path).
-//   2. Dotenv-style (step-5b writes `COMPANION_API_KEY=<token>\n
-//      COMPANION_API_URL=<url>\n` — legacy path for pre-1.4.2 installs
-//      whose device-code flow never completed).
-// The paired URL matters for staging installs whose COMPANION_API_URL
-// only lives in the project-scoped credentials file (step-5b moved it
-// out of .env). Without recovering it here, a rescued msd_ token would
-// be sent to the production host and 401 anyway. Codex P2 follow-up.
-function normalizeStoredTokenValue(raw: string): { token: string; apiUrl: string | null } {
-  // Bare-token shortcut: no newline AND no equals → return as-is.
-  if (!raw.includes('\n') && !raw.includes('=')) {
-    return { token: raw, apiUrl: null };
-  }
-  let token = raw;
-  let apiUrl: string | null = null;
-  const tokenMatch = raw.match(/^COMPANION_API_KEY=(.+)$/m);
-  if (tokenMatch !== null && tokenMatch[1] !== undefined) {
-    token = tokenMatch[1].trim();
-  }
-  const urlMatch = raw.match(/^COMPANION_API_URL=(.+)$/m);
-  if (urlMatch !== null && urlMatch[1] !== undefined) {
-    apiUrl = urlMatch[1].trim();
-  }
-  return { token, apiUrl };
-}
+// Item 2 (2026-05-25): credential-format normalization moved into
+// `getDeviceToken` in keychain.ts so every caller — not just buildContext —
+// gets a clean token. The shape returned by `getDeviceToken` now exposes
+// `{ token, storage, apiUrl }`; `apiUrl` is non-null when the underlying
+// store held step-5b dotenv-style content. buildContext consumes that
+// shape directly below; no local normalization needed.
 
 // v1.4.4 legacy-key warning state. Module-scoped so a single process only
 // emits the marker + prose once even if buildContext is called twice.
@@ -230,18 +208,23 @@ export function buildContext(flags: ParsedFlags): CommandContext {
   let keychainRescue = false;
 
   // Lazy keychain lookup — memoized so the rescue check and the
-  // empty-credential fallback share a single shell-out.
-  let keychainTokenCache: string | null | undefined = undefined;
-  const loadKeychainToken = (): string | null => {
-    if (keychainTokenCache !== undefined) return keychainTokenCache;
+  // empty-credential fallback share a single shell-out. Normalization
+  // happens inside getDeviceToken (Item 2): the returned shape already
+  // exposes `{ token, apiUrl }`, so buildContext just consumes both.
+  let keychainCache: { token: string; apiUrl: string | null } | null | undefined = undefined;
+  const loadKeychain = (): { token: string; apiUrl: string | null } | null => {
+    if (keychainCache !== undefined) return keychainCache;
     try {
       const fromStorage = getDeviceToken(rootDir);
-      keychainTokenCache = fromStorage !== null ? fromStorage.token : null;
+      keychainCache =
+        fromStorage !== null
+          ? { token: fromStorage.token, apiUrl: fromStorage.apiUrl }
+          : null;
     } catch {
       // Best-effort. If keychain lookup throws, treat as absent.
-      keychainTokenCache = null;
+      keychainCache = null;
     }
-    return keychainTokenCache;
+    return keychainCache;
   };
 
   if (flags.apiKey !== null && flags.apiKey.length > 0) {
@@ -255,18 +238,9 @@ export function buildContext(flags: ParsedFlags): CommandContext {
     // token, prefer it; the warning shifts to "your env is stale, unset
     // it to silence." Caught by codex review on v1.4.4 PR #28.
     if (!apiKey.startsWith('msd_')) {
-      const fromKeychain = loadKeychainToken();
-      // Normalize: keychain.ts's fileGet returns the raw file contents.
-      // setDeviceToken writes bare `<token>\n`, but step-5b legacy writes
-      // dotenv-style `COMPANION_API_KEY=<token>\nCOMPANION_API_URL=...`
-      // to the SAME path. Without parsing the latter, file-fallback users
-      // whose first init never completed device-code stay stuck in a
-      // re-auth loop even though a valid msd_ token exists on disk.
-      // Codex P2 follow-up on PR #28.
-      const normalized =
-        fromKeychain !== null ? normalizeStoredTokenValue(fromKeychain) : null;
-      if (normalized !== null && normalized.token.startsWith('msd_')) {
-        apiKey = normalized.token;
+      const fromKeychain = loadKeychain();
+      if (fromKeychain !== null && fromKeychain.token.startsWith('msd_')) {
+        apiKey = fromKeychain.token;
         apiKeySource = 'keychain';
         keychainRescue = true;
         // Recover the paired COMPANION_API_URL when shell env didn't
@@ -275,26 +249,19 @@ export function buildContext(flags: ParsedFlags): CommandContext {
         // would send the rescued msd_ token to the production host and
         // 401 anyway. Shell env wins if both are set — explicit user
         // override of staging targeting stays intact.
-        if (!apiBaseFromEnv && normalized.apiUrl !== null) {
-          apiBase = normalized.apiUrl;
+        if (!apiBaseFromEnv && fromKeychain.apiUrl !== null) {
+          apiBase = fromKeychain.apiUrl;
         }
       }
     }
   }
   if (apiKey.length === 0) {
-    const fromKeychain = loadKeychainToken();
+    const fromKeychain = loadKeychain();
     if (fromKeychain !== null) {
-      // Normalize the stored value here too, for symmetry with the
-      // rescue branch above. Without this, a customer who follows the
-      // rescue warning and unsets COMPANION_API_KEY would fall into this
-      // branch, get the raw step-5b dotenv blob assigned to ctx.apiKey,
-      // and end up sending a malformed bearer to /whoami. Codex pass-4
-      // P2 — the rescue advice itself was breaking the next-run path.
-      const normalized = normalizeStoredTokenValue(fromKeychain);
-      apiKey = normalized.token;
+      apiKey = fromKeychain.token;
       apiKeySource = 'keychain';
-      if (!apiBaseFromEnv && normalized.apiUrl !== null) {
-        apiBase = normalized.apiUrl;
+      if (!apiBaseFromEnv && fromKeychain.apiUrl !== null) {
+        apiBase = fromKeychain.apiUrl;
       }
     }
   }

--- a/src/lib/keychain.ts
+++ b/src/lib/keychain.ts
@@ -35,8 +35,97 @@ import { projectHash } from './project-hash.js';
 export type TokenStorage = 'keychain' | 'file_fallback';
 
 export interface ReadResult {
+  /** Normalized bare token, safe to paste into a Bearer header. */
   token: string;
   storage: TokenStorage;
+  /**
+   * Paired `COMPANION_API_URL` when the stored credential was written by
+   * step-5b in dotenv format. `null` for bare-token stores (the v1.4.0+
+   * path written by `setDeviceToken`). Surfaced so `buildContext` can
+   * recover the URL during legacy-credential rescue without re-parsing.
+   */
+  apiUrl: string | null;
+}
+
+/**
+ * Two formats live at the same project-scoped credentials path:
+ *   1. Bare token — `setDeviceToken` writes `<token>\n` (v1.4.0+ canonical).
+ *   2. step-5b exact dotenv format —
+ *      `COMPANION_API_KEY=<token>\nCOMPANION_API_URL=<url>\n` (legacy /
+ *      installed-base recovery path). step-5b writes this exact shape;
+ *      we do not aspire to be a general dotenv parser.
+ *
+ * Item 2 (2026-05-25): `getDeviceToken` previously returned the raw blob.
+ * Callers that pasted `ReadResult.token` into a Bearer header (notably
+ * `mysecond doctor`) hit `Headers.append: invalid header value` because of
+ * the embedded newline. Normalization now happens inside `getDeviceToken`
+ * so every caller is regression-proof by construction.
+ *
+ * Hardening (post-review, 2026-05-25):
+ *   - Always trim the returned token. `fileGet`/`macosKeychainGet` both
+ *     trim their output today, but the normalizer should not depend on
+ *     that — a future input source (libsecret, Windows credential mgr)
+ *     might not.
+ *   - If input looks structured (contains `\n` or `=`) but no
+ *     `COMPANION_API_KEY=` line matches, treat as unparseable and return
+ *     an empty token. The caller (`getDeviceToken`) converts that to
+ *     `null`, so downstream sees "no credential" rather than a malformed
+ *     bearer. This catches: empty-value `COMPANION_API_KEY=` lines,
+ *     `export`-prefixed keys, spaces around `=`, and any future drift in
+ *     step-5b's write format.
+ *   - Final post-check: if the returned token still contains any
+ *     control char that `Headers.append` rejects (CR/LF), reject it.
+ *     Defense in depth.
+ *
+ * Exported as `_normalizeStoredCredentialForTests` so the unit suite can
+ * cover CRLF and malformed-format inputs without filesystem fixtures.
+ */
+export function _normalizeStoredCredentialForTests(
+  raw: string
+): { token: string; apiUrl: string | null } {
+  return normalizeStoredCredential(raw);
+}
+
+function normalizeStoredCredential(raw: string): { token: string; apiUrl: string | null } {
+  // Bare-token shortcut: trim leading/trailing whitespace (including CR,
+  // LF, tabs) and check whether anything structured remains. The
+  // canonical `setDeviceToken` write format is `<token>\n` — after trim
+  // that becomes a clean bare token.
+  const trimmed = raw.trim();
+  if (!trimmed.includes('\n') && !trimmed.includes('=')) {
+    return { token: containsCtl(trimmed) ? '' : trimmed, apiUrl: null };
+  }
+
+  // step-5b exact format: `^COMPANION_API_KEY=<value>$` at column 0.
+  // `.+` requires at least one character so empty-value lines miss the
+  // match and fall through to the "unparseable structured input" branch
+  // below — safer than returning an empty token tied to a recovered URL.
+  let apiUrl: string | null = null;
+  const tokenMatch = raw.match(/^COMPANION_API_KEY=(.+)$/m);
+  const urlMatch = raw.match(/^COMPANION_API_URL=(.+)$/m);
+  if (urlMatch !== null && urlMatch[1] !== undefined) {
+    apiUrl = urlMatch[1].trim();
+  }
+
+  if (tokenMatch !== null && tokenMatch[1] !== undefined) {
+    const token = tokenMatch[1].trim();
+    return { token: containsCtl(token) ? '' : token, apiUrl };
+  }
+
+  // Structured input (has `\n` or `=` after trim) but no
+  // `COMPANION_API_KEY=` match. Reject the entire credential — returning
+  // the raw blob would put a multi-line string into someone's Bearer
+  // header. Caller treats empty token as "no credential found" and
+  // prompts re-auth.
+  return { token: '', apiUrl: null };
+}
+
+/** True if `s` contains any character that `Headers.append` would reject. */
+function containsCtl(s: string): boolean {
+  // Headers.append rejects CR, LF, NUL, and anything outside ISO-8859-1.
+  // We only need to guard the cases the credential store has ever
+  // produced — CR/LF — but checking the full set is cheap.
+  return /[\r\n\0]/.test(s);
 }
 
 /**
@@ -244,13 +333,21 @@ export function getDeviceToken(absoluteProjectDir: string): ReadResult | null {
     const account = accountFor(absoluteProjectDir);
     const fromKeychain = macosKeychainGet(account);
     if (fromKeychain !== null) {
-      return { token: fromKeychain, storage: 'keychain' };
+      const { token, apiUrl } = normalizeStoredCredential(fromKeychain);
+      // Empty token => normalizer rejected the stored value (malformed
+      // structured input, or hit the control-char post-check). Treat as
+      // "no credential" so downstream prompts re-auth instead of
+      // pasting a bad bearer.
+      if (token.length === 0) return null;
+      return { token, storage: 'keychain', apiUrl };
     }
   }
 
   const fromFile = fileGet(absoluteProjectDir);
   if (fromFile !== null) {
-    return { token: fromFile, storage: 'file_fallback' };
+    const { token, apiUrl } = normalizeStoredCredential(fromFile);
+    if (token.length === 0) return null;
+    return { token, storage: 'file_fallback', apiUrl };
   }
   return null;
 }

--- a/tests/lib/keychain.test.ts
+++ b/tests/lib/keychain.test.ts
@@ -1,0 +1,221 @@
+// Regression coverage for Item 2 — the doctor env-parser regression
+// surfaced on 2026-05-25. step-5b writes dotenv-style credentials
+// (`COMPANION_API_KEY=<token>\nCOMPANION_API_URL=<url>\n`) to the SAME
+// project-scoped file that `setDeviceToken` writes bare tokens to. Before
+// this fix, `getDeviceToken` returned the raw blob, so any caller that
+// used `ReadResult.token` directly (notably `mysecond doctor`) pasted the
+// literal "COMPANION_API_KEY=msd_..." string into the Bearer header and
+// hit `Headers.append: invalid header value` from the embedded newline.
+//
+// Fix: normalize inside `getDeviceToken`. All callers get a clean token
+// by default; the paired API URL is surfaced as a new optional field
+// for the auth context (buildContext) that needs it.
+
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  _normalizeStoredCredentialForTests as normalizeStoredCredential,
+  getDeviceToken,
+} from '../../src/lib/keychain.js';
+import { projectHash } from '../../src/lib/project-hash.js';
+
+/**
+ * Plant a project-scoped credentials file under an isolated $HOME so
+ * `getDeviceToken`'s file-fallback path picks it up. Mirrors the helper
+ * already used in `tests/lib/context.test.ts`.
+ */
+function plantCredsFile(home: string, projectDir: string, content: string): string {
+  const credsDir = join(home, '.mysecond', 'projects', projectHash(projectDir));
+  mkdirSync(credsDir, { recursive: true });
+  const credsFile = join(credsDir, 'credentials');
+  writeFileSync(credsFile, content, { encoding: 'utf-8', mode: 0o600 });
+  chmodSync(credsFile, 0o600);
+  return credsFile;
+}
+
+describe('getDeviceToken — normalizes stored credential format', () => {
+  let savedHome: string | undefined;
+
+  beforeEach(() => {
+    savedHome = process.env.HOME;
+    // MYSECOND_NO_KEYCHAIN=1 forces the file-fallback path so the test is
+    // deterministic across darwin (system keychain) and linux/CI.
+    process.env.MYSECOND_NO_KEYCHAIN = '1';
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    delete process.env.MYSECOND_NO_KEYCHAIN;
+  });
+
+  it('returns the bare token when credentials file is bare-token format', () => {
+    const home = mkdtempSync(join(tmpdir(), 'mysecond-kc-'));
+    const project = mkdtempSync(join(tmpdir(), 'mysecond-kc-proj-'));
+    process.env.HOME = home;
+    plantCredsFile(home, project, 'msd_bare_token_abc\n');
+
+    const result = getDeviceToken(project);
+    expect(result).not.toBeNull();
+    expect(result!.token).toBe('msd_bare_token_abc');
+    expect(result!.storage).toBe('file_fallback');
+    expect(result!.apiUrl).toBeNull();
+  });
+
+  it('strips the dotenv wrapper when step-5b wrote dotenv-style content', () => {
+    // This is the regression case. Before the fix, .token contained the
+    // literal "COMPANION_API_KEY=msd_...\nCOMPANION_API_URL=..." blob.
+    const home = mkdtempSync(join(tmpdir(), 'mysecond-kc-'));
+    const project = mkdtempSync(join(tmpdir(), 'mysecond-kc-proj-'));
+    process.env.HOME = home;
+    plantCredsFile(
+      home,
+      project,
+      'COMPANION_API_KEY=msd_dotenv_token_xyz\nCOMPANION_API_URL=https://staging.mysecond.ai\n'
+    );
+
+    const result = getDeviceToken(project);
+    expect(result).not.toBeNull();
+    expect(result!.token).toBe('msd_dotenv_token_xyz');
+    expect(result!.token).not.toContain('\n');
+    expect(result!.token).not.toContain('COMPANION_API_KEY=');
+    expect(result!.token).not.toContain('COMPANION_API_URL=');
+    expect(result!.apiUrl).toBe('https://staging.mysecond.ai');
+  });
+
+  it('handles dotenv format with COMPANION_API_KEY only (no URL line)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'mysecond-kc-'));
+    const project = mkdtempSync(join(tmpdir(), 'mysecond-kc-proj-'));
+    process.env.HOME = home;
+    plantCredsFile(home, project, 'COMPANION_API_KEY=msd_only_key\n');
+
+    const result = getDeviceToken(project);
+    expect(result).not.toBeNull();
+    expect(result!.token).toBe('msd_only_key');
+    expect(result!.apiUrl).toBeNull();
+  });
+
+  it('returns null when no credentials file exists', () => {
+    const home = mkdtempSync(join(tmpdir(), 'mysecond-kc-'));
+    const project = mkdtempSync(join(tmpdir(), 'mysecond-kc-proj-'));
+    process.env.HOME = home;
+
+    expect(getDeviceToken(project)).toBeNull();
+  });
+
+  it('produces a token safe to use as a Bearer header value (regression-proof)', () => {
+    // Direct guard for the Item 2 failure mode: Headers.append rejects any
+    // value containing CR/LF. If a future caller pastes ReadResult.token
+    // into a header again, this test ensures the value is well-formed.
+    const home = mkdtempSync(join(tmpdir(), 'mysecond-kc-'));
+    const project = mkdtempSync(join(tmpdir(), 'mysecond-kc-proj-'));
+    process.env.HOME = home;
+    plantCredsFile(
+      home,
+      project,
+      'COMPANION_API_KEY=msd_token\nCOMPANION_API_URL=https://app.mysecond.ai\n'
+    );
+
+    const result = getDeviceToken(project);
+    expect(result).not.toBeNull();
+
+    // The actual platform check that was failing: `new Headers()` throws on
+    // values containing newlines or other control characters.
+    expect(() => {
+      new Headers({ authorization: `Bearer ${result!.token}` });
+    }).not.toThrow();
+  });
+});
+
+// Direct unit coverage for the normalizer. Exercises inputs that the
+// `fileGet`/`macosKeychainGet` pipelines pre-trim in practice, but the
+// normalizer should defend against on its own — review feedback (codex
+// review pass, 2026-05-25): callers should not be load-bearing for
+// header-safety.
+describe('normalizeStoredCredential — direct, no filesystem', () => {
+  it('strips a trailing newline from a bare token (defense in depth)', () => {
+    // Real callers trim before passing in, but the normalizer should be
+    // safe even if a future input source (libsecret, Win cred mgr)
+    // doesn't.
+    expect(normalizeStoredCredential('msd_token_xyz\n')).toEqual({
+      token: 'msd_token_xyz',
+      apiUrl: null,
+    });
+  });
+
+  it('strips CRLF from a bare token', () => {
+    expect(normalizeStoredCredential('msd_token_crlf\r\n')).toEqual({
+      token: 'msd_token_crlf',
+      apiUrl: null,
+    });
+  });
+
+  it('extracts token + apiUrl from CRLF-encoded step-5b dotenv', () => {
+    // Windows-mounted volumes or hand-edited files can carry CRLF.
+    const result = normalizeStoredCredential(
+      'COMPANION_API_KEY=msd_crlf_token\r\nCOMPANION_API_URL=https://staging.mysecond.ai\r\n'
+    );
+    expect(result.token).toBe('msd_crlf_token');
+    expect(result.apiUrl).toBe('https://staging.mysecond.ai');
+  });
+
+  it('rejects empty-value COMPANION_API_KEY= (malformed step-5b output)', () => {
+    // If step-5b ever wrote an empty key value, the regex misses (`.+`
+    // requires ≥1 char) and the normalizer must NOT fall through to
+    // returning the raw multi-line blob. Empty token signals "no
+    // credential" to the caller.
+    const result = normalizeStoredCredential(
+      'COMPANION_API_KEY=\nCOMPANION_API_URL=https://app.mysecond.ai\n'
+    );
+    expect(result.token).toBe('');
+  });
+
+  it('rejects `export `-prefixed COMPANION_API_KEY (unsupported variant)', () => {
+    // Our regex anchors at column 0 with no `export ` tolerance — that
+    // matches step-5b's exact write format. An export-prefixed file is
+    // rejected (empty token) rather than silently returned with the
+    // wrapper as the token.
+    const result = normalizeStoredCredential(
+      'export COMPANION_API_KEY=msd_x\nCOMPANION_API_URL=https://app.mysecond.ai\n'
+    );
+    expect(result.token).toBe('');
+  });
+
+  it('rejects spaces-around-equals (unsupported variant)', () => {
+    const result = normalizeStoredCredential('COMPANION_API_KEY = msd_x\n');
+    expect(result.token).toBe('');
+  });
+
+  it('rejects any structured input whose token would contain a newline', () => {
+    // Belt-and-suspenders: even if a future regex change matched a
+    // value that happened to contain a CR/LF, the final post-check
+    // forces an empty token.
+    const result = normalizeStoredCredential('plain\nmultiline\nwithout\ndotenv\nmarkers');
+    expect(result.token).toBe('');
+  });
+
+  it('every direct output is safe in Headers.append (sweep)', () => {
+    const inputs = [
+      'msd_bare',
+      'msd_with_trailing_lf\n',
+      'msd_with_crlf\r\n',
+      'COMPANION_API_KEY=msd_dotenv\nCOMPANION_API_URL=https://app.mysecond.ai\n',
+      'COMPANION_API_KEY=msd_dotenv_crlf\r\nCOMPANION_API_URL=https://app.mysecond.ai\r\n',
+      'COMPANION_API_KEY=\nCOMPANION_API_URL=https://app.mysecond.ai\n',
+      'export COMPANION_API_KEY=msd_x\n',
+      '',
+    ];
+    for (const raw of inputs) {
+      const { token } = normalizeStoredCredential(raw);
+      // Empty token is fine — getDeviceToken converts to null. Non-empty
+      // tokens MUST be safe in a Bearer header.
+      if (token.length > 0) {
+        expect(() => new Headers({ authorization: `Bearer ${token}` })).not.toThrow();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

Fixes `mysecond doctor` failing with `Headers.append: invalid header value` when the project-scoped credentials file holds step-5b's dotenv format. Latent regression since v1.4.4 — `buildContext` normalized locally but `doctor.ts` called `getDeviceToken` directly and pasted the raw multi-line blob into a Bearer header.

## Approach

Single source of truth: move credential normalization into `getDeviceToken`. Every caller now gets a clean, header-safe token by default; `ReadResult` gains `apiUrl: string | null` to surface the paired URL the legacy-credential rescue path in `buildContext` needs. The duplicate `normalizeStoredTokenValue` in context.ts is removed.

## Hardening from review

Both /codex review and the cto-tech-lead subagent flagged additional subtleties. Folded into the same diff:

- **Trim first, then check for structured markers.** A canonical `setDeviceToken` write (`<token>\n`) fast-paths cleanly even if a future input source forgets to pre-trim.
- **Structured-but-unparseable inputs are rejected.** If raw has `\n`/`=` after trim but no `COMPANION_API_KEY=` line matches, the normalizer returns an empty token; `getDeviceToken` converts that to `null` so downstream sees "no credential" instead of a malformed bearer. Catches: empty-value `COMPANION_API_KEY=` lines, `export `-prefixed keys, and spaces around `=`.
- **CR/LF/NUL post-check.** Defense in depth against any future regex change capturing a value with control chars.
- **Test export.** Normalizer exposed as `_normalizeStoredCredentialForTests` so CRLF and malformed-input edges are covered without filesystem fixtures.

## Verification

- ✅ `npm run typecheck` clean.
- ✅ `npm run build` clean (`dist/mysecond.mjs` 154.9kb).
- ✅ 13 new keychain tests (5 integration + 8 direct-normalizer) pass.
- ✅ All 35 existing `context.test.ts` tests pass — zero behavior delta on the v1.4.4 rescue path.
- ✅ Full suite — 32 of 33 test files reported ✓ before vitest hung on shutdown locally (CI will give the clean exit). The one unreported file is `cli.test.ts` (CLI arg parsing); diff doesn't touch any code it exercises.
- ✅ Manual `mysecond doctor` against five planted credential formats — dotenv, bare+\n, CRLF dotenv, empty key, `export`-prefix — all behave correctly (reach server cleanly or "install incomplete"; no `Headers.append` failures).

## Why this isn't bundled with #34

Item 2 ships first as `1.4.11`. Then #34 (the upgrade nag) ships as `1.4.12`. Sequencing matters: if #34 shipped first, the nag would walk customers from 1.4.10 → 1.4.11 and they'd run `doctor` to verify the upgrade and hit this exact bug. The bug fix needs to land first.

## Release plan

1. Merge this PR.
2. `npm version patch` → tag `v1.4.11` → publish via `publish.yml`.
3. Then start #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)