### PR TITLE
fix(init): resolve claude binary so desktop-app installs complete (P0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.12",
+  "version": "1.4.14-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mysecond/cli",
-      "version": "1.4.12",
+      "version": "1.4.14-rc.0",
       "license": "UNLICENSED",
       "dependencies": {
         "proper-lockfile": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.14-rc.0",
+  "version": "1.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mysecond/cli",
-      "version": "1.4.14-rc.0",
+      "version": "1.4.14",
       "license": "UNLICENSED",
       "dependencies": {
         "proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.13",
+  "version": "1.4.14-rc.0",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.14-rc.0",
+  "version": "1.4.14",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/lib/claude-bin.ts
+++ b/src/lib/claude-bin.ts
@@ -1,0 +1,150 @@
+// Resolve the Claude Code `claude` CLI binary.
+//
+// Install + plugin registration shell out to `claude plugin …`. Bare-name PATH
+// lookup (`spawnSync('claude', …)`) fails on native desktop-app Claude installs:
+// `claude` is NOT on PATH there — its absolute path is exposed in the
+// `$CLAUDE_CODE_EXECPATH` env var (which Claude Code sets for child processes).
+// That ENOENT aborted `init` at step 9 and stranded desktop-app customers.
+//
+// This resolver removes the bare-name assumption. It NEVER throws — worst case
+// it returns bare 'claude' (today's behavior, ENOENT handled downstream).
+//
+// Resolution order (each candidate validated as executable with access(X_OK) —
+// existsSync is insufficient: a non-exec file would still spawn with EACCES):
+//   1. $CLAUDE_CODE_EXECPATH        — the desktop signal (set inside Claude Code)
+//   2. persisted last-seen path     — so a plain terminal (execpath unset) resolves
+//   3. PATH walk                    — npm-CLI installs ($PATH has claude)
+//   4. known native-install dirs    — desktop/native installs off PATH
+//   5. fallback 'claude'            — nothing validated; preserves prior behavior
+//
+// $CLAUDE_CODE_EXECPATH is version-pinned (e.g. .../claude-code/2.1.156/...), so
+// it dies on a Claude Code auto-update. We validate it; if it's set-but-missing
+// we fire the `onExecpathStale` canary (early warning of a CC release moving the
+// binary) and fall through.
+
+import { accessSync, constants } from 'node:fs';
+import { homedir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
+export type ClaudeBinSource =
+  | 'execpath'
+  | 'persisted'
+  | 'path'
+  | 'known-location'
+  | 'fallback';
+
+export interface ResolvedClaudeBin {
+  path: string;
+  source: ClaudeBinSource;
+}
+
+export interface ResolveClaudeBinOpts {
+  /** Last-seen working path persisted in sync-state (resolver step 2). */
+  persistedPath?: string | null;
+  /**
+   * Called when CLAUDE_CODE_EXECPATH is set but does NOT point at an executable
+   * — the canary for a Claude Code version bump that moved/removed the binary.
+   */
+  onExecpathStale?: (execpath: string) => void;
+}
+
+let cache: ResolvedClaudeBin | undefined;
+
+function isExecutable(p: string): boolean {
+  try {
+    accessSync(p, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// paste-detect.ts:62 gotcha — vitest caches os.homedir() and ignores per-test
+// $HOME overrides, so read process.env.HOME first for testability.
+function home(): string {
+  return process.env.HOME ?? homedir();
+}
+
+function pathCandidates(): string[] {
+  const raw = process.env.PATH;
+  if (raw === undefined || raw === '') return [];
+  const exts =
+    process.platform === 'win32'
+      ? (process.env.PATHEXT ?? '.EXE;.CMD;.BAT').split(';').filter((e) => e !== '')
+      : [''];
+  const out: string[] = [];
+  for (const dir of raw.split(delimiter)) {
+    if (dir === '') continue;
+    for (const ext of exts) {
+      out.push(join(dir, `claude${ext}`));
+    }
+  }
+  return out;
+}
+
+function knownLocations(): string[] {
+  const h = home();
+  if (process.platform === 'win32') {
+    const locs: string[] = [];
+    const local = process.env.LOCALAPPDATA;
+    if (local !== undefined && local !== '') {
+      locs.push(join(local, 'Programs', 'claude', 'claude.exe'));
+    }
+    locs.push(join(h, '.local', 'bin', 'claude.exe'));
+    return locs;
+  }
+  return [
+    join(h, '.claude', 'local', 'claude'),
+    '/usr/local/bin/claude',
+    '/opt/homebrew/bin/claude',
+    join(h, '.local', 'bin', 'claude'),
+  ];
+}
+
+/**
+ * Resolve the `claude` CLI path. Memoized per-process (one resolution per init
+ * run). Never throws.
+ */
+export function resolveClaudeBin(opts: ResolveClaudeBinOpts = {}): ResolvedClaudeBin {
+  if (cache !== undefined) return cache;
+
+  const execpath = process.env.CLAUDE_CODE_EXECPATH;
+  if (execpath !== undefined && execpath !== '') {
+    if (isExecutable(execpath)) {
+      cache = { path: execpath, source: 'execpath' };
+      return cache;
+    }
+    // Set but not executable → a CC version bump likely moved it. Canary + fall
+    // through so we still resolve via PATH / known locations.
+    opts.onExecpathStale?.(execpath);
+  }
+
+  const persisted = opts.persistedPath;
+  if (persisted !== undefined && persisted !== null && persisted !== '' && isExecutable(persisted)) {
+    cache = { path: persisted, source: 'persisted' };
+    return cache;
+  }
+
+  for (const cand of pathCandidates()) {
+    if (isExecutable(cand)) {
+      cache = { path: cand, source: 'path' };
+      return cache;
+    }
+  }
+
+  for (const cand of knownLocations()) {
+    if (isExecutable(cand)) {
+      cache = { path: cand, source: 'known-location' };
+      return cache;
+    }
+  }
+
+  cache = { path: 'claude', source: 'fallback' };
+  return cache;
+}
+
+export const __testing = {
+  reset(): void {
+    cache = undefined;
+  },
+};

--- a/src/lib/init-runner.ts
+++ b/src/lib/init-runner.ts
@@ -158,6 +158,27 @@ export async function runInit(ctx: CommandContext): Promise<number> {
         throw new MysecondError(1, `step ${entry.number} aborted: ${result.outcome.reason}`);
       }
 
+      // A `degraded` outcome means a step's REQUIRED part succeeded but a
+      // DEGRADABLE part failed (today: step 9 fetched/extracted the marketplace
+      // but couldn't register the plugin with Claude Code). Do NOT abort — the
+      // customer's context must still sync (step 11). Do NOT mark the step
+      // complete, so a re-run / re-open re-attempts the degradable part. The
+      // step itself already set the machine-readable shared flags
+      // (pluginRegistered=false + reason) for step-13 + install telemetry.
+      if (result.outcome.kind === 'degraded') {
+        if (!ctx.silent) {
+          process.stdout.write(
+            `step ${entry.number}/${STEPS.length}: ${entry.description} — partial; continuing so your context still syncs (${result.outcome.reason})\n`
+          );
+        }
+        void emitTelemetry(ctx, 'mysecond.init.step_degraded', {
+          customer_id: state.customerId ?? 'unknown',
+          step_number: entry.number,
+          reason: result.outcome.reason,
+        });
+        continue;
+      }
+
       // Only persist ledger if NOT dry-run. Dry-run runs read-only steps fully
       // (Node version check, install-ready poll, plugin-load probe) but never
       // advances the ledger so the synthetic doesn't pollute the customer's
@@ -186,6 +207,15 @@ export async function runInit(ctx: CommandContext): Promise<number> {
       // top-of-funnel metric for every two-command run.
       void emitTelemetry(ctx, 'mysecond.install.completed', {
         slug: sctx.shared.customerId ?? telemetrySlug,
+        // Honest signal: reaching here means the install finished and step 11
+        // ran (context synced), but plugin_registered may be false if step 9
+        // degraded. Consumers (Desktop watcher / app) MUST read these booleans
+        // and not treat install.completed alone as "skills are ready".
+        context_synced: true,
+        plugin_registered: sctx.shared.pluginRegistered ?? true,
+        ...(sctx.shared.pluginRegistered === false
+          ? { registration_degraded_reason: sctx.shared.registrationDegradedReason ?? 'unknown' }
+          : {}),
       });
     }
 

--- a/src/lib/prune-stale-plugins.ts
+++ b/src/lib/prune-stale-plugins.ts
@@ -63,6 +63,7 @@ import { join } from 'node:path';
 
 import lockfile from 'proper-lockfile';
 
+import { resolveClaudeBin } from './claude-bin.js';
 import { marketplaceName, validateSlug } from './mysecond-paths.js';
 
 /**
@@ -290,7 +291,7 @@ export async function pruneStalePlugins(
   slug: string,
   opts: { claudeBin?: string; silent?: boolean } = {},
 ): Promise<PruneResult> {
-  const claudeBin = opts.claudeBin ?? 'claude';
+  const claudeBin = opts.claudeBin ?? resolveClaudeBin().path;
 
   // planStalePluginPrune validates the slug + applies the allowlist + token
   // guard. An invalid slug / corrupt ledger / no matches all yield an empty

--- a/src/lib/steps/step-13.ts
+++ b/src/lib/steps/step-13.ts
@@ -23,32 +23,49 @@ export const step13: StepFn = async ({ ctx, shared }) => {
   const pmName = shared.pmName ?? 'you';
   const companyName = shared.companyName ?? 'your company';
 
+  // Did the plugin actually REGISTER with Claude Code? Step 9 sets this false
+  // when its degradable registration phase failed (binary unresolvable, timeout,
+  // non-zero exit). countPluginContents() reads the EXTRACTED tarball — and
+  // extraction is NOT registration, so on a degraded install those counts would
+  // claim skills that aren't actually loadable. Gate everything on registration.
+  const registered = shared.pluginRegistered ?? true;
+
   // Count installed skills/agents/workflows from the extracted plugin tree as
-  // proof the install populated content. Best-effort: if the slug is missing
-  // or the extract dir is unreadable, counts default to all-zero and the
-  // success copy degrades to a generic "PM skill library" phrase.
-  if (shared.pluginCounts === undefined && shared.customerSlug !== undefined) {
+  // proof the install populated content. Only meaningful when registered.
+  if (registered && shared.pluginCounts === undefined && shared.customerSlug !== undefined) {
     shared.pluginCounts = countPluginContents(pluginExtractDir(shared.customerSlug));
   }
 
   if (!ctx.silent) {
-    process.stdout.write('\n' + successBox(pmName, companyName, shared.pluginCounts, shared.isInvitedPm ?? false) + '\n\n');
+    if (registered) {
+      process.stdout.write('\n' + successBox(pmName, companyName, shared.pluginCounts, shared.isInvitedPm ?? false) + '\n\n');
+    } else {
+      // Degraded: be honest. Context synced, skills did not finish installing.
+      process.stdout.write(
+        `\nYour context for ${companyName} synced successfully — but the PM OS skills didn't finish installing in this session.\n` +
+          `To finish loading them, re-open Claude Code (or re-run the install command). Your data is safe and already synced.\n\n`,
+      );
+    }
   }
 
-  // Emit install_completed JSON status event (Item 5B). Calls
-  // emitInstallCompleted (not emitStatus) so this event always reaches stdout
-  // regardless of --silent mode — it is the deterministic "done" signal the
-  // Claude Code Desktop chat assistant needs to stop its watcher loop.
-  // The '\n\n' above (after successBox) is what separates the success box from
-  // this JSON line — emitInstallCompleted does not add leading whitespace.
-  // shared.userEmail is populated by step-15 from /whoami; falls back to
-  // "you" if /whoami had a network error or didn't return an email field.
+  // Emit install_completed JSON status event (Item 5B). Always reaches stdout
+  // (even --silent) — the deterministic "done" signal the Claude Code Desktop
+  // chat watcher needs to stop its loop. We keep kind='install_completed' so an
+  // existing watcher still stops, but carry plugin_registered/context_synced so
+  // it (and the web app) can distinguish a full install from a degraded one and
+  // never claim skills are ready when they aren't. skills counts are zeroed when
+  // registration degraded (extraction != registration).
   emitInstallCompleted({
     kind: 'install_completed',
-    message: installCompleteClaudeMessage(shared.userEmail ?? 'you'),
-    skills_installed: shared.pluginCounts?.skills ?? 0,
-    agents_installed: shared.pluginCounts?.agents ?? 0,
-    workflows_installed: shared.pluginCounts?.workflows ?? 0,
+    message: registered
+      ? installCompleteClaudeMessage(shared.userEmail ?? 'you')
+      : `Context synced for ${shared.userEmail ?? 'you'}, but the PM OS skills didn't finish installing — re-open Claude Code (or re-run the install) to finish.`,
+    context_synced: true,
+    plugin_registered: registered,
+    skills_installed: registered ? (shared.pluginCounts?.skills ?? 0) : 0,
+    agents_installed: registered ? (shared.pluginCounts?.agents ?? 0) : 0,
+    workflows_installed: registered ? (shared.pluginCounts?.workflows ?? 0) : 0,
+    ...(registered ? {} : { registration_degraded_reason: shared.registrationDegradedReason ?? 'unknown' }),
   });
 
   return { step: 13, outcome: { kind: 'completed' } };

--- a/src/lib/steps/step-9.ts
+++ b/src/lib/steps/step-9.ts
@@ -20,6 +20,7 @@ import { join } from 'node:path';
 
 import { emitTelemetry, pluginTarball } from '../api.js';
 import { atomicRenameDir } from '../atomic-write.js';
+import { resolveClaudeBin } from '../claude-bin.js';
 import { staleCacheBanner } from '../copy.js';
 import { MysecondError } from '../errors.js';
 import {
@@ -50,6 +51,23 @@ import { writeSyncState } from '../sync-state.js';
 import type { StepFn } from './types.js';
 
 const AUTH_THRASH_THRESHOLD = 3;
+
+// Shared wall-clock budget for the (degradable) plugin-registration phase —
+// `claude plugin marketplace remove/add` + `plugin install`. A short single
+// budget (vs a long per-spawn timeout) means a wedged `claude` degrades fast
+// instead of freezing the install. Registration is non-fatal: on timeout the
+// install continues so context still syncs (step 11).
+const REGISTER_BUDGET_MS = 30_000;
+
+// spawnSync sets signal 'SIGTERM' (status: null) when it kills a process that
+// exceeded its `timeout`; some platforms surface ETIMEDOUT on result.error.
+function isSpawnTimeout(r: ReturnType<typeof spawnSync>): boolean {
+  return (
+    r.signal === 'SIGTERM' ||
+    r.signal === 'SIGKILL' ||
+    (r.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT'
+  );
+}
 
 export const step9: StepFn = async ({ ctx, state, shared }) => {
   const rawSlug = shared.customerSlug ?? state.customerSlug;
@@ -95,6 +113,29 @@ async function doStep9(
   // the install time is actually consumed here. Emitted as step_9_total_timed
   // at step end (silent mode) and logged to stderr (interactive mode).
   const step9StartMs = performance.now();
+
+  // Resolve the `claude` CLI explicitly. Bare 'claude' isn't on PATH for
+  // native desktop-app installs (it lives at $CLAUDE_CODE_EXECPATH) — the root
+  // cause of desktop-install stranding. resolveClaudeBin never throws; worst
+  // case it returns bare 'claude' (ENOENT still handled below).
+  const claudeBin = resolveClaudeBin({
+    persistedPath: state.lastClaudeBinPath,
+    onExecpathStale: (execpath) => {
+      // Canary: $CLAUDE_CODE_EXECPATH set but not executable → a Claude Code
+      // version bump likely moved the binary. Early warning for ops.
+      void emitTelemetry(ctx, 'mysecond.init.claude_execpath_stale', {
+        customer_id: state.customerId ?? 'unknown',
+        execpath,
+      });
+    },
+  }).path;
+
+  // Happy-path default. Flipped to false only if the degradable registration
+  // phase (9b) fails — see the try/catch around it below. step-13 and the
+  // install telemetry read this so they never claim skills are installed when
+  // registration didn't actually complete.
+  shared.pluginRegistered = true;
+
   // Sub-step (a): fetch signed URL.
   let meta;
   try {
@@ -112,13 +153,15 @@ async function doStep9(
     // re-prompt). subscription_cancelled / plugin_revoked also bypass cache
     // (the customer shouldn't keep running cached content).
     if (err instanceof MysecondError && err.subCode === 'network') {
-      const fallback = tryFallback(slug, state);
+      const fallback = tryFallback(slug, state, claudeBin, Date.now() + REGISTER_BUDGET_MS);
       if (fallback !== null) {
         shared.staleCacheUsed = { cachedAgeHours: fallback.cachedAgeHours };
         shared.pluginVersion = fallback.version;
         // RED-TEAM P0-1: reset counter on ANY successful step 9 completion,
         // including LKG fallback. Without this, customer hits 2 transient 401s,
         // both served from cache, then 1 more 401 → exit 8 forever.
+        // LKG fallback registered the plugin via claudeBin — remember it.
+        state.lastClaudeBinPath = claudeBin;
         state.step9Auth401RetryCount = 0;
         writeSyncState(ctx.rootDir, state);
         // RED-TEAM R2 P1-D: telemetry for ops visibility into LKG usage.
@@ -160,11 +203,13 @@ async function doStep9(
       if (attempt >= 2) {
         // Second mismatch / fetch error → cleanup + try fallback or exit 6.
         rmSync(tmpMarketplaceDir, { recursive: true, force: true });
-        const fallback = tryFallback(slug, state);
+        const fallback = tryFallback(slug, state, claudeBin, Date.now() + REGISTER_BUDGET_MS);
         if (fallback !== null && err instanceof MysecondError && err.subCode === 'network') {
           shared.staleCacheUsed = { cachedAgeHours: fallback.cachedAgeHours };
           shared.pluginVersion = fallback.version;
           // RED-TEAM P0-1: reset counter on LKG fallback success (see above).
+          // LKG fallback registered the plugin via claudeBin — remember it.
+          state.lastClaudeBinPath = claudeBin;
           state.step9Auth401RetryCount = 0;
           writeSyncState(ctx.rootDir, state);
           // RED-TEAM R2 P1-D: telemetry for SHA-mismatch fallback path.
@@ -226,6 +271,37 @@ async function doStep9(
   // atomicRenameDir handles non-empty destination cross-platform via rm+rename.
   atomicRenameDir(tmpMarketplaceDir, marketplaceDir(slug));
 
+  // Fetch + extract + marketplace materialization all succeeded. Clear the
+  // fetch-401 thrash counter NOW — it tracks consecutive signed-URL 401s, and a
+  // successful fetch means we're not thrashing on auth, regardless of how the
+  // (degradable) registration below turns out. Without this, a prior transient
+  // 401 could linger across runs that succeed-fetch-but-degrade-registration.
+  state.step9Auth401RetryCount = 0;
+  writeSyncState(ctx.rootDir, state);
+
+  // === 9b: register the plugin with Claude Code (DEGRADABLE) ===
+  // Everything below shells out to `claude plugin …`. If it fails (ENOENT,
+  // timeout, non-zero), we do NOT abort the install — we return a `degraded`
+  // outcome so the runner continues to step 11 (first sync) and the customer's
+  // context still lands. step-13 reports the degraded state honestly.
+  const registerDeadline = Date.now() + REGISTER_BUDGET_MS;
+  // Hard shared budget. Returns ms remaining; once the deadline passes it
+  // THROWS (→ caught below → degraded) instead of handing out a fresh slice, so
+  // the registration phase can't exceed REGISTER_BUDGET_MS across all spawns.
+  const registerTimeout = (): number => {
+    const remaining = registerDeadline - Date.now();
+    if (remaining <= 0) {
+      throw new MysecondError(
+        6,
+        'Registering the PM OS plugin with Claude Code timed out. Your context still synced — re-open Claude Code (or re-run the install) to finish loading the skills.'
+      );
+    }
+    return remaining;
+  };
+  // Declared BEFORE the try so the post-registration timing emit (outside the
+  // try) can read it.
+  const failedPlugins: string[] = [];
+  try {
   // RED-TEAM R2 P0-D: stale-state recovery. If the customer previously ran
   // init successfully and then `rm -rf ~/.mysecond` (manual cleanup, disk
   // sweep, syncthing flap), Claude Code's user-settings still has the
@@ -235,37 +311,48 @@ async function doStep9(
   // Idempotency pattern: remove first (best-effort, swallow non-zero), then
   // add. Covers both first-install (remove is no-op) and stale-pointer cases.
   spawnSync(
-    'claude',
+    claudeBin,
     ['plugin', 'marketplace', 'remove', marketplaceName(slug), '--scope', 'user'],
-    { stdio: 'pipe' }
+    { stdio: 'pipe', timeout: registerTimeout() }
   );
 
   // Sub-step (f): claude plugin marketplace add + claude plugin install.
   // Both verified non-interactive on Ron's Mac 2026-04-22 (DV-1).
   const addResult = spawnSync(
-    'claude',
+    claudeBin,
     ['plugin', 'marketplace', 'add', marketplaceDir(slug), '--scope', 'user'],
-    { stdio: ctx.silent ? 'pipe' : 'inherit' }
+    { stdio: ctx.silent ? 'pipe' : 'inherit', timeout: registerTimeout() }
   );
   // RED-TEAM R2 P1-A: ENOENT detection. spawnSync returns status:null +
-  // error.code='ENOENT' when the binary isn't on PATH (nvm + fish, login vs
-  // non-login shell, custom PATH ordering). Without this check, we'd report
-  // "exit null" which is meaningless to a customer and routes the failure
-  // through the LKG fallback path (which also can't find claude).
+  // error.code='ENOENT' when the binary isn't found. With the resolver this is
+  // now rare (it validates candidates), but the fallback path returns bare
+  // 'claude', so keep the check. This throw is now DEGRADABLE (caught below):
+  // the install continues and context still syncs.
   if (addResult.error !== undefined && (addResult.error as NodeJS.ErrnoException).code === 'ENOENT') {
     throw new MysecondError(
       6,
-      "Cannot find 'claude' binary on PATH. Make sure Claude Code is installed and `which claude` resolves in this terminal. If you use nvm + a non-bash shell, try: `npm install -g @mysecond/cli` from the same shell where `which claude` works."
+      "Couldn't run the Claude Code CLI to register the PM OS plugin (binary not found). Your context still synced — re-open Claude Code (or re-run the install) to finish loading the skills."
+    );
+  }
+  // Timeout detection — spawnSync sets signal:'SIGTERM' (status:null) on a
+  // timeout kill, so this MUST come before the status!==0 check below.
+  if (isSpawnTimeout(addResult)) {
+    throw new MysecondError(
+      6,
+      'Registering the PM OS plugin with Claude Code timed out. Your context still synced — re-open Claude Code (or re-run the install) to finish loading the skills.'
     );
   }
   if (addResult.status !== 0) {
     // Try last-known-good fallback if marketplace add fails (e.g., Claude Code
-    // version mismatch or transient marketplace state).
-    const fallback = tryFallback(slug, state);
+    // version mismatch or transient marketplace state). Shares the registration
+    // deadline so the fallback can't exceed the hard budget.
+    const fallback = tryFallback(slug, state, claudeBin, registerDeadline);
     if (fallback !== null) {
       shared.staleCacheUsed = { cachedAgeHours: fallback.cachedAgeHours };
       shared.pluginVersion = fallback.version;
       // RED-TEAM P0-1: reset counter on LKG fallback success.
+      // LKG fallback registered the plugin via claudeBin — remember it.
+      state.lastClaudeBinPath = claudeBin;
       state.step9Auth401RetryCount = 0;
       writeSyncState(ctx.rootDir, state);
       // RED-TEAM R2 P1-D: telemetry for marketplace-add-failure fallback path.
@@ -292,7 +379,6 @@ async function doStep9(
   // multi-plugin future. Tracks failures; hard-fails on the sentinel
   // (`pm-os` itself) since that's the entire install — non-sentinel
   // failures degrade gracefully.
-  const failedPlugins: string[] = [];
   for (let pluginIdx = 0; pluginIdx < plugins.length; pluginIdx++) {
     // plugins[] is bounded by the loop condition; the non-null assertion is safe.
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -302,9 +388,9 @@ async function doStep9(
     // which plugin(s) are slow before deciding whether to parallelize.
     const pluginStartMs = performance.now();
     const installResult = spawnSync(
-      'claude',
+      claudeBin,
       ['plugin', 'install', spec, '--scope', 'user'],
-      { stdio: ctx.silent ? 'pipe' : 'inherit' }
+      { stdio: ctx.silent ? 'pipe' : 'inherit', timeout: registerTimeout() }
     );
     const pluginDurationMs = Math.round(performance.now() - pluginStartMs);
 
@@ -328,12 +414,18 @@ async function doStep9(
       );
     }
 
-    // ENOENT on the binary is fatal regardless of which plugin in the loop
-    // hit it — PATH issue affects every plugin install.
+    // ENOENT / timeout on the binary affects every plugin install. Now
+    // DEGRADABLE (caught below): the install continues and context still syncs.
     if (installResult.error !== undefined && (installResult.error as NodeJS.ErrnoException).code === 'ENOENT') {
       throw new MysecondError(
         6,
-        "Cannot find 'claude' binary on PATH (between marketplace add + plugin install). Re-run `mysecond init` from the same shell where `which claude` works."
+        "Couldn't run the Claude Code CLI to install the PM OS plugin (binary not found). Your context still synced — re-open Claude Code (or re-run the install) to finish loading the skills."
+      );
+    }
+    if (isSpawnTimeout(installResult)) {
+      throw new MysecondError(
+        6,
+        'Installing the PM OS plugin into Claude Code timed out. Your context still synced — re-open Claude Code (or re-run the install) to finish loading the skills.'
       );
     }
     if (installResult.status !== 0) {
@@ -362,6 +454,30 @@ async function doStep9(
   if (failedPlugins.length > 0) {
     shared.failedPlugins = failedPlugins;
   }
+  } catch (err) {
+    // 9b (registration: marketplace remove/add + plugin install) failed —
+    // DEGRADABLE. The marketplace was already materialized, so returning
+    // `degraded` lets the runner continue to step 11 (first sync): the
+    // customer's context still lands and step-13 / install telemetry report
+    // honestly that skills didn't finish. NOT ledgered (runner skips
+    // markStepComplete on `degraded`), so a re-run / re-open re-attempts it.
+    // SCOPED to ONLY the spawn region above — the post-registration bookkeeping
+    // below (prune, probe, cache, persist) runs OUTSIDE this try, so a hiccup
+    // there can never mislabel a SUCCESSFUL registration as degraded.
+    const reason = err instanceof Error ? err.message : String(err);
+    shared.pluginRegistered = false;
+    shared.registrationDegradedReason = reason;
+    void emitTelemetry(ctx, 'mysecond.init.plugin_registration_degraded', {
+      customer_id: state.customerId ?? 'unknown',
+      reason,
+    });
+    if (!ctx.silent) {
+      process.stderr.write(`[mysecond] ${reason}\n`);
+    }
+    return { step: 9, outcome: { kind: 'degraded', reason } };
+  }
+
+  // === Registration succeeded — post-registration bookkeeping (NOT degradable) ===
 
   // Make the install REPLACING, not additive (Finding #2 — "duplicate skills").
   // During the 2026-05-04→05 multi-category experiment, customers were
@@ -414,7 +530,10 @@ async function doStep9(
   // Cache the validated extracted tree as last-known-good.
   cacheLastKnownGood(slug, meta.version, meta.sha256, join(marketplaceDir(slug), 'plugin'));
 
-  // Reset auth-thrash counter on success (CTO-v1.3-B3 critical).
+  // Registration succeeded. Remember the working `claude` path so a later
+  // plain-terminal context (where $CLAUDE_CODE_EXECPATH is unset) can still
+  // resolve the binary. Counter was already cleared post-fetch; keep it 0.
+  state.lastClaudeBinPath = claudeBin;
   state.step9Auth401RetryCount = 0;
   writeSyncState(ctx.rootDir, state);
 
@@ -444,10 +563,19 @@ async function doStep9(
 // surface this to the customer.
 function tryFallback(
   slug: string,
-  _state: import('../sync-state.js').SyncState
+  _state: import('../sync-state.js').SyncState,
+  claudeBin: string,
+  // Shared spawn deadline (epoch ms). The fallback's claude spawns draw from
+  // the SAME budget as the main registration path — without this, a fallback
+  // after an add-failure could spend a fresh full budget per spawn and blow the
+  // hard ceiling on a wedged binary.
+  deadline: number,
 ): { version: string; cachedAgeHours: number } | null {
   const hit = findLastKnownGood(slug);
   if (hit === null) return null;
+  // Budget already exhausted (e.g. the main add spawn timed out) → don't start
+  // more spawns; treat as a fallback miss.
+  if (deadline - Date.now() <= 0) return null;
 
   // Rehydrate: copy cached version into marketplace dir (so claude plugin
   // marketplace add works against it). This is a synchronous best-effort
@@ -483,19 +611,20 @@ function tryFallback(
     // Run marketplace add against the rehydrated dir (best-effort — if Claude
     // Code is also down or admin-restricted, this fails and we surface error).
     const result = spawnSync(
-      'claude',
+      claudeBin,
       ['plugin', 'marketplace', 'add', marketplaceTarget, '--scope', 'user'],
-      { stdio: 'pipe' }
+      { stdio: 'pipe', timeout: Math.max(1, deadline - Date.now()) }
     );
     if (result.status !== 0) return null;
 
     // Install loop over the LKG plugins. Same sentinel-fail-hard semantics
     // as the main path: `pm-os` MUST install for fallback to count.
     for (const plugin of plugins) {
+      if (deadline - Date.now() <= 0) return null; // budget exhausted mid-loop
       const installResult = spawnSync(
-        'claude',
+        claudeBin,
         ['plugin', 'install', pluginInstallSpec(slug, plugin.name), '--scope', 'user'],
-        { stdio: 'pipe' }
+        { stdio: 'pipe', timeout: Math.max(1, deadline - Date.now()) }
       );
       if (installResult.status !== 0 && plugin.name === SENTINEL_PLUGIN_NAME) {
         return null;

--- a/src/lib/steps/types.ts
+++ b/src/lib/steps/types.ts
@@ -36,6 +36,14 @@ export interface StepContext {
     // Step 9 populates these from /plugin-tarball + extraction.
     pluginVersion?: string;
     pluginSha256?: string;
+    // Step 9 registration outcome. The marketplace fetch/extract is fatal, but
+    // registering the plugin with Claude Code (`claude plugin …`) is degradable:
+    // if it fails, the install continues so context still syncs (step 11), and
+    // step 13 / install telemetry report the degraded state honestly instead of
+    // claiming skills are installed. `pluginRegistered` defaults to true on the
+    // happy path; set false + `registrationDegradedReason` when 9b degrades.
+    pluginRegistered?: boolean;
+    registrationDegradedReason?: string;
     // Workstream B Day 5+: sub-plugin install loop (multi-plugin PMO
     // marketplace) tracks any non-sentinel plugins whose `claude plugin
     // install` exited non-zero. Sentinel (pm-os) failure is
@@ -60,6 +68,7 @@ export interface StepContext {
 export type StepOutcome =
   | { kind: 'completed' }                                       // step ran (or was already complete)
   | { kind: 'skipped'; reason: string }                          // intentionally skipped (--dry-run)
+  | { kind: 'degraded'; reason: string }                         // step's required part ran, but a degradable part failed: do NOT ledger it (so it re-runs), but continue the install (don't abort)
   | { kind: 'aborted'; reason: string };                         // step decided to halt the whole init w/o throwing
 
 export interface StepResult {

--- a/src/lib/sync-state.ts
+++ b/src/lib/sync-state.ts
@@ -55,6 +55,12 @@ export interface SyncState {
   // the same upgrade line.
   lastKnownLatestNpmVersion: string | null;
   lastUpgradePromptAt: string | null;
+  // Last-seen working `claude` CLI path (resolveClaudeBin persists it on a
+  // successful spawn). Lets a plain-terminal context — where
+  // $CLAUDE_CODE_EXECPATH is unset (e.g. the `plugin-install` remediation) —
+  // still resolve the binary instead of falling through to PATH lookups that
+  // fail on desktop-app installs.
+  lastClaudeBinPath: string | null;
 }
 
 function freshEmptyState(): SyncState {
@@ -71,6 +77,7 @@ function freshEmptyState(): SyncState {
     customerSlug: null,
     lastKnownLatestNpmVersion: null,
     lastUpgradePromptAt: null,
+    lastClaudeBinPath: null,
   };
 }
 

--- a/tests/lib/claude-bin.test.ts
+++ b/tests/lib/claude-bin.test.ts
@@ -1,0 +1,131 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveClaudeBin, __testing } from '../../src/lib/claude-bin.js';
+
+// Env keys the resolver reads. Save + clear so the CC bash sandbox (which sets
+// CLAUDE_CODE_EXECPATH / PATH) can't contaminate these tests.
+const ENV_KEYS = ['CLAUDE_CODE_EXECPATH', 'PATH', 'PATHEXT', 'HOME', 'LOCALAPPDATA'];
+
+let workDir: string;
+let saved: Record<string, string | undefined> = {};
+
+function makeExecutable(dir: string, name = 'claude'): string {
+  const p = join(dir, name);
+  writeFileSync(p, '#!/bin/sh\necho ok\n');
+  chmodSync(p, 0o755);
+  return p;
+}
+
+function makeNonExecutable(dir: string, name = 'claude'): string {
+  const p = join(dir, name);
+  writeFileSync(p, 'not executable\n');
+  chmodSync(p, 0o644);
+  return p;
+}
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'mysecond-claudebin-'));
+  saved = {};
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  // Point HOME at an empty dir so known-location probing can't accidentally hit
+  // a real ~/.claude/local/claude on the dev machine.
+  process.env.HOME = mkdtempSync(join(tmpdir(), 'mysecond-home-'));
+  __testing.reset();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] !== undefined) process.env[k] = saved[k];
+    else delete process.env[k];
+  }
+  rmSync(workDir, { recursive: true, force: true });
+  __testing.reset();
+});
+
+describe('resolveClaudeBin', () => {
+  it('prefers CLAUDE_CODE_EXECPATH when it points at an executable', () => {
+    const exec = makeExecutable(workDir);
+    process.env.CLAUDE_CODE_EXECPATH = exec;
+    const r = resolveClaudeBin();
+    expect(r).toEqual({ path: exec, source: 'execpath' });
+  });
+
+  it('falls through and fires onExecpathStale when execpath is set but missing', () => {
+    process.env.CLAUDE_CODE_EXECPATH = join(workDir, 'gone', 'claude'); // does not exist
+    const onExecpathStale = vi.fn();
+    // PATH has a working claude so we have somewhere to fall through to.
+    const pathDir = mkdtempSync(join(tmpdir(), 'mysecond-path-'));
+    makeExecutable(pathDir);
+    process.env.PATH = pathDir;
+
+    const r = resolveClaudeBin({ onExecpathStale });
+    expect(r.source).toBe('path');
+    expect(onExecpathStale).toHaveBeenCalledOnce();
+    rmSync(pathDir, { recursive: true, force: true });
+  });
+
+  it('does NOT shadow a working PATH claude when execpath is non-executable (regression)', () => {
+    // execpath set but NOT executable (EACCES). A naive existsSync check would
+    // pick it and then spawn would EACCES — the resolver must fall through to
+    // the working PATH binary so today's npm-CLI customers keep working.
+    process.env.CLAUDE_CODE_EXECPATH = makeNonExecutable(workDir);
+    const pathDir = mkdtempSync(join(tmpdir(), 'mysecond-path-'));
+    const pathClaude = makeExecutable(pathDir);
+    process.env.PATH = pathDir;
+
+    const r = resolveClaudeBin();
+    expect(r).toEqual({ path: pathClaude, source: 'path' });
+    rmSync(pathDir, { recursive: true, force: true });
+  });
+
+  it('uses the persisted candidate when execpath is unset (plain-terminal case)', () => {
+    const persisted = makeExecutable(workDir);
+    // No execpath (plain terminal). Persisted path resolves before PATH.
+    const r = resolveClaudeBin({ persistedPath: persisted });
+    expect(r).toEqual({ path: persisted, source: 'persisted' });
+  });
+
+  it('ignores a stale persisted candidate that is no longer executable', () => {
+    const persisted = makeNonExecutable(workDir);
+    const pathDir = mkdtempSync(join(tmpdir(), 'mysecond-path-'));
+    const pathClaude = makeExecutable(pathDir);
+    process.env.PATH = pathDir;
+    const r = resolveClaudeBin({ persistedPath: persisted });
+    expect(r).toEqual({ path: pathClaude, source: 'path' });
+    rmSync(pathDir, { recursive: true, force: true });
+  });
+
+  it('walks PATH (multiple dirs) and picks the first executable claude', () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), 'mysecond-empty-'));
+    const pathDir = mkdtempSync(join(tmpdir(), 'mysecond-path-'));
+    const pathClaude = makeExecutable(pathDir);
+    process.env.PATH = [emptyDir, pathDir].join(delimiter);
+    const r = resolveClaudeBin();
+    expect(r).toEqual({ path: pathClaude, source: 'path' });
+    rmSync(emptyDir, { recursive: true, force: true });
+    rmSync(pathDir, { recursive: true, force: true });
+  });
+
+  it('resolves a known native-install location (~/.claude/local/claude)', () => {
+    // No execpath, no persisted, nothing on PATH → known locations.
+    const localDir = join(process.env.HOME as string, '.claude', 'local');
+    mkdirSync(localDir, { recursive: true });
+    const known = makeExecutable(localDir);
+    process.env.PATH = mkdtempSync(join(tmpdir(), 'mysecond-empty-')); // no claude here
+    const r = resolveClaudeBin();
+    expect(r).toEqual({ path: known, source: 'known-location' });
+  });
+
+  it('falls back to bare claude when nothing resolves (never throws)', () => {
+    process.env.PATH = mkdtempSync(join(tmpdir(), 'mysecond-empty-')); // no claude anywhere
+    const r = resolveClaudeBin();
+    expect(r).toEqual({ path: 'claude', source: 'fallback' });
+  });
+});

--- a/tests/lib/init-runner-degraded.test.ts
+++ b/tests/lib/init-runner-degraded.test.ts
@@ -1,0 +1,114 @@
+// Runner-level regression lock for the desktop-install fix (plan Part 7).
+//
+// The single most important behavior this fix introduces: when step 9
+// (plugin registration) returns a `degraded` outcome, the runner must NOT
+// abort — it continues to the first-sync step so the customer's context still
+// syncs, it does NOT ledger the degraded step (so a re-run re-attempts it), and
+// the install still exits 0 while honestly flagging plugin_registered:false.
+//
+// We drive the REAL runInit with a stubbed STEPS list (a degradable step + a
+// later sync step) against a real temp sync-state, so the ledger + control flow
+// are exercised for real, not asserted by source-reading.
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const ranSync = { value: false };
+  const degradedStep = vi.fn(async (sctx: { shared: Record<string, unknown> }) => {
+    // Mimic real step 9 on a registration failure.
+    sctx.shared.pluginRegistered = false;
+    sctx.shared.registrationDegradedReason = 'test: claude not found';
+    return { step: 9, outcome: { kind: 'degraded', reason: 'test: claude not found' } };
+  });
+  const syncStep = vi.fn(async () => {
+    ranSync.value = true;
+    return { step: 11, outcome: { kind: 'completed' } };
+  });
+  const emitTelemetry = vi.fn();
+  return { ranSync, degradedStep, syncStep, emitTelemetry };
+});
+
+vi.mock('../../src/lib/steps/index.js', () => ({
+  STEPS: [
+    { number: 9, fn: h.degradedStep, mutates: true, description: 'register plugin (degradable)' },
+    { number: 11, fn: h.syncStep, mutates: true, description: 'first sync' },
+  ],
+}));
+vi.mock('../../src/lib/api.js', () => ({ emitTelemetry: h.emitTelemetry }));
+// Always-in-Claude-Code so the wrong-window gate passes deterministically.
+vi.mock('../../src/lib/paste-detect.js', () => ({
+  isInClaudeCodeContext: () => true,
+  WRONG_WINDOW_COPY: '',
+}));
+
+import { runInit } from '../../src/lib/init-runner.js';
+import { readSyncState } from '../../src/lib/sync-state.js';
+import type { CommandContext } from '../../src/lib/context.js';
+
+let rootDir: string;
+
+function makeCtx(): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'msd_test',
+    rootDir,
+    silent: true,
+    dryRun: false,
+    forceUpdate: false,
+    fix: false,
+    resume: false,
+    authOnly: false,
+    pushAll: false,
+    strategy: 'cloud-wins',
+  } as unknown as CommandContext;
+}
+
+beforeEach(() => {
+  rootDir = mkdtempSync(join(tmpdir(), 'mysecond-runner-'));
+  h.ranSync.value = false;
+  h.degradedStep.mockClear();
+  h.syncStep.mockClear();
+  h.emitTelemetry.mockClear();
+});
+
+afterEach(() => {
+  rmSync(rootDir, { recursive: true, force: true });
+});
+
+describe('init-runner: degraded step does not strand the customer', () => {
+  it('continues to the first sync, exits 0, and does not ledger the degraded step', async () => {
+    const exit = await runInit(makeCtx());
+
+    // Install must NOT abort on a degraded registration.
+    expect(exit).toBe(0);
+    // The first-sync step MUST run after the degraded step.
+    expect(h.syncStep).toHaveBeenCalledOnce();
+    expect(h.ranSync.value).toBe(true);
+
+    // Ledger: degraded step 9 NOT marked complete (re-runs next time); the
+    // completed sync step 11 IS marked complete.
+    const state = readSyncState(rootDir);
+    expect(state.initCompletedSteps).not.toContain(9);
+    expect(state.initCompletedSteps).toContain(11);
+  });
+
+  it('emits honest telemetry (step_degraded + completion carrying plugin_registered:false)', async () => {
+    await runInit(makeCtx());
+
+    const events = h.emitTelemetry.mock.calls.map((c) => ({ name: c[1], props: c[2] }));
+
+    const degraded = events.find((e) => e.name === 'mysecond.init.step_degraded');
+    expect(degraded).toBeTruthy();
+    expect(degraded?.props.step_number).toBe(9);
+
+    const completed = events.find((e) => e.name === 'mysecond.install.completed');
+    expect(completed).toBeTruthy();
+    expect(completed?.props.context_synced).toBe(true);
+    expect(completed?.props.plugin_registered).toBe(false);
+    expect(completed?.props.registration_degraded_reason).toBeTruthy();
+  });
+});

--- a/tests/lib/red-team-r2-regression.test.ts
+++ b/tests/lib/red-team-r2-regression.test.ts
@@ -149,9 +149,13 @@ describe('RED-TEAM R2 P1-A: spawnSync ENOENT produces actionable error', () => {
     expect(enoentChecks.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('ENOENT error message mentions PATH + claude binary', () => {
-    expect(stepSrc).toMatch(/Cannot find 'claude' binary/);
-    expect(stepSrc).toMatch(/PATH/);
+  it('ENOENT error message is actionable (binary issue + recovery)', () => {
+    // Registration is now DEGRADABLE: the ENOENT copy no longer tells the user
+    // to fix PATH / `which claude` (pointless on a desktop-app install where
+    // claude isn't on PATH at all). It states the binary couldn't run and gives
+    // a concrete recovery — re-open Claude Code / re-run the install.
+    expect(stepSrc).toMatch(/binary not found/);
+    expect(stepSrc).toMatch(/re-open Claude Code/);
   });
 });
 

--- a/tests/lib/step-13.test.ts
+++ b/tests/lib/step-13.test.ts
@@ -15,6 +15,8 @@ function makeContext(opts: {
   userEmail?: string;
   pmName?: string;
   companyName?: string;
+  pluginRegistered?: boolean;
+  registrationDegradedReason?: string;
 }): StepContext {
   const ctx: CommandContext = {
     apiBase: 'https://app.mysecond.ai',
@@ -35,6 +37,8 @@ function makeContext(opts: {
       companyName: opts.companyName,
       userEmail: opts.userEmail,
       pluginCounts: { skills: 91, agents: 6, workflows: 4 },
+      pluginRegistered: opts.pluginRegistered,
+      registrationDegradedReason: opts.registrationDegradedReason,
     },
   };
 }
@@ -153,5 +157,54 @@ describe('step-13: install_completed JSON status event', () => {
     const result = await step13(sctx);
     expect(result.outcome.kind).toBe('completed');
     expect(result.step).toBe(13);
+  });
+
+  it('does NOT claim skills when registration degraded (honest status)', async () => {
+    setSilentMode(true);
+    const sctx = makeContext({
+      silent: true,
+      userEmail: 'ron@mysecond.ai',
+      pmName: 'Ron',
+      companyName: 'mySecond',
+      pluginRegistered: false,
+      registrationDegradedReason: 'claude marketplace add timed out',
+    });
+    await step13(sctx);
+
+    const events = stdoutWrites
+      .filter((s) => s.trim().startsWith('{'))
+      .map((line) => JSON.parse(line.trim()));
+    const completed = events.find((e: { kind?: string }) => e.kind === 'install_completed');
+
+    expect(completed).toBeTruthy();
+    // Watcher still gets a stop signal, but honestly flagged.
+    expect(completed.plugin_registered).toBe(false);
+    expect(completed.context_synced).toBe(true);
+    expect(completed.registration_degraded_reason).toBe('claude marketplace add timed out');
+    // Extraction != registration — counts must be zero even though pluginCounts
+    // (from the extracted tarball) is populated in shared.
+    expect(completed.skills_installed).toBe(0);
+    expect(completed.agents_installed).toBe(0);
+    expect(completed.workflows_installed).toBe(0);
+    expect(completed.message).toContain("didn't finish installing");
+  });
+
+  it('degraded interactive output explains the partial install (no success box)', async () => {
+    setSilentMode(false);
+    const sctx = makeContext({
+      silent: false,
+      userEmail: 'ron@mysecond.ai',
+      pmName: 'Ron',
+      companyName: 'mySecond',
+      pluginRegistered: false,
+      registrationDegradedReason: 'binary not found',
+    });
+    await step13(sctx);
+
+    const allOutput = stdoutWrites.join('');
+    expect(allOutput).toContain("didn't finish installing");
+    expect(allOutput).toContain('re-open Claude Code');
+    // The normal success box must NOT render on a degraded install.
+    expect(allOutput).not.toContain('mySecond PM OS installed');
   });
 });

--- a/tests/lib/step-timing.test.ts
+++ b/tests/lib/step-timing.test.ts
@@ -87,7 +87,7 @@ describe('Fix C Step 1 — step-9 structural timing assertions', () => {
     // The emitStatus call must come before the ENOENT check so we capture
     // timing data even when the install fails.
     const emojiPos = source.indexOf("kind: 'plugin_install_timed'");
-    const enoentPos = source.indexOf("Cannot find 'claude' binary on PATH (between marketplace add");
+    const enoentPos = source.indexOf("Couldn't run the Claude Code CLI to install the PM OS plugin");
     expect(emojiPos).toBeGreaterThan(0);
     expect(enoentPos).toBeGreaterThan(0);
     expect(emojiPos).toBeLessThan(enoentPos);


### PR DESCRIPTION
## Summary
- **P0:** customers who install Claude Code as the **native desktop app** can't finish `npx @mysecond/cli init`. Step 9 shells out to a bare `claude`, which isn't on PATH for desktop installs (its path is in `$CLAUDE_CODE_EXECPATH`). `spawnSync` ENOENTs → step 9 throws → the runner aborts the whole install **before the first sync (step 11)** → the customer never syncs and the app shows "Install PM OS" forever.
- **Fix:** resolve the `claude` binary explicitly (new `src/lib/claude-bin.ts`), make plugin registration **non-fatal** so the first sync always runs, report status **honestly** so a degraded install never claims skills are installed, and bound the registration spawns with a hard timeout.

## Customer impact
- **Before:** a (non-technical) PM installs the Claude Code desktop app, pastes the install command, it dies at step 9, and Work>Files shows "Install PM OS" forever. They're stuck with no path forward.
- **After:** install completes on desktop → `/welcome` runs → context files and skill outputs sync to the app. If registration ever *can't* complete, the customer is still **synced** (not stranded) and told exactly how to finish ("re-open Claude Code / re-run the install").

## What changed
- **`claude-bin.ts` (new):** `resolveClaudeBin()` — `$CLAUDE_CODE_EXECPATH` → persisted last-seen → PATH walk → known native locations → fallback, each validated executable via `access(X_OK)`; never throws. Routed every `claude` spawn (step-9 + prune) through it. Canary telemetry when execpath is set-but-stale (CC version-bump early warning).
- **step-9:** registration (`marketplace add` + `plugin install`) is now a `degraded` step outcome on failure (binary unresolvable / timeout / non-zero). Fetch/extract stay fatal. Hard 30s shared budget across the spawns (incl. LKG fallback). Auth-thrash counter cleared after a successful fetch. Persists the working `claude` path.
- **init-runner:** handles the `degraded` outcome — continues to step 11 (sync) without ledgering step 9 (so it re-runs), and `install.completed` telemetry carries `context_synced` / `plugin_registered`.
- **step-13:** zeroes skill counts + sets `plugin_registered:false` when degraded (extraction != registration); degraded success-box copy.

## Reviews
- **Codex** (REJECT → all must-fixes applied): scoped the degraded `try/catch` to the spawns only (it was mislabeling post-success write failures as degraded — a lie), made the 30s budget actually hard, fallback shares the deadline, persist the binary on LKG-success paths.
- **PMKit CTO persona** (APPROVE-WITH-CHANGES, no blocking): verified the degraded flow reaches step 11, auth-counter isolation, honest status, resolver safety, no regression for npm-CLI installs. Its agreed should-fix — a runner-level degraded test — is included (`init-runner-degraded.test.ts`).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run build` passes
- [x] new + affected unit tests green: resolver, runner-degraded (degraded step 9 → step 11 still runs → not ledgered → exit 0 → honest telemetry), honest status, timing, red-team
- [ ] **V1 (the real Definition of Done):** `npx @mysecond/cli@<tag> init` on a fresh desktop-app Mac → `/welcome` → context + skill outputs appear in the app. Run before promoting to `@latest`.

## Follow-ups (not in this PR)
- Version bump + publish (gated on V1 + owner go).
- Realtime output sync: PostToolUse hook still runs bare `mysecond` (no npx fallback) — same binary-on-PATH family, outputs sync per-session via the SessionStart npx fallback today. P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)