### PR TITLE
feat(sync): mysecond sync --push-all + credentials print (stranded-sync repair)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/credentials.ts
+++ b/src/commands/credentials.ts
@@ -1,0 +1,44 @@
+// `mysecond credentials print [--plaintext]` — the single credential resolver
+// that other surfaces (notably the base-plugin SessionStart sync hook) call so
+// there is ONE implementation of "where does this project's key live."
+//
+// Before this existed, the shell hook re-derived credential lookup itself and
+// only ever read `.env` — so when the CLI stored the key in the project-scoped
+// creds store (or the keychain), the hook silently found nothing and never
+// synced. Routing the hook through this command means the hook benefits from
+// the CLI's full resolution (keychain → project-scoped file → env, with legacy
+// rescue) without duplicating hash/path logic in bash.
+//
+// `ctx.apiKey` / `ctx.apiBase` are already fully resolved by buildContext, so
+// this command is a thin, read-only printer.
+//
+//   --plaintext  Emit env-style lines for a hook to source/parse:
+//                  COMPANION_API_KEY=<token>
+//                  COMPANION_API_URL=<url>
+//                Default (no flag) masks the token for safe-to-share output.
+
+import type { CommandContext } from '../lib/context.js';
+
+function mask(key: string): string {
+  if (key.length <= 12) return key;
+  return `${key.slice(0, 12)}…${key.slice(-4)}`;
+}
+
+export async function runCredentials(
+  args: readonly string[],
+  ctx: CommandContext
+): Promise<number> {
+  const plaintext = args.includes('--plaintext');
+
+  if (ctx.apiKey.length === 0) {
+    process.stderr.write(
+      'mysecond: no credential found for this project. Run `mysecond init --resume` to reconnect.\n'
+    );
+    return 1;
+  }
+
+  const token = plaintext ? ctx.apiKey : mask(ctx.apiKey);
+  process.stdout.write(`COMPANION_API_KEY=${token}\n`);
+  process.stdout.write(`COMPANION_API_URL=${ctx.apiBase}\n`);
+  return 0;
+}

--- a/src/commands/credentials.ts
+++ b/src/commands/credentials.ts
@@ -20,14 +20,38 @@
 import type { CommandContext } from '../lib/context.js';
 
 function mask(key: string): string {
-  if (key.length <= 12) return key;
-  return `${key.slice(0, 12)}…${key.slice(-4)}`;
+  // Never fully disclose, even for short test/dev tokens.
+  if (key.length <= 8) return '•'.repeat(key.length);
+  return `${key.slice(0, Math.min(12, key.length - 4))}…${key.slice(-4)}`;
+}
+
+/**
+ * POSIX single-quote escaping. `--plaintext` output is designed for a hook to
+ * `source`/`eval`, so values MUST be quoted — a token/URL containing shell
+ * metacharacters (`$(...)`, backticks, spaces, newlines) would otherwise
+ * execute or corrupt the sourced environment. Single quotes suppress ALL
+ * expansion; the only escape needed is the single quote itself.
+ */
+function shQuote(v: string): string {
+  return `'${v.replace(/'/g, "'\\''")}'`;
 }
 
 export async function runCredentials(
   args: readonly string[],
   ctx: CommandContext
 ): Promise<number> {
+  // Require the explicit `print` action when an action is given, so a typo'd
+  // subcommand (`mysecond credentials dump --plaintext`) can't accidentally
+  // dump the raw credential. Bare `mysecond credentials` (no action) stays
+  // valid and prints masked.
+  const action = args.find((a) => !a.startsWith('-'));
+  if (action !== undefined && action !== 'print') {
+    process.stderr.write(
+      `mysecond: unknown action '${action}'. Usage: mysecond credentials print [--plaintext]\n`
+    );
+    return 2;
+  }
+
   const plaintext = args.includes('--plaintext');
 
   if (ctx.apiKey.length === 0) {
@@ -37,8 +61,15 @@ export async function runCredentials(
     return 1;
   }
 
-  const token = plaintext ? ctx.apiKey : mask(ctx.apiKey);
-  process.stdout.write(`COMPANION_API_KEY=${token}\n`);
+  if (plaintext) {
+    // Quoted — safe to `source`/`eval`.
+    process.stdout.write(`COMPANION_API_KEY=${shQuote(ctx.apiKey)}\n`);
+    process.stdout.write(`COMPANION_API_URL=${shQuote(ctx.apiBase)}\n`);
+    return 0;
+  }
+
+  // Masked, human-readable (display only — never sourced).
+  process.stdout.write(`COMPANION_API_KEY=${mask(ctx.apiKey)}\n`);
   process.stdout.write(`COMPANION_API_URL=${ctx.apiBase}\n`);
   return 0;
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -602,15 +602,31 @@ async function runPushAll(ctx: CommandContext): Promise<number> {
         );
       }
     } else {
+      // accepted === synced + skipped; report both so a `synced:0, skipped:N`
+      // (everything already up to date) success doesn't read as "pushed 0".
+      const upToDate = res.skipped > 0 ? `, ${res.skipped} already up to date` : '';
       process.stdout.write(
-        `mysecond: pushed ${res.synced} context file(s) to mySecond.\n`
+        `mysecond: pushed ${res.synced} context file(s)${upToDate}.\n`
       );
     }
   }
 
   if (artifacts.length > 0) {
     const ares = await artifactsSync(ctx, artifacts);
-    process.stdout.write(`mysecond: pushed ${ares.synced} work artifact(s).\n`);
+    if (ares.synced > 0) {
+      process.stdout.write(`mysecond: pushed ${ares.synced} work artifact(s).\n`);
+    } else {
+      // ArtifactsResponse carries only { synced } — no errors[]/skipped — so we
+      // can't tell "already up to date" from "rejected". Don't hard-fail (that
+      // would false-fail on a re-run where artifacts are already synced), but
+      // don't claim success either: surface it neutrally. Context-file
+      // failures above remain the hard exit-1 gate (that's what strands users).
+      process.stderr.write(
+        `mysecond: 0 of ${artifacts.length} work artifact(s) were accepted — ` +
+          'they may already be up to date, or the push was rejected. ' +
+          'Run `mysecond doctor` if you expected them to sync.\n'
+      );
+    }
   }
 
   return failed ? 1 : 0;

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -551,12 +551,84 @@ export function readTeamIdFromCreds(rootDir: string): string | null {
   }
 }
 
