### PR TITLE
feat(sync): emit upgrade-staleness nag once per day (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ This is the v1.1.0 scaffold. `init`, `sync`, and `artifact-sync` are stubs that 
 - An active mySecond subscription ([mysecond.ai/pricing](https://mysecond.ai/pricing))
 - Claude Code (Desktop or CLI)
 
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `COMPANION_API_KEY` | Override the device token (legacy / per-shell auth path). |
+| `COMPANION_API_URL` | Override the API host (staging / local dev). |
+| `MYSECOND_NO_KEYCHAIN=1` | Force file-fallback credential storage even on macOS. |
+| `MYSECOND_NO_UPGRADE_NAG=1` | Silence the once-per-day "your CLI is behind" stderr line on session-start sync. |
+
 ## Development
 
 ```bash

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -27,7 +27,12 @@ import {
   writeInstallState,
   type InstallState,
 } from '../lib/install-state.js';
-import { markNpmUpdated, shouldRunNpmUpdate } from '../lib/npm.js';
+import {
+  fetchLatestNpmVersion,
+  markNpmUpdated,
+  maybePrintUpgradeNag,
+  shouldRunNpmUpdate,
+} from '../lib/npm.js';
 import {
   scanArtifacts,
   scanContextFiles,
@@ -740,15 +745,35 @@ export async function runSync(
 
   // The 24h gate is honored; actual `npm update -g @mysecond/customer-{slug}`
   // invocation lands when PR 4c provisions the customer plugin slug to local
-  // state. Until then the gate just stamps the timestamp so the cadence starts
-  // from install day.
+  // state. Until then the gate stamps the timestamp so the cadence starts
+  // from install day AND drives the upgrade-staleness probe (issue #34):
+  // fetch the latest published `@mysecond/cli` version once per 24h and
+  // cache it in sync-state for `maybePrintUpgradeNag` below.
+  //
+  // markNpmUpdated stamps regardless of fetch outcome (success or null).
+  // Rationale: the SessionStart hook runs on EVERY Claude Code session — a
+  // multi-hour npm registry outage would otherwise hammer the registry on
+  // every session start. Worst case of stamping-on-failure is a 24h delay
+  // before the next retry, acceptable for a nag (vs. a feature). Auto-
+  // upgrade follow-up should split `lastNpmUpdateAt` into
+  // `lastVersionCheckAt` so success and failure cadences can diverge —
+  // tracked in the issue #34 plan's "Foundation for auto-upgrade" section.
   if (shouldRunNpmUpdate(state, ctx)) {
+    const latest = await fetchLatestNpmVersion();
+    if (latest !== null) state.lastKnownLatestNpmVersion = latest;
     markNpmUpdated(state);
     summary.npmUpdateRan = true;
   }
 
   state.lastSyncedAt = response.syncedAt;
   writeSyncState(ctx.rootDir, state);
+
+  // Issue #34: emit one stderr line if the running CLI is behind the cached
+  // latest version. Self-persisting (own writeSyncState call) so the 24h
+  // prompt debounce stamp cannot be lost by call-site ordering mistakes.
+  // Called AFTER the writeSyncState above so the same persist isn't done
+  // twice in the common (no-nag) case.
+  maybePrintUpgradeNag(state, ctx.rootDir);
 
   // Self-heal the "duplicate skills" bug (Finding #2) for EXISTING customers.
   // step-9 (plugin install) is skipped on re-runs once the init ledger is

--- a/src/lib/npm.ts
+++ b/src/lib/npm.ts
@@ -136,19 +136,23 @@ export function maybePrintUpgradeNag(state: SyncState, rootDir: string): void {
       'Set MYSECOND_NO_UPGRADE_NAG=1 to silence.\n'
   );
 
-  // Persist BEFORE mutating in-memory state. If the write fails, the
-  // customer sees the nag again tomorrow — annoying but never broken — and
-  // the in-memory `state` stays consistent with disk truth. Without this
-  // ordering, a downstream caller that re-reads `state.lastUpgradePromptAt`
-  // could believe the prompt was stamped when disk says otherwise (codex
-  // review pass, 2026-05-26).
+  // Persist BEFORE mutating in-memory state. If the write fails, leave
+  // `state.lastUpgradePromptAt` null so disk and memory stay consistent —
+  // a downstream caller re-reading `state.lastUpgradePromptAt` always
+  // matches what's on disk. Codex review pass, 2026-05-26.
+  //
+  // Tradeoff on persist failure: the debounce stamp doesn't land, so if
+  // the underlying disk issue persists the customer sees the nag on
+  // every session (not "again tomorrow"). Acceptable best-effort
+  // behavior — a persistent write failure means sync-state itself is
+  // broken and the customer has bigger problems to surface. We never
+  // fail sync because of the debounce stamp.
   const stamp = new Date().toISOString();
   const persisted: SyncState = { ...state, lastUpgradePromptAt: stamp };
   try {
     writeSyncState(rootDir, persisted);
     state.lastUpgradePromptAt = stamp;
   } catch {
-    // Best-effort persistence. Leave in-memory state unchanged. Never
-    // fail sync because of the debounce stamp.
+    // Best-effort persistence. Leave in-memory state unchanged.
   }
 }

--- a/src/lib/npm.ts
+++ b/src/lib/npm.ts
@@ -8,16 +8,28 @@
 // Rule: cache lastNpmUpdateAt in .claude/sync-state.json. Skip the update if
 // less than 24h has passed. `--force-update` bypasses the gate.
 //
-// PR 4b ships the gate logic + the structured wrapper for the future
-// `npm update` invocation. Actual `execa('npm', ...)` + 401 retry per EDD §5.4
-// lands when the customer plugin slug is known to the CLI (post-PR-4c, since
-// only `mysecond init` provisions the slug into local state). For now the
-// timebox is honored as a no-op placeholder so the gate is exercised by tests.
+// Issue #34 layer (2026-05-26): the gate is now also the cadence for an
+// upgrade-staleness probe. `fetchLatestNpmVersion` runs at most once per 24h
+// (same gate as the dormant `npm update -g` hook) and the result lands in
+// `lastKnownLatestNpmVersion`. `maybePrintUpgradeNag` reads that cache plus
+// the running `__VERSION__` and writes one stderr line on session-start when
+// the customer is behind. Independent 24h debounce on the prompt itself
+// (`lastUpgradePromptAt`) keeps the nag from spamming.
 
 import type { CommandContext } from './context.js';
 import type { SyncState } from './sync-state.js';
+import { writeSyncState } from './sync-state.js';
+
+declare const __VERSION__: string;
 
 export const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+// Registry probe timeout. 1s covers a healthy registry response in ~all
+// conditions and bails fast on captive-portal / corp-proxy / DNS-fail
+// scenarios. SessionStart hook has a UI timeout; 2s+ here is visibly slow.
+export const REGISTRY_FETCH_TIMEOUT_MS = 1000;
+
+const NPM_REGISTRY_LATEST_URL = 'https://registry.npmjs.org/@mysecond/cli/latest';
 
 export function shouldRunNpmUpdate(state: SyncState, ctx: CommandContext): boolean {
   if (ctx.forceUpdate) return true;
@@ -29,4 +41,114 @@ export function shouldRunNpmUpdate(state: SyncState, ctx: CommandContext): boole
 
 export function markNpmUpdated(state: SyncState): void {
   state.lastNpmUpdateAt = new Date().toISOString();
+}
+
+// ─── Issue #34: upgrade staleness probe + nag ──────────────────────────────
+
+/**
+ * Fetch the `latest` dist-tag version of `@mysecond/cli` from npm's public
+ * registry. Returns `null` on any failure (network, timeout, malformed JSON,
+ * non-200 status, OR a value that doesn't match `x.y.z`) — this is
+ * best-effort; sync must never fail because the registry is unreachable.
+ * Uses Node 20+ global `fetch` + `AbortSignal`; no subprocess, no auth
+ * (public scope).
+ *
+ * The `x.y.z` validation defends the cache: if `latest` is ever pointed at
+ * a prerelease (`1.5.0-beta.1`) or build-tagged version by mistake,
+ * caching that string would silently disable the nag for every customer
+ * (compareSemver returns 0 for non-conforming inputs). Bailing here lets
+ * the next 24h-gated check re-try once the registry is corrected — codex
+ * review pass, 2026-05-26.
+ */
+export async function fetchLatestNpmVersion(): Promise<string | null> {
+  try {
+    const response = await fetch(NPM_REGISTRY_LATEST_URL, {
+      signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
+      headers: { accept: 'application/json' },
+    });
+    if (!response.ok) return null;
+    const body = (await response.json().catch(() => null)) as { version?: unknown } | null;
+    if (body === null || typeof body.version !== 'string') return null;
+    if (!/^\d+\.\d+\.\d+$/.test(body.version)) return null;
+    return body.version;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compare two `x.y.z` strings. Returns -1 if `a < b`, 1 if `a > b`, 0 if
+ * equal OR if either input is malformed. Malformed = "not three integers
+ * separated by dots" — we deliberately treat pre-release tags
+ * (`1.4.10-rc.1`) as malformed because they're not on the `latest` dist-tag
+ * today; bailing to 0 makes the nag silently disable in that case rather
+ * than firing a false positive.
+ */
+export function compareSemver(a: string, b: string): -1 | 0 | 1 {
+  const parsed = (s: string): [number, number, number] | null => {
+    const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(s);
+    if (m === null) return null;
+    return [Number(m[1]), Number(m[2]), Number(m[3])];
+  };
+  const pa = parsed(a);
+  const pb = parsed(b);
+  if (pa === null || pb === null) return 0;
+  for (let i = 0; i < 3; i++) {
+    const av = pa[i] as number;
+    const bv = pb[i] as number;
+    if (av < bv) return -1;
+    if (av > bv) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Write one stderr line if the running CLI is behind the cached latest
+ * version. Self-contained — takes `rootDir` and calls `writeSyncState`
+ * itself so callers cannot accidentally lose the debounce stamp by
+ * forgetting to persist.
+ *
+ * Skip conditions (any of):
+ *   - `MYSECOND_NO_UPGRADE_NAG=1` set in env.
+ *   - `state.lastKnownLatestNpmVersion` is null (no probe result yet).
+ *   - `compareSemver(__VERSION__, latest) >= 0` — running CLI is at or
+ *     ahead of cached latest.
+ *   - `state.lastUpgradePromptAt` is within 24h of now.
+ *
+ * Writes to stderr regardless of `silent` — silent mode IS the Claude Code
+ * SessionStart hook, which is precisely where the customer needs the
+ * signal. The 24h debounce keeps it tolerable (one line per day max).
+ */
+export function maybePrintUpgradeNag(state: SyncState, rootDir: string): void {
+  if (process.env.MYSECOND_NO_UPGRADE_NAG === '1') return;
+  const latest = state.lastKnownLatestNpmVersion;
+  if (latest === null || latest.length === 0) return;
+  if (compareSemver(__VERSION__, latest) >= 0) return;
+
+  if (state.lastUpgradePromptAt !== null) {
+    const last = Date.parse(state.lastUpgradePromptAt);
+    if (!Number.isNaN(last) && Date.now() - last < TWENTY_FOUR_HOURS_MS) return;
+  }
+
+  process.stderr.write(
+    `mysecond: your CLI is ${__VERSION__} (latest ${latest}). ` +
+      'Run `npx @mysecond/cli@latest init` to update. ' +
+      'Set MYSECOND_NO_UPGRADE_NAG=1 to silence.\n'
+  );
+
+  // Persist BEFORE mutating in-memory state. If the write fails, the
+  // customer sees the nag again tomorrow — annoying but never broken — and
+  // the in-memory `state` stays consistent with disk truth. Without this
+  // ordering, a downstream caller that re-reads `state.lastUpgradePromptAt`
+  // could believe the prompt was stamped when disk says otherwise (codex
+  // review pass, 2026-05-26).
+  const stamp = new Date().toISOString();
+  const persisted: SyncState = { ...state, lastUpgradePromptAt: stamp };
+  try {
+    writeSyncState(rootDir, persisted);
+    state.lastUpgradePromptAt = stamp;
+  } catch {
+    // Best-effort persistence. Leave in-memory state unchanged. Never
+    // fail sync because of the debounce stamp.
+  }
 }

--- a/src/lib/sync-state.ts
+++ b/src/lib/sync-state.ts
@@ -45,6 +45,16 @@ export interface SyncState {
   workspaceScope: 'solo' | 'team' | null;
   // Customer slug — used to build marketplace name + paths everywhere.
   customerSlug: string | null;
+  // Issue #34 — upgrade-nag plumbing.
+  // `lastKnownLatestNpmVersion` is the last value `fetchLatestNpmVersion`
+  // returned successfully. Cached here so the nag-decision path can compare
+  // `__VERSION__` against it without re-hitting the registry on every sync
+  // (the registry call itself is 24h-gated separately by `lastNpmUpdateAt`).
+  // `lastUpgradePromptAt` debounces the stderr nag — without it, every silent
+  // SessionStart sync that crosses the registry-refresh boundary would re-emit
+  // the same upgrade line.
+  lastKnownLatestNpmVersion: string | null;
+  lastUpgradePromptAt: string | null;
 }
 
 function freshEmptyState(): SyncState {
@@ -59,6 +69,8 @@ function freshEmptyState(): SyncState {
     customerId: null,
     workspaceScope: null,
     customerSlug: null,
+    lastKnownLatestNpmVersion: null,
+    lastUpgradePromptAt: null,
   };
 }
 

--- a/tests/commands/base-sync.test.ts
+++ b/tests/commands/base-sync.test.ts
@@ -61,6 +61,8 @@ function seedState(rootDir: string, partial: Partial<SyncState> = {}): void {
     customerId: null,
     workspaceScope: null,
     customerSlug: null,
+    lastKnownLatestNpmVersion: null,
+    lastUpgradePromptAt: null,
   };
   writeSyncState(rootDir, { ...base, ...partial });
 }
@@ -390,5 +392,164 @@ describe('Workstream H — base plugin update sync', () => {
     const code = await runSync([], ctx(root));
     expect(code).toBe(0);
     expect(existsSync(getInstallStatePath(root))).toBe(true);
+  });
+});
+
+// Issue #34 — upgrade-nag end-to-end through runSync.
+// The unit tests in tests/lib/npm.test.ts prove the helpers in isolation; this
+// suite proves the wiring: when the 24h gate is open AND the registry returns
+// a newer version, runSync stores the cached latest, emits the nag to stderr,
+// and persists the debounce stamp to sync-state.json.
+describe('Workstream #34 — upgrade nag integration through runSync', () => {
+  let originalFetch: typeof fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalHome: string | undefined;
+  let tmpHome: string;
+  let stderrBuf: string;
+  let origStderrWrite: typeof process.stderr.write;
+  let savedNagEnv: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    originalHome = process.env.HOME;
+    tmpHome = mkdtempSync(join(tmpdir(), 'mysecond-nag-int-home-'));
+    process.env.HOME = tmpHome;
+    savedNagEnv = process.env.MYSECOND_NO_UPGRADE_NAG;
+    delete process.env.MYSECOND_NO_UPGRADE_NAG;
+    stderrBuf = '';
+    origStderrWrite = process.stderr.write.bind(process.stderr);
+    (process.stderr.write as unknown) = ((chunk: string | Uint8Array) => {
+      stderrBuf += typeof chunk === 'string' ? chunk : chunk.toString();
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stderr.write = origStderrWrite;
+    globalThis.fetch = originalFetch;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (savedNagEnv === undefined) delete process.env.MYSECOND_NO_UPGRADE_NAG;
+    else process.env.MYSECOND_NO_UPGRADE_NAG = savedNagEnv;
+  });
+
+  it('on 24h gate fire: fetches latest, caches it, emits nag, persists debounce stamp', async () => {
+    const root = tmpProject();
+    // 24h gate must be OPEN, so lastNpmUpdateAt = null. Also start with no
+    // prior nag stamp.
+    seedState(root, { lastNpmUpdateAt: null });
+
+    // Two fetches in order:
+    //   1. cli-sync (real sync work) — return an empty server response.
+    //   2. npm registry (fetchLatestNpmVersion) — return a far-future
+    //      version so the running CLI is unambiguously behind.
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        context_files: [],
+        custom_skills: [],
+        custom_agents: [],
+        custom_workflows: [],
+        base_plugin_version: SHA_NEW,
+        syncedAt: new Date().toISOString(),
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ version: '999.0.0' }),
+    );
+
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+
+    // Registry was probed.
+    const npmCall = (fetchMock.mock.calls.find(
+      (c) => String((c as unknown[])[0]).includes('registry.npmjs.org'),
+    )) as [URL | string, RequestInit] | undefined;
+    expect(npmCall).toBeDefined();
+
+    // Cached latest is persisted to disk; debounce stamp is too.
+    const raw = readFileSync(join(root, '.claude', 'sync-state.json'), 'utf8');
+    const persisted = JSON.parse(raw) as SyncState;
+    expect(persisted.lastKnownLatestNpmVersion).toBe('999.0.0');
+    expect(persisted.lastUpgradePromptAt).not.toBeNull();
+    expect(persisted.lastNpmUpdateAt).not.toBeNull();
+
+    // Nag fired to stderr.
+    expect(stderrBuf).toContain('mysecond: your CLI is');
+    expect(stderrBuf).toContain('(latest 999.0.0)');
+  });
+
+  it('on 24h gate CLOSED: no registry call, but cached latest still drives the nag', async () => {
+    const root = tmpProject();
+    // Gate closed (recent stamp), but cache already holds a "behind" latest
+    // from a previous gate-open run. This is the most common production
+    // state — most session-starts won't probe the registry.
+    seedState(root, {
+      lastNpmUpdateAt: new Date(Date.now() - 1000).toISOString(),
+      lastKnownLatestNpmVersion: '999.0.0',
+      lastUpgradePromptAt: null,
+    });
+
+    // Only the cli-sync call is expected; no second mock for the registry.
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        context_files: [],
+        custom_skills: [],
+        custom_agents: [],
+        custom_workflows: [],
+        base_plugin_version: SHA_NEW,
+        syncedAt: new Date().toISOString(),
+      }),
+    );
+
+    await runSync([], ctx(root));
+
+    // No registry call.
+    const npmCalls = fetchMock.mock.calls.filter((c) =>
+      String((c as unknown[])[0]).includes('registry.npmjs.org'),
+    );
+    expect(npmCalls).toHaveLength(0);
+
+    // Nag still fired from the cached latest.
+    expect(stderrBuf).toContain('mysecond: your CLI is');
+    expect(stderrBuf).toContain('(latest 999.0.0)');
+
+    // Stamp persisted.
+    const persisted = JSON.parse(
+      readFileSync(join(root, '.claude', 'sync-state.json'), 'utf8'),
+    ) as SyncState;
+    expect(persisted.lastUpgradePromptAt).not.toBeNull();
+  });
+
+  it('does not poison the cache when the registry returns a prerelease', async () => {
+    const root = tmpProject();
+    seedState(root, { lastNpmUpdateAt: null });
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        context_files: [],
+        custom_skills: [],
+        custom_agents: [],
+        custom_workflows: [],
+        base_plugin_version: SHA_NEW,
+        syncedAt: new Date().toISOString(),
+      }),
+    );
+    // Registry returns a prerelease — should be rejected at the fetch
+    // boundary, not cached.
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ version: '1.5.0-beta.1' }),
+    );
+
+    await runSync([], ctx(root));
+
+    const persisted = JSON.parse(
+      readFileSync(join(root, '.claude', 'sync-state.json'), 'utf8'),
+    ) as SyncState;
+    // Cache stays at whatever it was (null in this test) — NOT poisoned.
+    expect(persisted.lastKnownLatestNpmVersion).toBeNull();
+    // No nag (cache is empty).
+    expect(stderrBuf).not.toContain('mysecond: your CLI is');
   });
 });

--- a/tests/lib/npm.test.ts
+++ b/tests/lib/npm.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -48,17 +48,23 @@ function state(lastNpmUpdateAt: string | null): SyncState {
   };
 }
 
-/** Fresh SyncState with the issue-#34 fields populated, for nag tests. */
+/** Fresh structurally-complete SyncState, for nag tests. */
 function nagState(overrides: Partial<SyncState> = {}): SyncState {
   return {
     files: {},
     artifacts: {},
+    contextFiles: {},
     lastSyncedAt: null,
     lastNpmUpdateAt: null,
+    initCompletedSteps: [],
+    step9Auth401RetryCount: 0,
+    customerId: null,
+    workspaceScope: null,
+    customerSlug: null,
     lastKnownLatestNpmVersion: null,
     lastUpgradePromptAt: null,
     ...overrides,
-  } as SyncState;
+  };
 }
 
 describe('shouldRunNpmUpdate', () => {
@@ -379,7 +385,7 @@ describe('maybePrintUpgradeNag', () => {
     const blockedRoot = join(tmpRoot, 'blocked');
     // Write a file at the .claude path so mkdir fails when sync-state
     // tries to create .claude/sync-state.json inside it.
-    require('node:fs').writeFileSync(blockedRoot, 'not-a-directory');
+    writeFileSync(blockedRoot, 'not-a-directory');
     const s = nagState({ lastKnownLatestNpmVersion: '999.0.0' });
     maybePrintUpgradeNag(s, blockedRoot);
     // The stderr line still fires (best-effort persistence shouldn't

--- a/tests/lib/npm.test.ts
+++ b/tests/lib/npm.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CommandContext } from '../../src/lib/context.js';
-import { markNpmUpdated, shouldRunNpmUpdate, TWENTY_FOUR_HOURS_MS } from '../../src/lib/npm.js';
-import type { SyncState } from '../../src/lib/sync-state.js';
+import {
+  compareSemver,
+  fetchLatestNpmVersion,
+  markNpmUpdated,
+  maybePrintUpgradeNag,
+  REGISTRY_FETCH_TIMEOUT_MS,
+  shouldRunNpmUpdate,
+  TWENTY_FOUR_HOURS_MS,
+} from '../../src/lib/npm.js';
+import { readSyncState, writeSyncState, type SyncState } from '../../src/lib/sync-state.js';
 
 function ctx(overrides: Partial<CommandContext> = {}): CommandContext {
   return {
@@ -18,12 +30,35 @@ function ctx(overrides: Partial<CommandContext> = {}): CommandContext {
 }
 
 function state(lastNpmUpdateAt: string | null): SyncState {
+  // Structurally complete SyncState so future tests that read other
+  // fields don't get `undefined` (CTO review pass, 2026-05-26).
+  return {
+    files: {},
+    artifacts: {},
+    contextFiles: {},
+    lastSyncedAt: null,
+    lastNpmUpdateAt,
+    initCompletedSteps: [],
+    step9Auth401RetryCount: 0,
+    customerId: null,
+    workspaceScope: null,
+    customerSlug: null,
+    lastKnownLatestNpmVersion: null,
+    lastUpgradePromptAt: null,
+  };
+}
+
+/** Fresh SyncState with the issue-#34 fields populated, for nag tests. */
+function nagState(overrides: Partial<SyncState> = {}): SyncState {
   return {
     files: {},
     artifacts: {},
     lastSyncedAt: null,
-    lastNpmUpdateAt,
-  };
+    lastNpmUpdateAt: null,
+    lastKnownLatestNpmVersion: null,
+    lastUpgradePromptAt: null,
+    ...overrides,
+  } as SyncState;
 }
 
 describe('shouldRunNpmUpdate', () => {
@@ -61,5 +96,296 @@ describe('markNpmUpdated', () => {
     const stored = Date.parse(s.lastNpmUpdateAt!);
     expect(stored).toBeGreaterThanOrEqual(before);
     expect(stored).toBeLessThanOrEqual(after);
+  });
+});
+
+// ─── Issue #34 — compareSemver ────────────────────────────────────────────
+
+describe('compareSemver', () => {
+  it('returns 0 for equal versions', () => {
+    expect(compareSemver('1.4.11', '1.4.11')).toBe(0);
+  });
+
+  it('returns -1 when a is patch-behind b', () => {
+    expect(compareSemver('1.4.10', '1.4.11')).toBe(-1);
+  });
+
+  it('returns -1 when a is minor-behind b', () => {
+    expect(compareSemver('1.4.11', '1.5.0')).toBe(-1);
+  });
+
+  it('returns -1 when a is major-behind b', () => {
+    expect(compareSemver('1.4.11', '2.0.0')).toBe(-1);
+  });
+
+  it('returns 1 when a is ahead of b', () => {
+    expect(compareSemver('1.4.12', '1.4.11')).toBe(1);
+  });
+
+  it('returns 0 for any non-x.y.z input (pre-release, missing parts)', () => {
+    // Deliberate bail-safe: malformed input disables the nag rather than
+    // firing a false positive.
+    expect(compareSemver('1.4.11-rc.1', '1.4.11')).toBe(0);
+    expect(compareSemver('1.4', '1.4.11')).toBe(0);
+    expect(compareSemver('1.4.11', '1.4')).toBe(0);
+    expect(compareSemver('', '1.4.11')).toBe(0);
+    expect(compareSemver('latest', '1.4.11')).toBe(0);
+  });
+
+  it('numeric (not lexicographic) compare on each segment', () => {
+    expect(compareSemver('1.10.0', '1.9.99')).toBe(1);
+    expect(compareSemver('0.0.10', '0.0.9')).toBe(1);
+  });
+});
+
+// ─── Issue #34 — fetchLatestNpmVersion ────────────────────────────────────
+
+describe('fetchLatestNpmVersion', () => {
+  let realFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    realFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('returns the version on a 200 response', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ version: '1.4.99' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as unknown as typeof fetch;
+    expect(await fetchLatestNpmVersion()).toBe('1.4.99');
+  });
+
+  it('returns null on a 500 response', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response('', { status: 500 })
+    ) as unknown as typeof fetch;
+    expect(await fetchLatestNpmVersion()).toBeNull();
+  });
+
+  it('returns null on a 404 response', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response('', { status: 404 })
+    ) as unknown as typeof fetch;
+    expect(await fetchLatestNpmVersion()).toBeNull();
+  });
+
+  it('returns null on malformed JSON', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response('not json', { status: 200 })
+    ) as unknown as typeof fetch;
+    expect(await fetchLatestNpmVersion()).toBeNull();
+  });
+
+  it('returns null when version field is missing or non-string', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ name: '@mysecond/cli' }), { status: 200 })
+    ) as unknown as typeof fetch;
+    expect(await fetchLatestNpmVersion()).toBeNull();
+  });
+
+  it('returns null when fetch throws (network failure)', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('ENOTFOUND');
+    }) as unknown as typeof fetch;
+    expect(await fetchLatestNpmVersion()).toBeNull();
+  });
+
+  it('uses a bounded timeout', async () => {
+    // Caller-side AbortSignal.timeout is wired; this asserts the constant
+    // exists and is short enough for the SessionStart-hook context.
+    expect(REGISTRY_FETCH_TIMEOUT_MS).toBeLessThanOrEqual(2000);
+    expect(REGISTRY_FETCH_TIMEOUT_MS).toBeGreaterThanOrEqual(500);
+  });
+
+  it('returns null when fetch exceeds the timeout (AbortSignal triggers)', async () => {
+    // Mock fetch that respects the abort signal: it rejects with a
+    // DOMException when aborted, matching Node 20+ behavior. This proves
+    // the function actually wires the AbortSignal.timeout, not just
+    // names a constant. Codex review pass, 2026-05-26.
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      const signal = (init as RequestInit | undefined)?.signal as AbortSignal | undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        if (signal !== undefined) {
+          signal.addEventListener('abort', () => {
+            reject(new DOMException('aborted', 'AbortError'));
+          });
+        }
+        // Never resolve naturally; rely on the abort.
+      });
+    }) as unknown as typeof fetch;
+    const start = Date.now();
+    const result = await fetchLatestNpmVersion();
+    const elapsed = Date.now() - start;
+    expect(result).toBeNull();
+    // Should abort within ~timeout + small overhead.
+    expect(elapsed).toBeLessThan(REGISTRY_FETCH_TIMEOUT_MS + 500);
+  }, 5000);
+
+  it('rejects a successful response whose version is not x.y.z (poisoning guard)', async () => {
+    // If npm registry ever returns a prerelease as `latest` (mistake or
+    // ops accident), caching that string would silently disable the nag
+    // for every older customer. We bail at fetch instead so the next
+    // 24h-gated check can retry.
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ version: '1.5.0-beta.1' }), { status: 200 })
+    ) as unknown as typeof fetch;
+    expect(await fetchLatestNpmVersion()).toBeNull();
+
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ version: '1.5.0+build.7' }), { status: 200 })
+    ) as unknown as typeof fetch;
+    expect(await fetchLatestNpmVersion()).toBeNull();
+
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ version: 'latest' }), { status: 200 })
+    ) as unknown as typeof fetch;
+    expect(await fetchLatestNpmVersion()).toBeNull();
+
+    // Sanity: the canonical x.y.z is still accepted.
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ version: '1.4.99' }), { status: 200 })
+    ) as unknown as typeof fetch;
+    expect(await fetchLatestNpmVersion()).toBe('1.4.99');
+  });
+});
+
+// ─── Issue #34 — maybePrintUpgradeNag ─────────────────────────────────────
+
+describe('maybePrintUpgradeNag', () => {
+  let stderrBuf: string;
+  let origWrite: typeof process.stderr.write;
+  let tmpRoot: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    stderrBuf = '';
+    origWrite = process.stderr.write.bind(process.stderr);
+    (process.stderr.write as unknown) = ((chunk: string | Uint8Array) => {
+      stderrBuf += typeof chunk === 'string' ? chunk : chunk.toString();
+      return true;
+    }) as typeof process.stderr.write;
+    tmpRoot = mkdtempSync(join(tmpdir(), 'mysecond-nag-'));
+    savedEnv = process.env.MYSECOND_NO_UPGRADE_NAG;
+    delete process.env.MYSECOND_NO_UPGRADE_NAG;
+  });
+
+  afterEach(() => {
+    process.stderr.write = origWrite;
+    if (savedEnv === undefined) delete process.env.MYSECOND_NO_UPGRADE_NAG;
+    else process.env.MYSECOND_NO_UPGRADE_NAG = savedEnv;
+  });
+
+  it('emits nothing when lastKnownLatestNpmVersion is null', () => {
+    const s = nagState();
+    maybePrintUpgradeNag(s, tmpRoot);
+    expect(stderrBuf).toBe('');
+    expect(s.lastUpgradePromptAt).toBeNull();
+  });
+
+  it('emits nothing when running CLI matches the latest', () => {
+    // __VERSION__ at test time is package.json#version (vitest define).
+    const pkgVersion = JSON.parse(readFileSync('./package.json', 'utf-8')).version as string;
+    const s = nagState({ lastKnownLatestNpmVersion: pkgVersion });
+    maybePrintUpgradeNag(s, tmpRoot);
+    expect(stderrBuf).toBe('');
+    expect(s.lastUpgradePromptAt).toBeNull();
+  });
+
+  it('emits one stderr line when running CLI is behind', () => {
+    // 999.0.0 is unambiguously ahead of any real shipping version.
+    const s = nagState({ lastKnownLatestNpmVersion: '999.0.0' });
+    maybePrintUpgradeNag(s, tmpRoot);
+    expect(stderrBuf).toContain('mysecond: your CLI is');
+    expect(stderrBuf).toContain('(latest 999.0.0)');
+    expect(stderrBuf).toContain('`npx @mysecond/cli@latest init`');
+    expect(stderrBuf).toContain('MYSECOND_NO_UPGRADE_NAG=1');
+    expect(stderrBuf.endsWith('\n')).toBe(true);
+    // Exactly one line.
+    expect(stderrBuf.split('\n').filter((l) => l.length > 0)).toHaveLength(1);
+  });
+
+  it('stamps lastUpgradePromptAt and persists sync-state to disk', () => {
+    const s = nagState({ lastKnownLatestNpmVersion: '999.0.0' });
+    // Seed an existing sync-state file so writeSyncState reads/writes
+    // through projectPaths normally.
+    writeSyncState(tmpRoot, s);
+    maybePrintUpgradeNag(s, tmpRoot);
+    expect(s.lastUpgradePromptAt).not.toBeNull();
+    const persisted = readSyncState(tmpRoot);
+    expect(persisted.lastUpgradePromptAt).toBe(s.lastUpgradePromptAt);
+  });
+
+  it('honors MYSECOND_NO_UPGRADE_NAG=1', () => {
+    process.env.MYSECOND_NO_UPGRADE_NAG = '1';
+    const s = nagState({ lastKnownLatestNpmVersion: '999.0.0' });
+    maybePrintUpgradeNag(s, tmpRoot);
+    expect(stderrBuf).toBe('');
+    expect(s.lastUpgradePromptAt).toBeNull();
+  });
+
+  it('debounces within 24h (recent prompt = no re-emit)', () => {
+    const recent = new Date(Date.now() - 1000).toISOString();
+    const s = nagState({
+      lastKnownLatestNpmVersion: '999.0.0',
+      lastUpgradePromptAt: recent,
+    });
+    maybePrintUpgradeNag(s, tmpRoot);
+    expect(stderrBuf).toBe('');
+  });
+
+  it('re-emits after the 24h debounce expires', () => {
+    const old = new Date(Date.now() - TWENTY_FOUR_HOURS_MS - 1000).toISOString();
+    const s = nagState({
+      lastKnownLatestNpmVersion: '999.0.0',
+      lastUpgradePromptAt: old,
+    });
+    maybePrintUpgradeNag(s, tmpRoot);
+    expect(stderrBuf).toContain('mysecond: your CLI is');
+  });
+
+  it('treats an unparseable lastUpgradePromptAt as expired', () => {
+    const s = nagState({
+      lastKnownLatestNpmVersion: '999.0.0',
+      lastUpgradePromptAt: 'not-a-date',
+    });
+    maybePrintUpgradeNag(s, tmpRoot);
+    expect(stderrBuf).toContain('mysecond: your CLI is');
+  });
+
+  it('emits nothing when running CLI is AHEAD of cached latest (post-upgrade)', () => {
+    // A customer upgraded past the cached latest version (e.g., manually
+    // pinned to a newer tag). Treat as no-op.
+    const s = nagState({ lastKnownLatestNpmVersion: '0.0.1' });
+    maybePrintUpgradeNag(s, tmpRoot);
+    expect(stderrBuf).toBe('');
+  });
+
+  it('leaves in-memory state untouched when disk persist fails (no truth split)', () => {
+    // Codex review pass: if writeSyncState throws, the in-memory
+    // lastUpgradePromptAt must stay null so disk and memory agree. Without
+    // this, a downstream caller could re-read `state.lastUpgradePromptAt`
+    // and believe the prompt was stamped while disk says otherwise.
+    //
+    // Force the persist to fail by passing a rootDir whose parent is a
+    // file (not a directory) — `mkdirSync(dirname(path), recursive)`
+    // inside writeSyncState will throw ENOTDIR.
+    const blockedRoot = join(tmpRoot, 'blocked');
+    // Write a file at the .claude path so mkdir fails when sync-state
+    // tries to create .claude/sync-state.json inside it.
+    require('node:fs').writeFileSync(blockedRoot, 'not-a-directory');
+    const s = nagState({ lastKnownLatestNpmVersion: '999.0.0' });
+    maybePrintUpgradeNag(s, blockedRoot);
+    // The stderr line still fires (best-effort persistence shouldn't
+    // suppress the nag itself).
+    expect(stderrBuf).toContain('mysecond: your CLI is');
+    // But the in-memory stamp is NOT set, because disk failed.
+    expect(s.lastUpgradePromptAt).toBeNull();
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,18 @@
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'vitest/config';
 
+// esbuild injects `__VERSION__` at build time (esbuild.config.mjs). vitest
+// runs TS source directly with no esbuild step, so `__VERSION__` is
+// undefined inside tests without an explicit define. Use the same value
+// esbuild would inject — package.json#version — so any test that exercises
+// version-aware code paths (e.g., issue #34 upgrade nag) sees the real
+// shipping version.
+const pkgVersion = JSON.parse(readFileSync('./package.json', 'utf-8')).version as string;
+
 export default defineConfig({
+  define: {
+    __VERSION__: JSON.stringify(pkgVersion),
+  },
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts'],


### PR DESCRIPTION
Closes #34.

## What

When a customer's CLI version is behind the latest published `@mysecond/cli` on npm, `mysecond sync` (which runs on every Claude Code SessionStart via the customer plugin hook) now emits one stderr line:

```
mysecond: your CLI is 1.4.11 (latest 1.4.12). Run `npx @mysecond/cli@latest init` to update. Set MYSECOND_NO_UPGRADE_NAG=1 to silence.
```

Debounced to once per 24h per machine. Dismissable via env var. Stays silent for up-to-date CLIs.

## Why now

This replaces a per-feature workaround pattern. The latest example is [mysecond-app#221](https://github.com/mysecond-ai/mysecond-app/pull/221)'s `cli-upgrade-banner.tsx`, which paints a banner on `/customize/skills` when the active CLI is below `MIN_CLI_VERSION`. That works once per CLI-gated feature — every future gated feature would need its own banner. Fixing it at the CLI source means no feature ever needs that workaround again.

## Mechanism

| Component | Detail |
|---|---|
| Fetch | `https://registry.npmjs.org/@mysecond/cli/latest` via `fetch` + 1s `AbortSignal.timeout`. No subprocess, no auth (public scope). |
| Cadence | Existing `shouldRunNpmUpdate` 24h gate. Bounded to one call per machine per day. `--force-update` bypasses. |
| Validation | Registry response must match `x.y.z` before caching. Defends against a stray prerelease being pointed at `latest`. |
| Compare | `compareSemver` returns -1/0/1 on `x.y.z`, bail-safe 0 on anything else. |
| Nag | `maybePrintUpgradeNag` self-persists via its own `writeSyncState`. Persist-then-mutate ordering keeps disk and memory consistent on write failure. |
| Dismissal | `MYSECOND_NO_UPGRADE_NAG=1` |
| Debounce | 24h on `lastUpgradePromptAt` (independent of the registry-fetch gate). |

## Review pass

CTO + Codex review on the diff. All actionable findings folded in this PR. Highlights:

- **Validate semver before caching** (codex P1) — prevents poisoning the fleet's cache if registry ever points `latest` at a prerelease.
- **Persist-then-mutate in nag** (codex P1) — write failure no longer leaves in-memory `lastUpgradePromptAt` out of sync with disk.
- **Comment why we stamp `lastNpmUpdateAt` on fetch failure** — prevents registry hammering during multi-hour outages; auto-upgrade follow-up will split this into separate success/failure stamps.
- **Test-fixture completeness** + **fetch-timeout coverage** + **prerelease-rejection coverage** added.

Two CTO findings I explicitly disagreed with, rationale captured in code comments:

1. CTO P0 "stamp `lastNpmUpdateAt` only on fetch success." Defensible no — the alternative is hammering the npm registry on every SessionStart during a multi-hour outage. Worst case of the current behavior is a 24h retry delay, acceptable for a nag.
2. CTO P1 "route to stdout in silent mode." The plan explicitly chose stderr-always; no CAIO finding required stdout. Existing CLI warning lines (`[mysecond] ⚠️ …`) all use stderr and reach the customer in the SessionStart hook today.

## Tests

`tests/lib/npm.test.ts` — 32 total (6 existing + 26 new). Covers:

- `compareSemver`: equal / patch / minor / major / numeric-vs-lexicographic / malformed bail-safe.
- `fetchLatestNpmVersion`: 200, 404, 500, malformed JSON, missing-version field, network throw, **abort-on-timeout** (real `AbortSignal` round-trip), and **prerelease/build-metadata rejection at the boundary**.
- `maybePrintUpgradeNag`: no-latest-known, equal-version no-op, ahead-of-latest no-op, behind emits one line, env-var dismiss, 24h debounce, unparseable-timestamp expired, **disk persist round-trip**, **persist-failure leaves in-memory state untouched**.

## Verification

- ✅ `npm run typecheck` clean.
- ✅ `npm run build` clean (157.0kb bundle).
- ✅ 32 tests pass for `npm.test.ts`. Full suite: 32 of 33 test files reported ✓ before vitest hung on shutdown locally; CI will give clean output (same vitest-under-nohup quirk as PR #39).
- ✅ Diff is scoped: only `npm.ts`, `sync-state.ts`, `sync.ts`, `npm.test.ts`, `vitest.config.ts`, `README.md`.

## Out of scope (deferred)

- **`artifact-sync` nag wiring**. CTO P0 in plan review: that file has no clean top-level state read/write seam. SessionStart `sync` is the primary nag surface; duplicate signal on `artifact-sync` isn't worth the bracketing-reads cost.
- **Auto-upgrade** (opt-in `mysecond auto-upgrade on`, background detached install, install-path detection). ~80% of the plumbing here is reused as-is. Plan tracks what's net-new vs. carried-over — see `~/.claude/plans/ok-agreed-on-34-snoopy-thunder.md` "Foundation for auto-upgrade" section.

## Follow-up cleanup (in mysecond-app, NOT this PR)

After this ships as 1.4.12 and a majority of active customers are on ≥1.4.12 (~2-4 weeks):

- Delete `src/components/customize/cli-upgrade-banner.tsx`.
- Remove `CUSTOMS_V1_NAG_ENABLED`, `parseCliVersionFromUserAgent`, `CUSTOMS_V1_MIN_CLI_VERSION` in `src/app/customize/skills/page.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)