+/**
+ * `mysecond sync --push-all` — the deterministic repair. Normal `sync` only
+ * pulls; the PostToolUse `artifact-sync` hook only fires on an editor write;
+ * and the SessionStart sweep silently no-ops when it can't find a credential.
+ * So a customer whose context never reached the server (empty `context_files`,
+ * "Install PM OS" screen despite being installed) has no in-product way to
+ * catch up. This scans local context/ + work outputs and pushes them UP using
+ * the resolved credential (admin-capable device token via buildContext).
+ *
+ * Crucially it SURFACES failure: `/api/companion/files` can return
+ * `200 {synced:0, errors:[...]}` (e.g. `cannot_create_protected_file_as_pm`
+ * when the credential resolved as a PM). We treat synced===0 / errors[] as a
+ * failure and print actionable guidance instead of a silent success.
+ */
+async function runPushAll(ctx: CommandContext): Promise<number> {
+  const contextFiles = scanContextFiles(ctx.rootDir);
+  const artifacts = scanArtifacts(ctx.rootDir);
+
+  if (contextFiles.length === 0 && artifacts.length === 0) {
+    process.stdout.write(
+      'mysecond: no local context/ or work output files found to push.\n' +
+        '  Run /welcome in Claude Code to create your context files first.\n'
+    );
+    return 0;
+  }
+
+  let failed = false;
+
+  if (contextFiles.length > 0) {
+    const res = await contextFilesPush(ctx, contextFiles);
+    const errors = res.errors ?? [];
+    const accepted = res.synced + res.skipped;
+    if (errors.length > 0 || accepted === 0) {
+      failed = true;
+      process.stderr.write(
+        `mysecond: sent ${contextFiles.length} context file(s); server accepted ${res.synced}.\n`
+      );
+      if (errors.length > 0) {
+        for (const e of errors.slice(0, 10)) process.stderr.write(`  - ${e}\n`);
+        if (errors.some((e) => e.includes('cannot_create_protected_file_as_pm'))) {
+          process.stderr.write(
+            '  Your credential resolved as a PM (no admin user), so protected context/ files\n' +
+              '  cannot be created. Re-authenticate with an admin device token: `mysecond init --resume`.\n'
+          );
+        }
+      } else {
+        process.stderr.write(
+          '  The server accepted nothing. Check `mysecond doctor` and that your credential is valid.\n'
+        );
+      }
+    } else {
+      process.stdout.write(
+        `mysecond: pushed ${res.synced} context file(s) to mySecond.\n`
+      );
+    }
+  }
+
+  if (artifacts.length > 0) {
+    const ares = await artifactsSync(ctx, artifacts);
+    process.stdout.write(`mysecond: pushed ${ares.synced} work artifact(s).\n`);
+  }
+
+  return failed ? 1 : 0;
+}
+
 export async function runSync(
   _args: readonly string[],
   ctx: CommandContext
 ): Promise<number> {
   if (ctx.apiKey.length === 0) {
     throw MysecondError.invalidApiKey('COMPANION_API_KEY not set');
+  }
+
+  // `--push-all`: explicit local→server catch-up, independent of the pull
+  // reconcile and the hook side effects. Return early — push-all is a
+  // standalone repair, not part of the normal pull flow.
+  if (ctx.pushAll) {
+    return runPushAll(ctx);
   }
 
   maybeNudgeCredsMigration(ctx);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { runInit } from './commands/init.js';
 import { runSync } from './commands/sync.js';
 import { runArtifactSync } from './commands/artifact-sync.js';
 import { runWhereami } from './commands/whereami.js';
+import { runCredentials } from './commands/credentials.js';
 import { runDoctor } from './commands/doctor.js';
 import { setSilentMode } from './lib/silent-status.js';
 import { buildContext, parseGlobalFlags, type CommandContext } from './lib/context.js';
@@ -39,6 +40,11 @@ const SUBCOMMANDS: readonly Subcommand[] = [
     run: runWhereami,
   },
   {
+    name: 'credentials',
+    summary: 'Print this project\'s resolved credential (masked; --plaintext for hooks to source).',
+    run: runCredentials,
+  },
+  {
     name: 'doctor',
     summary: 'Check install state + token health. Reports next-step command on any failure.',
     run: runDoctor,
@@ -64,6 +70,7 @@ function printHelp(): void {
     '  --project-dir <path>   Override $CLAUDE_PROJECT_DIR / cwd',
     '  --strategy <mode>      Conflict resolution: prompt | cloud-wins | local-wins | skip',
     '  --force-update         Bypass the 24-hour npm-update timebox in sync',
+    '  --push-all             Push all local context/ + work output files up to mySecond (`mysecond sync` only). Repairs an empty workspace.',
     '  --fix                  Resolve init conflicts interactively (`mysecond init` only)',
     '  --auth-only            Mint device code, persist state, exit (`mysecond init` only). Pairs with --resume.',
     '  --resume               Resume install from persisted auth state OR re-run device-code OAuth (`mysecond init` only)',

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -34,6 +34,13 @@ export interface CommandContext {
    * the auth code to the agent.
    */
   authOnly: boolean;
+  /**
+   * `mysecond sync --push-all`. Scans local context/ and work outputs and
+   * pushes them UP to mySecond (the deterministic repair when the SessionStart
+   * sweep / PostToolUse hook never landed files). Normal `sync` is pull-only;
+   * this is the explicit catch-up that doesn't depend on hook side effects.
+   */
+  pushAll: boolean;
 }
 
 export interface ParsedFlags {
@@ -45,6 +52,7 @@ export interface ParsedFlags {
   fix: boolean;
   resume: boolean;
   authOnly: boolean;
+  pushAll: boolean;
   strategy: ConflictStrategy | null;
   positional: string[];
 }
@@ -61,6 +69,7 @@ export function parseGlobalFlags(args: readonly string[]): ParsedFlags {
     fix: false,
     resume: false,
     authOnly: false,
+    pushAll: false,
     strategy: null,
     positional: [],
   };
@@ -79,6 +88,8 @@ export function parseGlobalFlags(args: readonly string[]): ParsedFlags {
       out.resume = true;
     } else if (arg === '--auth-only') {
       out.authOnly = true;
+    } else if (arg === '--push-all') {
+      out.pushAll = true;
     } else if (arg === '--api-key') {
       const next = args[i + 1];
       if (next === undefined) throw MysecondError.invalidFlag('--api-key', 'requires a value');
@@ -305,6 +316,7 @@ export function buildContext(flags: ParsedFlags): CommandContext {
     fix: flags.fix,
     resume: flags.resume,
     authOnly: flags.authOnly,
+    pushAll: flags.pushAll,
     strategy,
   };
 }

--- a/tests/commands/credentials.test.ts
+++ b/tests/commands/credentials.test.ts
@@ -57,11 +57,26 @@ describe('mysecond credentials print', () => {
     expect(out).not.toContain('msd_abcdefghijklmnopqrstuvwxyz');
   });
 
-  it('emits the plaintext token with --plaintext (for hooks to source)', async () => {
+  it('emits the plaintext token SHELL-QUOTED with --plaintext (safe to source)', async () => {
     const code = await runCredentials(['print', '--plaintext'], ctx());
     expect(code).toBe(0);
-    expect(out).toContain('COMPANION_API_KEY=msd_abcdefghijklmnopqrstuvwxyz');
-    expect(out).toContain('COMPANION_API_URL=https://app.mysecond.ai');
+    // Single-quoted so a value with shell metacharacters can't execute on source.
+    expect(out).toContain("COMPANION_API_KEY='msd_abcdefghijklmnopqrstuvwxyz'");
+    expect(out).toContain("COMPANION_API_URL='https://app.mysecond.ai'");
+  });
+
+  it('escapes a single quote in a value for safe sourcing', async () => {
+    const code = await runCredentials(['print', '--plaintext'], ctx({ apiKey: "ab'cd" }));
+    expect(code).toBe(0);
+    // POSIX: ' -> '\'' so the assignment stays a single safe token.
+    expect(out).toContain("COMPANION_API_KEY='ab'\\''cd'");
+  });
+
+  it("rejects an unknown action without printing the credential", async () => {
+    const code = await runCredentials(['dump', '--plaintext'], ctx());
+    expect(code).toBe(2);
+    expect(err).toContain("unknown action 'dump'");
+    expect(out).toBe('');
   });
 
   it('exits 1 with guidance when no credential is resolved', async () => {

--- a/tests/commands/credentials.test.ts
+++ b/tests/commands/credentials.test.ts
@@ -1,0 +1,73 @@
+// Tests for `mysecond credentials print` — the single credential resolver the
+// base-plugin sync hook calls. Pure: runCredentials reads ctx.apiKey/apiBase
+// (already resolved by buildContext) and prints, so no fetch/keychain mocking.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runCredentials } from '../../src/commands/credentials.js';
+import type { CommandContext } from '../../src/lib/context.js';
+
+function ctx(overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'msd_abcdefghijklmnopqrstuvwxyz',
+    rootDir: '/tmp/proj',
+    silent: true,
+    dryRun: false,
+    forceUpdate: false,
+    fix: false,
+    resume: false,
+    authOnly: false,
+    pushAll: false,
+    strategy: 'cloud-wins',
+    ...overrides,
+  };
+}
+
+describe('mysecond credentials print', () => {
+  let out: string;
+  let err: string;
+  let outSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    out = '';
+    err = '';
+    outSpy = vi.spyOn(process.stdout, 'write').mockImplementation((s: string | Uint8Array) => {
+      out += String(s);
+      return true;
+    });
+    errSpy = vi.spyOn(process.stderr, 'write').mockImplementation((s: string | Uint8Array) => {
+      err += String(s);
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    outSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('masks the token by default and prints the URL', async () => {
+    const code = await runCredentials([], ctx());
+    expect(code).toBe(0);
+    expect(out).toContain('COMPANION_API_KEY=msd_abcdefgh…wxyz');
+    expect(out).toContain('COMPANION_API_URL=https://app.mysecond.ai');
+    // never leak the full token in masked mode
+    expect(out).not.toContain('msd_abcdefghijklmnopqrstuvwxyz');
+  });
+
+  it('emits the plaintext token with --plaintext (for hooks to source)', async () => {
+    const code = await runCredentials(['print', '--plaintext'], ctx());
+    expect(code).toBe(0);
+    expect(out).toContain('COMPANION_API_KEY=msd_abcdefghijklmnopqrstuvwxyz');
+    expect(out).toContain('COMPANION_API_URL=https://app.mysecond.ai');
+  });
+
+  it('exits 1 with guidance when no credential is resolved', async () => {
+    const code = await runCredentials(['print', '--plaintext'], ctx({ apiKey: '' }));
+    expect(code).toBe(1);
+    expect(err).toContain('no credential found');
+    expect(out).toBe('');
+  });
+});

--- a/tests/commands/push-all.test.ts
+++ b/tests/commands/push-all.test.ts
@@ -1,0 +1,118 @@
+// Tests for `mysecond sync --push-all` (runSync's pushAll branch).
+//
+// Unlike the normal up-sync (which is hash-gated, runs only after a successful
+// pull, and swallows push failures), --push-all force-pushes ALL local context
+// files unconditionally and SURFACES failures. It must not call cli-sync (the
+// pull) at all — it returns early.
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runSync } from '../../src/commands/sync.js';
+import type { CommandContext } from '../../src/lib/context.js';
+
+function tmpProject(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mysecond-push-all-'));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  return root;
+}
+
+function ctx(rootDir: string, overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'test-key',
+    rootDir,
+    silent: true,
+    dryRun: false,
+    forceUpdate: false,
+    fix: false,
+    resume: false,
+    authOnly: false,
+    pushAll: true,
+    strategy: 'cloud-wins',
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('mysecond sync --push-all', () => {
+  let originalFetch: typeof fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('force-pushes all context files and returns 0 on success (no pull/cli-sync GET)', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'company-content');
+    writeFileSync(join(root, 'context/product.md'), 'product-content');
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ synced: 2, skipped: 0, errors: [] }));
+
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+
+    // Exactly one call — the /files POST. No cli-sync GET (push-all returns early).
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(call[0].pathname).toBe('/api/companion/files');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.files.map((f: { file_path: string }) => f.file_path).sort()).toEqual([
+      'context/company.md',
+      'context/product.md',
+    ]);
+  });
+
+  it('returns 1 and surfaces a protected-file rejection (200 with errors)', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'company-content');
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        synced: 0,
+        skipped: 0,
+        errors: ['cannot_create_protected_file_as_pm: context/company.md'],
+      }),
+    );
+
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(1);
+  })
+
+  it('returns 1 when the server accepts nothing (silent rejection / swallowed 4xx)', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'company-content');
+
+    // contextFilesPush swallows >=400 into { synced:0, skipped:0, errors:[] }.
+    fetchMock.mockResolvedValueOnce(new Response('forbidden', { status: 403 }));
+
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(1);
+  })
+
+  it('returns 0 and makes no push call when there is nothing to push', async () => {
+    const root = tmpProject();
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  })
+})

--- a/tests/commands/push-all.test.ts
+++ b/tests/commands/push-all.test.ts
@@ -115,4 +115,30 @@ describe('mysecond sync --push-all', () => {
     expect(code).toBe(0);
     expect(fetchMock).not.toHaveBeenCalled();
   })
+
+  it('does not claim success when 0 artifacts are accepted (no false "pushed")', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'work/specs/outputs'), { recursive: true });
+    writeFileSync(join(root, 'work/specs/outputs/prd.md'), 'a prd');
+
+    // artifacts POST returns synced:0 (already up to date OR rejected — the
+    // response can't tell). Must NOT print "pushed 0" as success.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ synced: 0 }));
+
+    const errs: string[] = [];
+    const errSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation((s: string | Uint8Array) => {
+        errs.push(String(s));
+        return true;
+      });
+
+    // No context files → not a hard failure; artifacts synced:0 → neutral note.
+    const code = await runSync([], ctx(root));
+    errSpy.mockRestore();
+
+    expect(code).toBe(0);
+    const errText = errs.join('');
+    expect(errText).toContain('0 of 1 work artifact');
+  })
 })


### PR DESCRIPTION
## Summary

The CLI half of the silently-stranded-sync fix (companion plan). Customers install + authenticate but their context never reaches the server, and there's no in-product way to force a catch-up. Two additions:

- **`mysecond sync --push-all`** — scans local `context/` + work outputs and force-pushes them up using the resolved admin-capable device token, independent of the pull reconcile. Unlike the normal up-sync (hash-gated, post-pull, **failure-swallowing**), this is unconditional and **surfaces failure**: `/api/companion/files` can return `200 {synced:0, errors:[...]}` (e.g. `cannot_create_protected_file_as_pm` when the credential resolves as a PM) — we exit non-zero with actionable guidance. This is Julian's/stranded customers' one-command repair.
- **`credentials print [--plaintext]`** — the single credential resolver other surfaces call (notably the base-plugin SessionStart sync hook in PMKit), so credential lookup has ONE implementation (keychain → project-scoped file → env, with legacy rescue) instead of being re-derived in bash. Masked by default; `--plaintext` for hooks to source.

## Files
New: `src/commands/credentials.ts`, `tests/commands/push-all.test.ts`, `tests/commands/credentials.test.ts`
Modified: `src/commands/sync.ts` (runPushAll + branch), `src/lib/context.ts` (--push-all flag), `src/index.ts` (register + help)

## Test plan
- [x] `npm run typecheck` + `npm run build` clean
- [x] push-all: force-push all, protected rejection → exit 1 + guidance, silent rejection (swallowed 4xx) → exit 1, nothing-to-push → exit 0
- [x] credentials: masked default, `--plaintext`, no-cred → exit 1
- [x] Full suite green (33 files, no regressions)

## Not in this PR (follow-up)
The `projectHash` realpath + **dual-read/migrate** (P3) — it's the security-sensitive keychain-migration piece and is *hygiene, not the unblock*. Will land separately with its own symlink/iCloud/zsh/legacy-creds regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)