### PR TITLE
CLI 1.5.0: realtime push + plugin-refresh for npx-only installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.4.14",
+  "version": "1.5.0",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/artifact-sync.ts
+++ b/src/commands/artifact-sync.ts
@@ -19,7 +19,7 @@ import {
   type ArtifactPayload,
   type ContextFilePayload,
 } from '../lib/payload.js';
-import { readSyncState, writeSyncState } from '../lib/sync-state.js';
+import { updateSyncState } from '../lib/sync-state.js';
 
 interface ToolEvent {
   tool_name?: string;
@@ -116,9 +116,12 @@ export async function runArtifactSync(
       // record it so SessionStart can de-dupe). Pure-error response leaves
       // state untouched so the next SessionStart up-loop retries.
       if (result.synced > 0 || result.skipped > 0) {
-        const state = readSyncState(ctx.rootDir);
-        state.contextFiles[relativePath] = { hash, pushedAt: new Date().toISOString() };
-        writeSyncState(ctx.rootDir, state);
+        // Locked read-modify-write: this PostToolUse write can race the Stop
+        // `sync --push-only` sweep; updateSyncState serializes + re-reads so
+        // neither writer clobbers the other's hashes.
+        await updateSyncState(ctx.rootDir, (state) => {
+          state.contextFiles[relativePath] = { hash, pushedAt: new Date().toISOString() };
+        });
       }
     } catch (err) {
       // Honor server-side halt header: if the server flipped the rollback-pause

--- a/src/commands/plugin-refresh.ts
+++ b/src/commands/plugin-refresh.ts
@@ -139,8 +139,11 @@ export async function runPluginRefresh(
     // rename then failed. Move the old dir aside, move the new one in, drop the
     // old — and restore the old if the rename fails. The marketplace dir is
     // never left missing. All paths share a parent, so renameSync is atomic.
+    // Fixed `.bak` name (not pid-suffixed): the marketplace lock serializes
+    // refreshes so there's no collision, and the leading rmSync clears any stale
+    // backup a previously-crashed swap left behind (a pid suffix would orphan).
     const finalDir = marketplaceDir(slug);
-    const backupDir = `${finalDir}.bak-${process.pid}`;
+    const backupDir = `${finalDir}.bak`;
     const hadExisting = existsSync(finalDir);
     rmSync(backupDir, { recursive: true, force: true });
     if (hadExisting) renameSync(finalDir, backupDir);
@@ -182,10 +185,17 @@ export async function runPluginRefresh(
     // Record the version ACTUALLY installed FIRST (the durable, important
     // persist), THEN cache last-known-good best-effort — a cache write failure
     // must not make a successful refresh exit non-zero or lose the version.
-    await updateSyncState(ctx.rootDir, (s) => {
-      s.installedPluginVersion = meta.version;
-      s.lastClaudeBinPath = claudeBin;
-    });
+    // retries: 10 — this is the one durable, important write (it gates whether a
+    // future refresh needlessly re-installs). plugin-refresh is rare + not a hot
+    // path, so it waits out contention rather than fast-skipping like the hooks.
+    await updateSyncState(
+      ctx.rootDir,
+      (s) => {
+        s.installedPluginVersion = meta.version;
+        s.lastClaudeBinPath = claudeBin;
+      },
+      { retries: 10 }
+    );
     try {
       cacheLastKnownGood(slug, meta.version, meta.sha256, join(finalDir, 'plugin'));
     } catch {

--- a/src/commands/plugin-refresh.ts
+++ b/src/commands/plugin-refresh.ts
@@ -15,11 +15,10 @@
 // The only durable change on success is re-installing the latest plugin and
 // recording installedPluginVersion.
 
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { pluginTarball } from '../lib/api.js';
-import { atomicRenameDir } from '../lib/atomic-write.js';
 import { resolveClaudeBin } from '../lib/claude-bin.js';
 import type { CommandContext } from '../lib/context.js';
 import { cacheLastKnownGood } from '../lib/last-known-good.js';
@@ -35,7 +34,6 @@ import {
   marketplaceTmpJsonPath,
   pluginTmpExtractDir,
   validateSlug,
-  type PluginEntry,
 } from '../lib/mysecond-paths.js';
 import { registerMarketplaceAndInstall } from '../lib/plugin-register.js';
 import { fetchAndExtractPlugin } from '../lib/plugin-tarball.js';
@@ -101,39 +99,58 @@ export async function runPluginRefresh(
 
   const claudeBin = resolveClaudeBin({ persistedPath: state.lastClaudeBinPath }).path;
 
-  // Serialize against init / other refreshes — this mutates the shared
-  // marketplace dir.
-  const lock = await acquireMarketplaceLock();
+  // Serialize against init / other refreshes (this mutates the shared
+  // marketplace dir). acquireMarketplaceLock THROWS on contention/FS error, so
+  // guard it — the command must stay best-effort / exit 0. If another mysecond
+  // process holds the lock, skip; a later run retries.
+  let lock: { release: () => Promise<void> };
   try {
-    // Materialize the latest tarball into the marketplace dir (mirror step-9
-    // sub-steps b–e). Single attempt: on ANY failure we restore nothing and
-    // leave the existing install in place (no LKG fallback — unlike first
-    // install, a failed refresh isn't stranding; the old plugin still works).
+    lock = await acquireMarketplaceLock();
+  } catch {
+    if (!ctx.silent) {
+      process.stderr.write(
+        'mysecond: another mysecond process is busy; skipping plugin refresh (will retry later).\n'
+      );
+    }
+    return 0;
+  }
+
+  const tmpMarketplaceDir = marketplaceTmpDir(slug);
+  try {
+    // Materialize the latest tarball (mirror step-9 sub-steps b–e). No LKG
+    // fallback — unlike first install, a failed refresh isn't stranding: the
+    // already-installed plugin keeps working, so on ANY failure (outer catch)
+    // we leave it untouched and exit 0.
     const tmpExtractDir = pluginTmpExtractDir(slug);
-    const tmpMarketplaceDir = marketplaceTmpDir(slug);
     const tmpTarballPath = join(tmpMarketplaceDir, 'plugin.tgz');
     rmSync(tmpMarketplaceDir, { recursive: true, force: true });
     mkdirSync(tmpExtractDir, { recursive: true });
 
-    let plugins: PluginEntry[];
+    await fetchAndExtractPlugin(ctx, meta, tmpTarballPath, tmpExtractDir);
+    const plugins = listMarketplacePluginsFromExtractDir(tmpExtractDir);
+    mkdirSync(join(tmpMarketplaceDir, '.claude-plugin'), { recursive: true });
+    writeFileSync(
+      marketplaceTmpJsonPath(slug),
+      serializeMarketplaceJson(buildMarketplaceJson(slug, plugins))
+    );
+
+    // Safe swap — NOT atomicRenameDir, which rm's the destination BEFORE the
+    // rename and would destroy the customer's working marketplace source if the
+    // rename then failed. Move the old dir aside, move the new one in, drop the
+    // old — and restore the old if the rename fails. The marketplace dir is
+    // never left missing. All paths share a parent, so renameSync is atomic.
+    const finalDir = marketplaceDir(slug);
+    const backupDir = `${finalDir}.bak-${process.pid}`;
+    const hadExisting = existsSync(finalDir);
+    rmSync(backupDir, { recursive: true, force: true });
+    if (hadExisting) renameSync(finalDir, backupDir);
     try {
-      await fetchAndExtractPlugin(ctx, meta, tmpTarballPath, tmpExtractDir);
-      plugins = listMarketplacePluginsFromExtractDir(tmpExtractDir);
-      mkdirSync(join(tmpMarketplaceDir, '.claude-plugin'), { recursive: true });
-      writeFileSync(
-        marketplaceTmpJsonPath(slug),
-        serializeMarketplaceJson(buildMarketplaceJson(slug, plugins))
-      );
-      atomicRenameDir(tmpMarketplaceDir, marketplaceDir(slug));
-    } catch (err) {
-      rmSync(tmpMarketplaceDir, { recursive: true, force: true });
-      if (!ctx.silent) {
-        process.stderr.write(
-          `mysecond: couldn't download the latest plugin (${err instanceof Error ? err.message : String(err)}). Your current install is unchanged.\n`
-        );
-      }
-      return 0;
+      renameSync(tmpMarketplaceDir, finalDir);
+    } catch (renameErr) {
+      if (hadExisting) renameSync(backupDir, finalDir);
+      throw renameErr;
     }
+    if (hadExisting) rmSync(backupDir, { recursive: true, force: true });
 
     // Re-register with Claude Code via the shared mechanics helper.
     const result = registerMarketplaceAndInstall({
@@ -145,8 +162,9 @@ export async function runPluginRefresh(
     });
 
     if (result.outcome.kind !== 'registered') {
-      // Degraded: the previously-installed plugin is still present + working.
-      // Do NOT advance installedPluginVersion, so a later run retries.
+      // Degraded: the marketplace dir now holds the new tree but Claude Code
+      // didn't (re)install it. The previously-installed cached plugin still
+      // works. Do NOT advance installedPluginVersion, so a later run retries.
       if (!ctx.silent) {
         const why =
           result.outcome.kind === 'binary_not_found'
@@ -161,13 +179,18 @@ export async function runPluginRefresh(
       return 0;
     }
 
-    // Success — cache as last-known-good + record the version ACTUALLY installed
-    // (the latest we just fetched + registered), under the locked writer.
-    cacheLastKnownGood(slug, meta.version, meta.sha256, join(marketplaceDir(slug), 'plugin'));
+    // Record the version ACTUALLY installed FIRST (the durable, important
+    // persist), THEN cache last-known-good best-effort — a cache write failure
+    // must not make a successful refresh exit non-zero or lose the version.
     await updateSyncState(ctx.rootDir, (s) => {
       s.installedPluginVersion = meta.version;
       s.lastClaudeBinPath = claudeBin;
     });
+    try {
+      cacheLastKnownGood(slug, meta.version, meta.sha256, join(finalDir, 'plugin'));
+    } catch {
+      // best-effort cache; the refresh already succeeded + recorded the version.
+    }
 
     if (!ctx.silent) {
       process.stdout.write(
@@ -176,7 +199,17 @@ export async function runPluginRefresh(
       );
     }
     return 0;
+  } catch (err) {
+    // Any unexpected failure (download, swap, register, persist) — clean up tmp,
+    // leave the working install in place, exit 0. Refresh is best-effort.
+    rmSync(tmpMarketplaceDir, { recursive: true, force: true });
+    if (!ctx.silent) {
+      process.stderr.write(
+        `mysecond: plugin refresh didn't complete (${err instanceof Error ? err.message : String(err)}). Your current install is unchanged.\n`
+      );
+    }
+    return 0;
   } finally {
-    await lock.release();
+    await lock.release().catch(() => {});
   }
 }

--- a/src/commands/plugin-refresh.ts
+++ b/src/commands/plugin-refresh.ts
@@ -1,0 +1,182 @@
+// `mysecond plugin-refresh` — re-install the latest published plugin version so
+// an ALREADY-installed customer picks up new hooks / skills. Claude Code caches
+// the installed plugin and does NOT auto-update a local-directory marketplace,
+// and `mysecond sync` never re-installs the plugin — so a hook change shipped
+// via regen reaches existing installs only when something re-fetches + re-runs
+// `claude plugin install`. That "something" is this command.
+//
+// Run once per existing customer after a hook/plugin change ships. New installs
+// always pull the latest plugin at `init`, so they never need this. Currently
+// MANUAL / support-invoked — NOT auto-wired into the SessionStart hook (that
+// self-healing pipeline is the deferred "Option C").
+//
+// Best-effort + non-fatal: on ANY failure (no auth, network down, Claude Code
+// unavailable) it leaves the currently-installed plugin untouched and exits 0.
+// The only durable change on success is re-installing the latest plugin and
+// recording installedPluginVersion.
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { pluginTarball } from '../lib/api.js';
+import { atomicRenameDir } from '../lib/atomic-write.js';
+import { resolveClaudeBin } from '../lib/claude-bin.js';
+import type { CommandContext } from '../lib/context.js';
+import { cacheLastKnownGood } from '../lib/last-known-good.js';
+import {
+  buildMarketplaceJson,
+  serializeMarketplaceJson,
+} from '../lib/marketplace-json.js';
+import { acquireMarketplaceLock } from '../lib/marketplace-lock.js';
+import {
+  listMarketplacePluginsFromExtractDir,
+  marketplaceDir,
+  marketplaceTmpDir,
+  marketplaceTmpJsonPath,
+  pluginTmpExtractDir,
+  validateSlug,
+  type PluginEntry,
+} from '../lib/mysecond-paths.js';
+import { registerMarketplaceAndInstall } from '../lib/plugin-register.js';
+import { fetchAndExtractPlugin } from '../lib/plugin-tarball.js';
+import { readSyncState, updateSyncState } from '../lib/sync-state.js';
+
+// Single shared wall-clock budget for the registration spawns — mirror step-9's
+// REGISTER_BUDGET_MS so a wedged `claude` degrades fast instead of freezing.
+const REFRESH_BUDGET_MS = 30_000;
+
+export async function runPluginRefresh(
+  _args: readonly string[],
+  ctx: CommandContext
+): Promise<number> {
+  if (ctx.apiKey.length === 0) {
+    if (!ctx.silent) {
+      process.stderr.write('mysecond: not authenticated — run `mysecond init` first.\n');
+    }
+    return 0;
+  }
+
+  const state = readSyncState(ctx.rootDir);
+  const rawSlug = state.customerSlug;
+  if (rawSlug === null || rawSlug === undefined || rawSlug === '') {
+    if (!ctx.silent) {
+      process.stderr.write('mysecond: no install found to refresh — run `mysecond init` first.\n');
+    }
+    return 0;
+  }
+  let slug: string;
+  try {
+    slug = validateSlug(rawSlug);
+  } catch {
+    return 0; // corrupt slug in sync-state — nothing safe to do
+  }
+
+  // What version is available? Any error here (network/auth/revoked) leaves the
+  // working install in place — we just try again next time.
+  let meta: Awaited<ReturnType<typeof pluginTarball>>;
+  try {
+    meta = await pluginTarball(ctx, slug);
+  } catch (err) {
+    if (!ctx.silent) {
+      process.stderr.write(
+        `mysecond: couldn't check for a plugin update (${err instanceof Error ? err.message : String(err)}). Your current install is unchanged.\n`
+      );
+    }
+    return 0;
+  }
+
+  // Already current? `installedPluginVersion === null` means a pre-feature
+  // install whose materialized version we don't know — refresh once to
+  // self-heal. `--force-update` always re-installs.
+  if (
+    !ctx.forceUpdate &&
+    state.installedPluginVersion !== null &&
+    state.installedPluginVersion === meta.version
+  ) {
+    if (!ctx.silent) {
+      process.stdout.write(`mysecond: plugin already up to date (${meta.version}).\n`);
+    }
+    return 0;
+  }
+
+  const claudeBin = resolveClaudeBin({ persistedPath: state.lastClaudeBinPath }).path;
+
+  // Serialize against init / other refreshes — this mutates the shared
+  // marketplace dir.
+  const lock = await acquireMarketplaceLock();
+  try {
+    // Materialize the latest tarball into the marketplace dir (mirror step-9
+    // sub-steps b–e). Single attempt: on ANY failure we restore nothing and
+    // leave the existing install in place (no LKG fallback — unlike first
+    // install, a failed refresh isn't stranding; the old plugin still works).
+    const tmpExtractDir = pluginTmpExtractDir(slug);
+    const tmpMarketplaceDir = marketplaceTmpDir(slug);
+    const tmpTarballPath = join(tmpMarketplaceDir, 'plugin.tgz');
+    rmSync(tmpMarketplaceDir, { recursive: true, force: true });
+    mkdirSync(tmpExtractDir, { recursive: true });
+
+    let plugins: PluginEntry[];
+    try {
+      await fetchAndExtractPlugin(ctx, meta, tmpTarballPath, tmpExtractDir);
+      plugins = listMarketplacePluginsFromExtractDir(tmpExtractDir);
+      mkdirSync(join(tmpMarketplaceDir, '.claude-plugin'), { recursive: true });
+      writeFileSync(
+        marketplaceTmpJsonPath(slug),
+        serializeMarketplaceJson(buildMarketplaceJson(slug, plugins))
+      );
+      atomicRenameDir(tmpMarketplaceDir, marketplaceDir(slug));
+    } catch (err) {
+      rmSync(tmpMarketplaceDir, { recursive: true, force: true });
+      if (!ctx.silent) {
+        process.stderr.write(
+          `mysecond: couldn't download the latest plugin (${err instanceof Error ? err.message : String(err)}). Your current install is unchanged.\n`
+        );
+      }
+      return 0;
+    }
+
+    // Re-register with Claude Code via the shared mechanics helper.
+    const result = registerMarketplaceAndInstall({
+      slug,
+      plugins,
+      claudeBin,
+      deadlineMs: Date.now() + REFRESH_BUDGET_MS,
+      silent: ctx.silent,
+    });
+
+    if (result.outcome.kind !== 'registered') {
+      // Degraded: the previously-installed plugin is still present + working.
+      // Do NOT advance installedPluginVersion, so a later run retries.
+      if (!ctx.silent) {
+        const why =
+          result.outcome.kind === 'binary_not_found'
+            ? "couldn't run the Claude Code CLI — re-open Claude Code, then retry"
+            : result.outcome.kind === 'timed_out'
+              ? 'Claude Code took too long to respond'
+              : result.outcome.reason;
+        process.stderr.write(
+          `mysecond: plugin refresh didn't complete (${why}). Your current install still works.\n`
+        );
+      }
+      return 0;
+    }
+
+    // Success — cache as last-known-good + record the version ACTUALLY installed
+    // (the latest we just fetched + registered), under the locked writer.
+    cacheLastKnownGood(slug, meta.version, meta.sha256, join(marketplaceDir(slug), 'plugin'));
+    await updateSyncState(ctx.rootDir, (s) => {
+      s.installedPluginVersion = meta.version;
+      s.lastClaudeBinPath = claudeBin;
+    });
+
+    if (!ctx.silent) {
+      process.stdout.write(
+        `mysecond: refreshed PM OS plugin to ${meta.version}. ` +
+          'Reload Claude Code (/reload-plugins, or start a new session) to activate the updated skills + hooks.\n'
+      );
+    }
+    return 0;
+  } finally {
+    await lock.release();
+  }
+}

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -670,7 +670,12 @@ async function runPushOnly(ctx: CommandContext): Promise<number> {
     });
     if (toSync.length > 0) {
       const res = await artifactsSync(ctx, toSync, opts);
-      if (res.synced > 0) {
+      // Record hashes ONLY on a full accept. The artifacts response carries
+      // just { synced } (no per-file errors), so a partial accept
+      // (synced < count) must not mark un-accepted files as pushed — that would
+      // suppress retry until the file changes again. On a partial/failed push
+      // we record nothing and the next turn retries.
+      if (res.synced >= toSync.length) {
         const now = new Date().toISOString();
         for (const a of toSync) {
           pushedArtifacts[a.file_path] = { hash: a.current_hash, pushedAt: now };
@@ -694,7 +699,12 @@ async function runPushOnly(ctx: CommandContext): Promise<number> {
     });
     if (toSync.length > 0) {
       const res = await contextFilesPush(ctx, toSync, opts);
-      if (res.synced > 0 || res.skipped > 0) {
+      // Record only on a clean accept (no per-file errors). synced + skipped =
+      // accepted (new/updated + already-current); a non-empty errors[] means
+      // the server rejected some, so record nothing and retry next turn rather
+      // than marking a rejected file as pushed.
+      const errs = res.errors ?? [];
+      if (errs.length === 0 && (res.synced > 0 || res.skipped > 0)) {
         const now = new Date().toISOString();
         for (const f of toSync) {
           pushedContext[f.file_path] = { hash: f.current_hash, pushedAt: now };

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -48,7 +48,14 @@ import {
   spliceBetweenMarkers,
 } from '../lib/copy.js';
 import { pruneStalePlugins } from '../lib/prune-stale-plugins.js';
-import { readSyncState, writeSyncState, type SyncState } from '../lib/sync-state.js';
+import {
+  readSyncState,
+  updateSyncState,
+  writeSyncState,
+  type SyncState,
+  type SyncStateArtifactEntry,
+  type SyncStateContextEntry,
+} from '../lib/sync-state.js';
 
 const TEAM_OVERRIDE_START = '<!-- TEAM_OVERRIDE:START -->';
 const TEAM_OVERRIDE_END = '<!-- TEAM_OVERRIDE:END -->';
@@ -632,6 +639,97 @@ async function runPushAll(ctx: CommandContext): Promise<number> {
   return failed ? 1 : 0;
 }
 
+/**
+ * `mysecond sync --push-only` — the once-per-turn realtime push used by the
+ * Stop / SubagentStop hook. Scans local artifacts + context files and pushes
+ * only those whose hash changed since the last recorded push (incremental —
+ * the same hash-gating as the SessionStart up-sync). It does NOT pull,
+ * reconcile, touch CLAUDE.md, pull base-plugin updates, or run the npm-nag —
+ * those belong to the full SessionStart sync, not every turn.
+ *
+ * It persists ONLY the keys it actually pushed, via the locked updateSyncState,
+ * so it never clobbers a concurrent PostToolUse `artifact-sync` write.
+ *
+ * Best-effort + silent-safe: a push failure is swallowed under --silent (the
+ * hook path) and surfaced in interactive mode; the command always returns 0.
+ */
+async function runPushOnly(ctx: CommandContext): Promise<number> {
+  const state = readSyncState(ctx.rootDir);
+  const opts = silentSyncOpts(ctx);
+
+  const pushedArtifacts: Record<string, SyncStateArtifactEntry> = {};
+  const pushedContext: Record<string, SyncStateContextEntry> = {};
+
+  // Artifacts (work outputs). scanArtifacts is hardened (size-capped + skips
+  // unreadable files) so a single bad file can't fail the whole turn sweep.
+  try {
+    const artifacts = scanArtifacts(ctx.rootDir);
+    const toSync = artifacts.filter((a) => {
+      const last = state.artifacts[a.file_path];
+      return !last || last.hash !== a.current_hash;
+    });
+    if (toSync.length > 0) {
+      const res = await artifactsSync(ctx, toSync, opts);
+      if (res.synced > 0) {
+        const now = new Date().toISOString();
+        for (const a of toSync) {
+          pushedArtifacts[a.file_path] = { hash: a.current_hash, pushedAt: now };
+        }
+      }
+    }
+  } catch (err) {
+    if (!ctx.silent) {
+      process.stderr.write(
+        `mysecond: artifact push-only failed (${err instanceof Error ? err.message : String(err)}).\n`
+      );
+    }
+  }
+
+  // Context files.
+  try {
+    const files = scanContextFiles(ctx.rootDir);
+    const toSync = files.filter((f) => {
+      const last = state.contextFiles[f.file_path];
+      return !last || last.hash !== f.current_hash;
+    });
+    if (toSync.length > 0) {
+      const res = await contextFilesPush(ctx, toSync, opts);
+      if (res.synced > 0 || res.skipped > 0) {
+        const now = new Date().toISOString();
+        for (const f of toSync) {
+          pushedContext[f.file_path] = { hash: f.current_hash, pushedAt: now };
+        }
+      }
+    }
+  } catch (err) {
+    if (!ctx.silent) {
+      process.stderr.write(
+        `mysecond: context push-only failed (${err instanceof Error ? err.message : String(err)}).\n`
+      );
+    }
+  }
+
+  const artifactCount = Object.keys(pushedArtifacts).length;
+  const contextCount = Object.keys(pushedContext).length;
+  if (artifactCount > 0 || contextCount > 0) {
+    // Persist ONLY the keys we pushed, merged onto a freshly-read state under
+    // lock — never overwrite hashes a concurrent writer recorded.
+    await updateSyncState(ctx.rootDir, (s) => {
+      Object.assign(s.artifacts, pushedArtifacts);
+      Object.assign(s.contextFiles, pushedContext);
+    });
+    // stdout so Claude (which reads hook stdout as context) can note the sync.
+    // Emitted only when something was actually pushed — the common no-change
+    // turn stays silent.
+    const parts: string[] = [];
+    if (artifactCount > 0) parts.push(`${artifactCount} artifact(s)`);
+    if (contextCount > 0) parts.push(`${contextCount} context file(s)`);
+    process.stdout.write(`mysecond: pushed ${parts.join(' + ')}.\n`);
+  }
+
+  return 0;
+}
+
 export async function runSync(
   _args: readonly string[],
   ctx: CommandContext
@@ -645,6 +743,13 @@ export async function runSync(
   // standalone repair, not part of the normal pull flow.
   if (ctx.pushAll) {
     return runPushAll(ctx);
+  }
+
+  // `--push-only`: the once-per-turn realtime up-sync used by the Stop /
+  // SubagentStop hook. Incremental (changed files only) and standalone — no
+  // pull. Return early so a turn-end push never triggers a full re-pull.
+  if (ctx.pushOnly) {
+    return runPushOnly(ctx);
   }
 
   maybeNudgeCredsMigration(ctx);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -653,7 +653,7 @@ async function runPushAll(ctx: CommandContext): Promise<number> {
  * Best-effort + silent-safe: a push failure is swallowed under --silent (the
  * hook path) and surfaced in interactive mode; the command always returns 0.
  */
-async function runPushOnly(ctx: CommandContext): Promise<number> {
+export async function runPushOnly(ctx: CommandContext): Promise<number> {
   const state = readSyncState(ctx.rootDir);
   const opts = silentSyncOpts(ctx);
 
@@ -675,6 +675,11 @@ async function runPushOnly(ctx: CommandContext): Promise<number> {
       // (synced < count) must not mark un-accepted files as pushed — that would
       // suppress retry until the file changes again. On a partial/failed push
       // we record nothing and the next turn retries.
+      //
+      // No "already-current → synced:0 → re-push forever" loop: the artifacts
+      // endpoint UPSERTS every accepted file (it has no unchanged-skip path), so
+      // synced === count on a clean accept. A synced < count therefore means a
+      // genuine conflict/error on those files — correct to retry, not record.
       if (res.synced >= toSync.length) {
         const now = new Date().toISOString();
         for (const a of toSync) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { runInit } from './commands/init.js';
 import { runSync } from './commands/sync.js';
 import { runArtifactSync } from './commands/artifact-sync.js';
+import { runPluginRefresh } from './commands/plugin-refresh.js';
 import { runWhereami } from './commands/whereami.js';
 import { runCredentials } from './commands/credentials.js';
 import { runDoctor } from './commands/doctor.js';
@@ -33,6 +34,11 @@ const SUBCOMMANDS: readonly Subcommand[] = [
     name: 'artifact-sync',
     summary: 'Push a changed artifact (skill output, doc, plan) up to mysecond.ai.',
     run: runArtifactSync,
+  },
+  {
+    name: 'plugin-refresh',
+    summary: 'Re-install the latest PM OS plugin — refreshes hooks/skills for an existing install.',
+    run: runPluginRefresh,
   },
   {
     name: 'whereami',
@@ -71,6 +77,7 @@ function printHelp(): void {
     '  --strategy <mode>      Conflict resolution: prompt | cloud-wins | local-wins | skip',
     '  --force-update         Bypass the 24-hour npm-update timebox in sync',
     '  --push-all             Push all local context/ + work output files up to mySecond (`mysecond sync` only). Repairs an empty workspace.',
+    '  --push-only            Push only CHANGED context/work files, skip the pull (`mysecond sync` only). Used by the per-turn realtime hook.',
     '  --fix                  Resolve init conflicts interactively (`mysecond init` only)',
     '  --auth-only            Mint device code, persist state, exit (`mysecond init` only). Pairs with --resume.',
     '  --resume               Resume install from persisted auth state OR re-run device-code OAuth (`mysecond init` only)',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 // @mysecond/cli — entry point. Parses global flags, builds CommandContext, dispatches.
 
 import { runInit } from './commands/init.js';
-import { runSync } from './commands/sync.js';
+import { runPushOnly, runSync } from './commands/sync.js';
 import { runArtifactSync } from './commands/artifact-sync.js';
 import { runPluginRefresh } from './commands/plugin-refresh.js';
 import { runWhereami } from './commands/whereami.js';
@@ -29,6 +29,16 @@ const SUBCOMMANDS: readonly Subcommand[] = [
     name: 'sync',
     summary: 'Sync the latest context, skills, and agents from mysecond.ai into the workspace.',
     run: runSync,
+  },
+  {
+    // The realtime turn-end push hook (Stop/SubagentStop) targets this
+    // SUBCOMMAND, not `sync --push-only`, on purpose: an OLD CLI that predates
+    // it exits non-zero on an unknown subcommand (whereas `sync` silently
+    // swallows an unknown flag and runs a full pull), so the hook's
+    // `|| npx @latest` fallback reliably fires for every install cohort.
+    name: 'push',
+    summary: 'Push changed context/work files up to mysecond.ai (no pull). Used by the realtime hook.',
+    run: (_args, ctx) => runPushOnly(ctx),
   },
   {
     name: 'artifact-sync',

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -41,6 +41,13 @@ export interface CommandContext {
    * this is the explicit catch-up that doesn't depend on hook side effects.
    */
   pushAll: boolean;
+  /**
+   * `mysecond sync --push-only`. Runs ONLY the up-sync half (changed artifacts +
+   * context files), skipping the pull/reconcile entirely. The Stop/SubagentStop
+   * hook uses this for once-per-turn realtime push without re-pulling skills
+   * every turn. Incremental (hash-gated) — unlike --push-all which force-scans.
+   */
+  pushOnly: boolean;
 }
 
 export interface ParsedFlags {
@@ -53,6 +60,7 @@ export interface ParsedFlags {
   resume: boolean;
   authOnly: boolean;
   pushAll: boolean;
+  pushOnly: boolean;
   strategy: ConflictStrategy | null;
   positional: string[];
 }
@@ -70,6 +78,7 @@ export function parseGlobalFlags(args: readonly string[]): ParsedFlags {
     resume: false,
     authOnly: false,
     pushAll: false,
+    pushOnly: false,
     strategy: null,
     positional: [],
   };
@@ -90,6 +99,8 @@ export function parseGlobalFlags(args: readonly string[]): ParsedFlags {
       out.authOnly = true;
     } else if (arg === '--push-all') {
       out.pushAll = true;
+    } else if (arg === '--push-only') {
+      out.pushOnly = true;
     } else if (arg === '--api-key') {
       const next = args[i + 1];
       if (next === undefined) throw MysecondError.invalidFlag('--api-key', 'requires a value');
@@ -317,6 +328,7 @@ export function buildContext(flags: ParsedFlags): CommandContext {
     resume: flags.resume,
     authOnly: flags.authOnly,
     pushAll: flags.pushAll,
+    pushOnly: flags.pushOnly,
     strategy,
   };
 }

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -148,6 +148,13 @@ export const CONTEXT_DIR = 'context';
 // Server PER_FILE_LIMIT is 50KB. Pre-filter to skip wasted round-trips.
 export const CONTEXT_PER_FILE_LIMIT = 50 * 1024;
 
+// Server artifact cap is 500KB (mysecond-app /api/companion/artifacts rejects
+// content > 500*1024). The scan skips anything larger client-side — both to
+// avoid a guaranteed-reject round-trip and, critically, so the per-turn Stop
+// sweep (`sync --push-only`) can't OOM/stall on a giant file. Mirrors
+// CONTEXT_PER_FILE_LIMIT's role for context files.
+export const ARTIFACT_PER_FILE_LIMIT = 500 * 1024;
+
 // Filenames under context/ that are auto-generated metadata, not real context
 // files. These must not sync to context_files. PMO-4: `index.md` is generated
 // by various tools as a directory listing/index — treating it as user-edited
@@ -348,7 +355,19 @@ function walkArtifactDir(
     }
     if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
 
-    const content = readFileSync(fullPath, 'utf8');
+    let content: string;
+    try {
+      // stat first — a giant or transient artifact must not OOM or throw the
+      // per-turn Stop sweep (mirrors walkContextDir). Skip empties and anything
+      // over the server's artifact cap (it would be rejected server-side
+      // anyway). A read error (file vanished mid-turn, permissions) is skipped,
+      // never propagated — one bad file can't fail the whole push-only sweep.
+      const stat = statSync(fullPath);
+      if (stat.size === 0 || stat.size > ARTIFACT_PER_FILE_LIMIT) continue;
+      content = readFileSync(fullPath, 'utf8');
+    } catch {
+      continue;
+    }
     const relativePath = relative(rootDir, fullPath);
     const parentDir = basename(currentDir);
     const pmNameMatch = parentDir.match(/^\d{4}-\d{2}-\d{2}-\d{4}-(.+)$/);

--- a/src/lib/plugin-register.ts
+++ b/src/lib/plugin-register.ts
@@ -1,0 +1,147 @@
+// Shared Claude Code plugin-registration mechanics: `claude plugin marketplace
+// remove → add → install`, run via a resolved `claude` binary under a single
+// shared wall-clock budget, returning a STRUCTURED result.
+//
+// Used by `plugin-refresh` (the existing-customer hook-delivery path). step-9
+// (FIRST install) keeps its own registration block because it is interwoven
+// with init-only concerns the refresh path does not have — last-known-good
+// fallback, the auth-thrash circuit breaker, the `degraded` step outcome, and
+// step-timing telemetry — and because its exact source shape is pinned by the
+// red-team-r2 regression tests. The two paths share the canonical path + spec
+// builders in `mysecond-paths.ts` (marketplaceName / marketplaceDir /
+// pluginInstallSpec / SENTINEL_PLUGIN_NAME), so the command CONTRACT (the part
+// that would actually break if Claude Code changed its CLI) cannot drift; only
+// the small spawn-sequencing wrapper is intentionally duplicated.
+
+import { spawnSync } from 'node:child_process';
+
+import {
+  marketplaceDir,
+  marketplaceName,
+  pluginInstallSpec,
+  SENTINEL_PLUGIN_NAME,
+  type PluginEntry,
+} from './mysecond-paths.js';
+
+export interface RegisterParams {
+  slug: string;
+  /** Plugins to install (from the materialized marketplace's manifest). */
+  plugins: PluginEntry[];
+  /** Resolved `claude` binary path (from resolveClaudeBin). */
+  claudeBin: string;
+  /**
+   * Absolute epoch-ms deadline. Every spawn draws from this single budget so a
+   * wedged `claude` degrades fast instead of freezing — mirrors step-9's
+   * REGISTER_BUDGET_MS contract.
+   */
+  deadlineMs: number;
+  /** Pipe stdio (true) vs inherit (false, interactive). */
+  silent: boolean;
+}
+
+export type RegisterOutcome =
+  | { kind: 'registered' }
+  | { kind: 'binary_not_found' }
+  | { kind: 'timed_out' }
+  | { kind: 'failed'; reason: string };
+
+export interface RegisterResult {
+  outcome: RegisterOutcome;
+  /**
+   * Plugins whose install exited non-zero. A non-sentinel failure is tolerated
+   * (recorded here, registration still 'registered'); a sentinel (`pm-os`)
+   * failure makes the outcome 'failed'.
+   */
+  failedPlugins: string[];
+}
+
+// spawnSync sets signal 'SIGTERM'/'SIGKILL' (status: null) when it kills a
+// process that exceeded `timeout`; some platforms surface ETIMEDOUT on .error.
+// (Mirror of the same predicate in step-9.ts.)
+function spawnTimedOut(r: ReturnType<typeof spawnSync>): boolean {
+  return (
+    r.signal === 'SIGTERM' ||
+    r.signal === 'SIGKILL' ||
+    (r.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT'
+  );
+}
+
+function isEnoent(r: ReturnType<typeof spawnSync>): boolean {
+  return (r.error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT';
+}
+
+function remaining(deadlineMs: number): number {
+  return deadlineMs - Date.now();
+}
+
+/**
+ * Register (or re-register) the customer marketplace + install its plugins via
+ * Claude Code. Idempotent: removes the marketplace first (covers a stale
+ * pointer / a re-install), then adds the materialized dir, then installs each
+ * plugin. The CALLER must have already materialized `marketplaceDir(slug)`
+ * (fetch + extract + marketplace.json) before calling, and decides what to
+ * persist from the structured result.
+ *
+ * Never throws — every failure mode is reported via the structured outcome so
+ * a best-effort, exit-0 caller (plugin-refresh) can branch without try/catch.
+ */
+export function registerMarketplaceAndInstall(params: RegisterParams): RegisterResult {
+  const { slug, plugins, claudeBin, deadlineMs, silent } = params;
+  const failedPlugins: string[] = [];
+  const stdio: 'pipe' | 'inherit' = silent ? 'pipe' : 'inherit';
+
+  // Idempotency: remove any existing registration first (best-effort — a
+  // first-time refresh has nothing to remove; a re-run clears a stale pointer).
+  if (remaining(deadlineMs) <= 0) return { outcome: { kind: 'timed_out' }, failedPlugins };
+  spawnSync(
+    claudeBin,
+    ['plugin', 'marketplace', 'remove', marketplaceName(slug), '--scope', 'user'],
+    { stdio: 'pipe', timeout: Math.max(1, remaining(deadlineMs)) }
+  );
+
+  // Add the materialized marketplace dir.
+  if (remaining(deadlineMs) <= 0) return { outcome: { kind: 'timed_out' }, failedPlugins };
+  const addResult = spawnSync(
+    claudeBin,
+    ['plugin', 'marketplace', 'add', marketplaceDir(slug), '--scope', 'user'],
+    { stdio, timeout: Math.max(1, remaining(deadlineMs)) }
+  );
+  if (isEnoent(addResult)) return { outcome: { kind: 'binary_not_found' }, failedPlugins };
+  if (spawnTimedOut(addResult)) return { outcome: { kind: 'timed_out' }, failedPlugins };
+  if (addResult.status !== 0) {
+    return {
+      outcome: {
+        kind: 'failed',
+        reason: `claude plugin marketplace add exited ${addResult.status ?? 'null'}`,
+      },
+      failedPlugins,
+    };
+  }
+
+  // Install each plugin. Sentinel (`pm-os`) failure is fatal; others tolerated.
+  for (const plugin of plugins) {
+    if (remaining(deadlineMs) <= 0) return { outcome: { kind: 'timed_out' }, failedPlugins };
+    const spec = pluginInstallSpec(slug, plugin.name);
+    const installResult = spawnSync(
+      claudeBin,
+      ['plugin', 'install', spec, '--scope', 'user'],
+      { stdio, timeout: Math.max(1, remaining(deadlineMs)) }
+    );
+    if (isEnoent(installResult)) return { outcome: { kind: 'binary_not_found' }, failedPlugins };
+    if (spawnTimedOut(installResult)) return { outcome: { kind: 'timed_out' }, failedPlugins };
+    if (installResult.status !== 0) {
+      failedPlugins.push(plugin.name);
+      if (plugin.name === SENTINEL_PLUGIN_NAME) {
+        return {
+          outcome: {
+            kind: 'failed',
+            reason: `claude plugin install ${spec} exited ${installResult.status ?? 'null'}`,
+          },
+          failedPlugins,
+        };
+      }
+    }
+  }
+
+  return { outcome: { kind: 'registered' }, failedPlugins };
+}

--- a/src/lib/steps/step-9.ts
+++ b/src/lib/steps/step-9.ts
@@ -534,6 +534,12 @@ async function doStep9(
   // plain-terminal context (where $CLAUDE_CODE_EXECPATH is unset) can still
   // resolve the binary. Counter was already cleared post-fetch; keep it 0.
   state.lastClaudeBinPath = claudeBin;
+  // Record the version Claude Code actually has materialized (Codex #3) so a
+  // later `mysecond plugin-refresh` can tell whether a re-install is needed.
+  // Set ONLY on this normal-success path: an LKG fallback installs a STALE
+  // cached version and intentionally leaves this null, so a future refresh
+  // upgrades the customer off that stale cache rather than recording it as current.
+  state.installedPluginVersion = meta.version;
   state.step9Auth401RetryCount = 0;
   writeSyncState(ctx.rootDir, state);
 

--- a/src/lib/sync-state.ts
+++ b/src/lib/sync-state.ts
@@ -1,7 +1,8 @@
 // .claude/sync-state.json — read/write the local sync ledger.
 
-import { mkdirSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
+import lockfile from 'proper-lockfile';
 
 import { atomicWriteFile } from './atomic-write.js';
 import { projectPaths } from './files.js';
@@ -61,6 +62,14 @@ export interface SyncState {
   // still resolve the binary instead of falling through to PATH lookups that
   // fail on desktop-app installs.
   lastClaudeBinPath: string | null;
+  // Plugin version (the `1.{unix-ms}.0` minted by regen) that Claude Code
+  // currently has MATERIALIZED for this customer. Written by step-9 and
+  // `plugin-refresh` to the version they ACTUALLY installed — which may be an
+  // older last-known-good cache on a network/registration failure, never
+  // blindly the latest available. `plugin-refresh` compares the latest
+  // available version against this to decide whether a re-install is needed.
+  // Null on installs that predate this field → treated as "refresh once".
+  installedPluginVersion: string | null;
 }
 
 function freshEmptyState(): SyncState {
@@ -78,6 +87,7 @@ function freshEmptyState(): SyncState {
     lastKnownLatestNpmVersion: null,
     lastUpgradePromptAt: null,
     lastClaudeBinPath: null,
+    installedPluginVersion: null,
   };
 }
 
@@ -129,4 +139,69 @@ export function writeSyncState(rootDir: string, state: SyncState): void {
   // mkdirSync recursive is a no-op if the directory exists.
   mkdirSync(dirname(path), { recursive: true });
   atomicWriteFile(path, JSON.stringify(state, null, 2) + '\n');
+}
+
+// Lock tuning for sync-state writes — mirror marketplace-lock's proven values.
+const SYNC_STATE_LOCK_STALE_MS = 30_000;
+const SYNC_STATE_LOCK_RETRIES = 5;
+const SYNC_STATE_LOCK_MIN_TIMEOUT_MS = 100;
+
+/**
+ * Read-modify-write sync-state.json under a file lock so concurrent writers
+ * don't clobber each other. `writeSyncState` replaces the WHOLE file, so two
+ * writers that each `read → mutate → write` can lose one another's keys: the
+ * PostToolUse `artifact-sync` hook (records one context-file hash) and the Stop
+ * `sync --push-only` sweep (records many artifact/context hashes) fire close
+ * together, and without serialization the later write would drop the earlier
+ * one's freshly-recorded hash (→ a benign but wasteful re-push next turn). The
+ * mutator runs against state read FRESH under the lock, so it only ever adds to
+ * the latest on-disk state.
+ *
+ * Best-effort by contract: hooks must never crash on lock contention. If the
+ * lock can't be acquired (timeout, unsupported FS), we fall back to an unlocked
+ * read-modify-write — no worse than the pre-lock behavior, and the common
+ * (uncontended) case is fully serialized.
+ */
+export async function updateSyncState(
+  rootDir: string,
+  mutate: (state: SyncState) => void
+): Promise<void> {
+  const path = projectPaths(rootDir).syncStatePath;
+  mkdirSync(dirname(path), { recursive: true });
+  // proper-lockfile requires the target to exist before lock(). A brand-new
+  // workspace may not have written sync-state yet; materialize an empty one so
+  // the very first concurrent writers still serialize.
+  if (!existsSync(path)) {
+    atomicWriteFile(path, JSON.stringify(freshEmptyState(), null, 2) + '\n');
+  }
+
+  let release: (() => Promise<void>) | null = null;
+  try {
+    release = await lockfile.lock(path, {
+      retries: {
+        retries: SYNC_STATE_LOCK_RETRIES,
+        minTimeout: SYNC_STATE_LOCK_MIN_TIMEOUT_MS,
+      },
+      stale: SYNC_STATE_LOCK_STALE_MS,
+    });
+  } catch {
+    // Couldn't acquire the lock — degrade to an unlocked read-modify-write.
+    // Never throw from here: this path serves best-effort hook writes.
+    const state = readSyncState(rootDir);
+    mutate(state);
+    writeSyncState(rootDir, state);
+    return;
+  }
+
+  try {
+    const state = readSyncState(rootDir);
+    mutate(state);
+    writeSyncState(rootDir, state);
+  } finally {
+    try {
+      await release();
+    } catch {
+      // Lock auto-releases after the stale window; ignore release errors.
+    }
+  }
 }

--- a/src/lib/sync-state.ts
+++ b/src/lib/sync-state.ts
@@ -185,11 +185,11 @@ export async function updateSyncState(
       stale: SYNC_STATE_LOCK_STALE_MS,
     });
   } catch {
-    // Couldn't acquire the lock — degrade to an unlocked read-modify-write.
-    // Never throw from here: this path serves best-effort hook writes.
-    const state = readSyncState(rootDir);
-    mutate(state);
-    writeSyncState(rootDir, state);
+    // Couldn't acquire the lock (contention or an unsupported FS). SKIP the
+    // write rather than doing an UNLOCKED read-modify-write: an unlocked writer
+    // could clobber a concurrent locked writer's keys (the very thing this
+    // helper exists to prevent). These are best-effort hook writes — the
+    // mutation is simply re-done on the next turn / SessionStart.
     return;
   }
 

--- a/src/lib/sync-state.ts
+++ b/src/lib/sync-state.ts
@@ -151,20 +151,23 @@ const SYNC_STATE_LOCK_MIN_TIMEOUT_MS = 100;
  * don't clobber each other. `writeSyncState` replaces the WHOLE file, so two
  * writers that each `read → mutate → write` can lose one another's keys: the
  * PostToolUse `artifact-sync` hook (records one context-file hash) and the Stop
- * `sync --push-only` sweep (records many artifact/context hashes) fire close
- * together, and without serialization the later write would drop the earlier
- * one's freshly-recorded hash (→ a benign but wasteful re-push next turn). The
- * mutator runs against state read FRESH under the lock, so it only ever adds to
- * the latest on-disk state.
+ * `push` sweep (records many artifact/context hashes) fire close together, and
+ * without serialization the later write would drop the earlier one's
+ * freshly-recorded hash. The mutator runs against state read FRESH under the
+ * lock, so it only ever adds to the latest on-disk state.
  *
- * Best-effort by contract: hooks must never crash on lock contention. If the
- * lock can't be acquired (timeout, unsupported FS), we fall back to an unlocked
- * read-modify-write — no worse than the pre-lock behavior, and the common
- * (uncontended) case is fully serialized.
+ * Best-effort by contract: callers must never crash on lock contention. If the
+ * lock can't be acquired we SKIP the write — we do NOT write unlocked, which
+ * could clobber a concurrent locked writer. The common (uncontended) case
+ * always serializes; on the rare miss the mutation is simply re-done next time.
+ * `opts.retries` lets an important, low-frequency writer (e.g. plugin-refresh
+ * recording installedPluginVersion) wait harder so it effectively never skips,
+ * while hot-path hooks keep the default fast-skip.
  */
 export async function updateSyncState(
   rootDir: string,
-  mutate: (state: SyncState) => void
+  mutate: (state: SyncState) => void,
+  opts: { retries?: number } = {}
 ): Promise<void> {
   const path = projectPaths(rootDir).syncStatePath;
   mkdirSync(dirname(path), { recursive: true });
@@ -179,7 +182,7 @@ export async function updateSyncState(
   try {
     release = await lockfile.lock(path, {
       retries: {
-        retries: SYNC_STATE_LOCK_RETRIES,
+        retries: opts.retries ?? SYNC_STATE_LOCK_RETRIES,
         minTimeout: SYNC_STATE_LOCK_MIN_TIMEOUT_MS,
       },
       stale: SYNC_STATE_LOCK_STALE_MS,

--- a/tests/commands/plugin-refresh.test.ts
+++ b/tests/commands/plugin-refresh.test.ts
@@ -18,7 +18,7 @@ const h = vi.hoisted(() => ({
   listPlugins: vi.fn(),
   registerMarketplaceAndInstall: vi.fn(),
   cacheLastKnownGood: vi.fn(),
-  atomicRenameDir: vi.fn(),
+  acquireMarketplaceLock: vi.fn(),
   marketplaceDir: vi.fn(),
   marketplaceTmpDir: vi.fn(),
   marketplaceTmpJsonPath: vi.fn(),
@@ -32,7 +32,7 @@ vi.mock('../../src/lib/plugin-register.js', () => ({
 }));
 vi.mock('../../src/lib/last-known-good.js', () => ({ cacheLastKnownGood: h.cacheLastKnownGood }));
 vi.mock('../../src/lib/marketplace-lock.js', () => ({
-  acquireMarketplaceLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+  acquireMarketplaceLock: h.acquireMarketplaceLock,
 }));
 vi.mock('../../src/lib/mysecond-paths.js', async (orig) => {
   const actual = (await orig()) as Record<string, unknown>;
@@ -91,13 +91,13 @@ beforeEach(() => {
     h.listPlugins,
     h.registerMarketplaceAndInstall,
     h.cacheLastKnownGood,
-    h.atomicRenameDir,
+    h.acquireMarketplaceLock,
   ]) {
     fn.mockReset();
   }
   h.fetchAndExtractPlugin.mockResolvedValue(undefined);
   h.listPlugins.mockReturnValue([{ name: 'pm-os' }]);
-  h.atomicRenameDir.mockReturnValue(undefined);
+  h.acquireMarketplaceLock.mockResolvedValue({ release: async () => {} });
 
   // Redirect all marketplace paths into a fresh temp dir.
   mpDir = mkdtempSync(join(tmpdir(), 'mysecond-mp-'));
@@ -187,5 +187,31 @@ describe('mysecond plugin-refresh', () => {
     const code = await runPluginRefresh([], ctx(root, { apiKey: '' }));
     expect(code).toBe(0);
     expect(h.pluginTarball).not.toHaveBeenCalled();
+  });
+
+  // Codex review #1: acquireMarketplaceLock throws on contention — must not
+  // make the command exit non-zero.
+  it('degradable: exit 0 (no register) when the marketplace lock cannot be acquired', async () => {
+    const root = tmpProject('acme', '1.100.0');
+    h.pluginTarball.mockResolvedValue({ version: '1.200.0', sha256: 'abc' });
+    h.acquireMarketplaceLock.mockRejectedValue(new Error('lock busy'));
+    const code = await runPluginRefresh([], ctx(root));
+    expect(code).toBe(0);
+    expect(h.registerMarketplaceAndInstall).not.toHaveBeenCalled();
+    expect(readSyncState(root).installedPluginVersion).toBe('1.100.0');
+  });
+
+  // Codex review #5: a best-effort LKG cache write failure after a successful
+  // install must not lose the recorded version nor exit non-zero.
+  it('records the installed version even when last-known-good caching throws', async () => {
+    const root = tmpProject('acme', '1.100.0');
+    h.pluginTarball.mockResolvedValue({ version: '1.200.0', sha256: 'abc' });
+    h.registerMarketplaceAndInstall.mockReturnValue({ outcome: { kind: 'registered' }, failedPlugins: [] });
+    h.cacheLastKnownGood.mockImplementation(() => {
+      throw new Error('disk full');
+    });
+    const code = await runPluginRefresh([], ctx(root));
+    expect(code).toBe(0);
+    expect(readSyncState(root).installedPluginVersion).toBe('1.200.0');
   });
 });

--- a/tests/commands/plugin-refresh.test.ts
+++ b/tests/commands/plugin-refresh.test.ts
@@ -1,0 +1,191 @@
+// Tests for `mysecond plugin-refresh` (runPluginRefresh) — the existing-customer
+// delivery path. Verifies version-gating, the null→refresh-once self-heal,
+// version persistence on success, and that EVERY failure mode is degradable
+// (exit 0, installed version not advanced, working install left intact).
+//
+// All filesystem + network + spawn boundaries are mocked; marketplace path
+// builders are redirected to a per-test temp dir so nothing touches ~/.mysecond.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  pluginTarball: vi.fn(),
+  fetchAndExtractPlugin: vi.fn(),
+  listPlugins: vi.fn(),
+  registerMarketplaceAndInstall: vi.fn(),
+  cacheLastKnownGood: vi.fn(),
+  atomicRenameDir: vi.fn(),
+  marketplaceDir: vi.fn(),
+  marketplaceTmpDir: vi.fn(),
+  marketplaceTmpJsonPath: vi.fn(),
+  pluginTmpExtractDir: vi.fn(),
+}));
+
+vi.mock('../../src/lib/api.js', () => ({ pluginTarball: h.pluginTarball }));
+vi.mock('../../src/lib/plugin-tarball.js', () => ({ fetchAndExtractPlugin: h.fetchAndExtractPlugin }));
+vi.mock('../../src/lib/plugin-register.js', () => ({
+  registerMarketplaceAndInstall: h.registerMarketplaceAndInstall,
+}));
+vi.mock('../../src/lib/last-known-good.js', () => ({ cacheLastKnownGood: h.cacheLastKnownGood }));
+vi.mock('../../src/lib/marketplace-lock.js', () => ({
+  acquireMarketplaceLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+}));
+vi.mock('../../src/lib/mysecond-paths.js', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    listMarketplacePluginsFromExtractDir: h.listPlugins,
+    marketplaceDir: h.marketplaceDir,
+    marketplaceTmpDir: h.marketplaceTmpDir,
+    marketplaceTmpJsonPath: h.marketplaceTmpJsonPath,
+    pluginTmpExtractDir: h.pluginTmpExtractDir,
+  };
+});
+vi.mock('../../src/lib/atomic-write.js', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return { ...actual, atomicRenameDir: h.atomicRenameDir };
+});
+
+import { runPluginRefresh } from '../../src/commands/plugin-refresh.js';
+import { readSyncState, writeSyncState } from '../../src/lib/sync-state.js';
+import type { CommandContext } from '../../src/lib/context.js';
+
+function tmpProject(slug: string | null = 'acme', installedVersion: string | null = null): string {
+  const root = mkdtempSync(join(tmpdir(), 'mysecond-refresh-'));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  const state = readSyncState(root);
+  state.customerSlug = slug;
+  state.installedPluginVersion = installedVersion;
+  writeSyncState(root, state);
+  return root;
+}
+
+function ctx(rootDir: string, overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'test-key',
+    rootDir,
+    silent: true,
+    dryRun: false,
+    forceUpdate: false,
+    fix: false,
+    resume: false,
+    authOnly: false,
+    pushAll: false,
+    pushOnly: false,
+    strategy: 'cloud-wins',
+    ...overrides,
+  };
+}
+
+let mpDir: string;
+
+beforeEach(() => {
+  for (const fn of [
+    h.pluginTarball,
+    h.fetchAndExtractPlugin,
+    h.listPlugins,
+    h.registerMarketplaceAndInstall,
+    h.cacheLastKnownGood,
+    h.atomicRenameDir,
+  ]) {
+    fn.mockReset();
+  }
+  h.fetchAndExtractPlugin.mockResolvedValue(undefined);
+  h.listPlugins.mockReturnValue([{ name: 'pm-os' }]);
+  h.atomicRenameDir.mockReturnValue(undefined);
+
+  // Redirect all marketplace paths into a fresh temp dir.
+  mpDir = mkdtempSync(join(tmpdir(), 'mysecond-mp-'));
+  h.marketplaceDir.mockReturnValue(join(mpDir, 'customer'));
+  h.marketplaceTmpDir.mockReturnValue(join(mpDir, 'customer.tmp'));
+  h.marketplaceTmpJsonPath.mockReturnValue(join(mpDir, 'customer.tmp', '.claude-plugin', 'marketplace.json'));
+  h.pluginTmpExtractDir.mockReturnValue(join(mpDir, 'customer.tmp', 'plugin'));
+});
+
+afterEach(() => {
+  rmSync(mpDir, { recursive: true, force: true });
+});
+
+describe('mysecond plugin-refresh', () => {
+  it('no-op when already at the latest version (no re-install)', async () => {
+    const root = tmpProject('acme', '1.100.0');
+    h.pluginTarball.mockResolvedValue({ version: '1.100.0', sha256: 'abc' });
+    const code = await runPluginRefresh([], ctx(root));
+    expect(code).toBe(0);
+    expect(h.registerMarketplaceAndInstall).not.toHaveBeenCalled();
+    expect(readSyncState(root).installedPluginVersion).toBe('1.100.0');
+  });
+
+  it('refreshes when a newer version is available and persists the installed version', async () => {
+    const root = tmpProject('acme', '1.100.0');
+    h.pluginTarball.mockResolvedValue({ version: '1.200.0', sha256: 'abc' });
+    h.registerMarketplaceAndInstall.mockReturnValue({ outcome: { kind: 'registered' }, failedPlugins: [] });
+    const code = await runPluginRefresh([], ctx(root));
+    expect(code).toBe(0);
+    expect(h.registerMarketplaceAndInstall).toHaveBeenCalledOnce();
+    expect(readSyncState(root).installedPluginVersion).toBe('1.200.0');
+  });
+
+  it('self-heals: a null installedPluginVersion always refreshes once', async () => {
+    const root = tmpProject('acme', null);
+    h.pluginTarball.mockResolvedValue({ version: '1.200.0', sha256: 'abc' });
+    h.registerMarketplaceAndInstall.mockReturnValue({ outcome: { kind: 'registered' }, failedPlugins: [] });
+    await runPluginRefresh([], ctx(root));
+    expect(h.registerMarketplaceAndInstall).toHaveBeenCalledOnce();
+    expect(readSyncState(root).installedPluginVersion).toBe('1.200.0');
+  });
+
+  it('--force-update re-installs even when the version already matches', async () => {
+    const root = tmpProject('acme', '1.100.0');
+    h.pluginTarball.mockResolvedValue({ version: '1.100.0', sha256: 'abc' });
+    h.registerMarketplaceAndInstall.mockReturnValue({ outcome: { kind: 'registered' }, failedPlugins: [] });
+    await runPluginRefresh([], ctx(root, { forceUpdate: true }));
+    expect(h.registerMarketplaceAndInstall).toHaveBeenCalledOnce();
+  });
+
+  it('degradable: register binary_not_found → exit 0, version NOT advanced', async () => {
+    const root = tmpProject('acme', '1.100.0');
+    h.pluginTarball.mockResolvedValue({ version: '1.200.0', sha256: 'abc' });
+    h.registerMarketplaceAndInstall.mockReturnValue({ outcome: { kind: 'binary_not_found' }, failedPlugins: [] });
+    const code = await runPluginRefresh([], ctx(root));
+    expect(code).toBe(0);
+    expect(readSyncState(root).installedPluginVersion).toBe('1.100.0');
+  });
+
+  it('degradable: download failure → exit 0, no register, version unchanged', async () => {
+    const root = tmpProject('acme', '1.100.0');
+    h.pluginTarball.mockResolvedValue({ version: '1.200.0', sha256: 'abc' });
+    h.fetchAndExtractPlugin.mockRejectedValue(new Error('sha mismatch'));
+    const code = await runPluginRefresh([], ctx(root));
+    expect(code).toBe(0);
+    expect(h.registerMarketplaceAndInstall).not.toHaveBeenCalled();
+    expect(readSyncState(root).installedPluginVersion).toBe('1.100.0');
+  });
+
+  it('exit 0 with no register when the version check (pluginTarball) throws', async () => {
+    const root = tmpProject('acme', '1.100.0');
+    h.pluginTarball.mockRejectedValue(new Error('network'));
+    const code = await runPluginRefresh([], ctx(root));
+    expect(code).toBe(0);
+    expect(h.registerMarketplaceAndInstall).not.toHaveBeenCalled();
+  });
+
+  it('exit 0 + no network call when there is no customer slug', async () => {
+    const root = tmpProject(null, null);
+    const code = await runPluginRefresh([], ctx(root));
+    expect(code).toBe(0);
+    expect(h.pluginTarball).not.toHaveBeenCalled();
+  });
+
+  it('exit 0 + no network call when not authenticated', async () => {
+    const root = tmpProject('acme', null);
+    const code = await runPluginRefresh([], ctx(root, { apiKey: '' }));
+    expect(code).toBe(0);
+    expect(h.pluginTarball).not.toHaveBeenCalled();
+  });
+});

--- a/tests/commands/sync-push-only.test.ts
+++ b/tests/commands/sync-push-only.test.ts
@@ -5,7 +5,7 @@
 // --push-all it is hash-gated (only CHANGED files push). It is best-effort:
 // always exits 0, persists only the keys it actually pushed.
 
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -136,5 +136,48 @@ describe('mysecond sync --push-only', () => {
     const code = await runSync([], ctx(root));
     expect(code).toBe(0);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  function recordedSection(root: string, key: 'artifacts' | 'contextFiles'): Record<string, unknown> {
+    const statePath = join(root, '.claude/sync-state.json');
+    if (!existsSync(statePath)) return {};
+    return (JSON.parse(readFileSync(statePath, 'utf8'))[key] ?? {}) as Record<string, unknown>;
+  }
+
+  // Codex review #3: a partial server accept must NOT record un-accepted files
+  // as pushed (the artifacts response has no per-file info, so synced < count
+  // means we can't tell which were rejected → record none, retry next turn).
+  it('does NOT record artifact hashes on a partial accept (synced < count)', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'work/specs/outputs'), { recursive: true });
+    writeFileSync(join(root, 'work/specs/outputs/a.md'), 'aaa');
+    writeFileSync(join(root, 'work/specs/outputs/b.md'), 'bbb');
+    fetchMock.mockImplementation((url: URL) => {
+      if (url.pathname === '/api/companion/artifacts') return Promise.resolve(jsonResponse({ synced: 1 }));
+      throw new Error(`unexpected fetch to ${url.pathname}`);
+    });
+
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+    // Neither file recorded → both retry next turn (no false "pushed").
+    expect(recordedSection(root, 'artifacts')).toEqual({});
+  });
+
+  it('does NOT record context hashes when the server returns per-file errors', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'company');
+    fetchMock.mockImplementation((url: URL) => {
+      if (url.pathname === '/api/companion/files') {
+        return Promise.resolve(
+          jsonResponse({ synced: 0, skipped: 0, errors: ['rejected: context/company.md'] }),
+        );
+      }
+      throw new Error(`unexpected fetch to ${url.pathname}`);
+    });
+
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+    expect(recordedSection(root, 'contextFiles')).toEqual({});
   });
 });

--- a/tests/commands/sync-push-only.test.ts
+++ b/tests/commands/sync-push-only.test.ts
@@ -1,0 +1,140 @@
+// Tests for `mysecond sync --push-only` (runSync's pushOnly branch / runPushOnly).
+//
+// --push-only is the once-per-turn realtime push used by the Stop/SubagentStop
+// hook. Unlike a full `sync` it must NEVER pull (no GET /cli-sync); unlike
+// --push-all it is hash-gated (only CHANGED files push). It is best-effort:
+// always exits 0, persists only the keys it actually pushed.
+
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runSync } from '../../src/commands/sync.js';
+import { shortHash } from '../../src/lib/files.js';
+import type { CommandContext } from '../../src/lib/context.js';
+
+function tmpProject(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mysecond-push-only-'));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  return root;
+}
+
+function ctx(rootDir: string, overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'test-key',
+    rootDir,
+    silent: true,
+    dryRun: false,
+    forceUpdate: false,
+    fix: false,
+    resume: false,
+    authOnly: false,
+    pushAll: false,
+    pushOnly: true,
+    strategy: 'cloud-wins',
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function calledPaths(fetchMock: ReturnType<typeof vi.fn>): string[] {
+  return fetchMock.mock.calls.map((c) => (c[0] as URL).pathname);
+}
+
+describe('mysecond sync --push-only', () => {
+  let originalFetch: typeof fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('pushes changed artifacts + context files and NEVER calls cli-sync (no pull)', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'company-content');
+    mkdirSync(join(root, 'work/specs/outputs'), { recursive: true });
+    writeFileSync(join(root, 'work/specs/outputs/prd.md'), 'a prd');
+
+    fetchMock.mockImplementation((url: URL) => {
+      const p = url.pathname;
+      if (p === '/api/companion/artifacts') return Promise.resolve(jsonResponse({ synced: 1 }));
+      if (p === '/api/companion/files') {
+        return Promise.resolve(jsonResponse({ synced: 1, skipped: 0, errors: [] }));
+      }
+      throw new Error(`unexpected fetch to ${p}`);
+    });
+
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+
+    const paths = calledPaths(fetchMock);
+    expect(paths).toContain('/api/companion/artifacts');
+    expect(paths).toContain('/api/companion/files');
+    // The whole point of --push-only: it must not pull.
+    expect(paths).not.toContain('/api/companion/cli-sync');
+  });
+
+  it('is incremental — skips files whose hash already matches sync-state', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    const content = 'already-synced';
+    writeFileSync(join(root, 'context/company.md'), content);
+    // Pre-seed sync-state with the matching hash → nothing to push.
+    writeFileSync(
+      join(root, '.claude/sync-state.json'),
+      JSON.stringify({
+        contextFiles: { 'context/company.md': { hash: shortHash(content), pushedAt: '2026-01-01T00:00:00Z' } },
+      }),
+    );
+
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+    // No change → no push, and never a pull.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('records pushed hashes in sync-state so the next turn skips them', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'company-content');
+    fetchMock.mockResolvedValue(jsonResponse({ synced: 1, skipped: 0, errors: [] }));
+
+    await runSync([], ctx(root));
+
+    const state = JSON.parse(readFileSync(join(root, '.claude/sync-state.json'), 'utf8'));
+    expect(state.contextFiles['context/company.md']).toBeTruthy();
+  });
+
+  it('is best-effort — returns 0 even when the push fails', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'x');
+    fetchMock.mockResolvedValue(new Response('err', { status: 500 }));
+
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+  });
+
+  it('no-op (still exit 0, no calls) when there is nothing to push', async () => {
+    const root = tmpProject();
+    const code = await runSync([], ctx(root));
+    expect(code).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/plugin-register.test.ts
+++ b/tests/lib/plugin-register.test.ts
@@ -1,0 +1,98 @@
+// Tests for registerMarketplaceAndInstall — the shared Claude Code registration
+// mechanics used by plugin-refresh. Mocks spawnSync so we can drive each outcome
+// (ENOENT / timeout / non-zero exit / success) deterministically.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({ spawnSync: vi.fn() }));
+vi.mock('node:child_process', () => ({ spawnSync: h.spawnSync }));
+
+import { registerMarketplaceAndInstall } from '../../src/lib/plugin-register.js';
+import { SENTINEL_PLUGIN_NAME, type PluginEntry } from '../../src/lib/mysecond-paths.js';
+
+type SpawnReturn = ReturnType<typeof import('node:child_process').spawnSync>;
+function ok(): Partial<SpawnReturn> {
+  return { status: 0, signal: null };
+}
+function nonZero(status = 1): Partial<SpawnReturn> {
+  return { status, signal: null };
+}
+function enoent(): Partial<SpawnReturn> {
+  return { status: null, signal: null, error: Object.assign(new Error('spawn enoent'), { code: 'ENOENT' }) };
+}
+function timedOut(): Partial<SpawnReturn> {
+  return { status: null, signal: 'SIGTERM' };
+}
+
+const sentinel = [{ name: SENTINEL_PLUGIN_NAME }] as unknown as PluginEntry[];
+function params(overrides: Partial<Parameters<typeof registerMarketplaceAndInstall>[0]> = {}) {
+  return {
+    slug: 'acme',
+    plugins: sentinel,
+    claudeBin: '/bin/claude',
+    deadlineMs: Date.now() + 30_000,
+    silent: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => h.spawnSync.mockReset());
+afterEach(() => vi.clearAllMocks());
+
+describe('registerMarketplaceAndInstall', () => {
+  it('runs marketplace remove → add → install in order and returns registered', () => {
+    h.spawnSync.mockReturnValue(ok());
+    const r = registerMarketplaceAndInstall(params());
+    expect(r.outcome.kind).toBe('registered');
+    const cmds = h.spawnSync.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(cmds[0]).toContain('marketplace remove');
+    expect(cmds[1]).toContain('marketplace add');
+    expect(cmds[2]).toContain('install');
+    // remove must come before add (idempotency contract).
+    expect(cmds[0].indexOf('remove')).toBeGreaterThanOrEqual(0);
+    expect(cmds[1].indexOf('add')).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns binary_not_found on ENOENT from marketplace add', () => {
+    h.spawnSync.mockReturnValueOnce(ok()).mockReturnValueOnce(enoent());
+    expect(registerMarketplaceAndInstall(params()).outcome.kind).toBe('binary_not_found');
+  });
+
+  it('returns timed_out when a spawn is killed by the budget (SIGTERM)', () => {
+    h.spawnSync.mockReturnValueOnce(ok()).mockReturnValueOnce(timedOut());
+    expect(registerMarketplaceAndInstall(params()).outcome.kind).toBe('timed_out');
+  });
+
+  it('returns failed when marketplace add exits non-zero', () => {
+    h.spawnSync.mockReturnValueOnce(ok()).mockReturnValueOnce(nonZero(1));
+    const r = registerMarketplaceAndInstall(params());
+    expect(r.outcome.kind).toBe('failed');
+  });
+
+  it('returns failed when the SENTINEL plugin install exits non-zero', () => {
+    h.spawnSync.mockReturnValueOnce(ok()).mockReturnValueOnce(ok()).mockReturnValueOnce(nonZero(1));
+    const r = registerMarketplaceAndInstall(params());
+    expect(r.outcome.kind).toBe('failed');
+    expect(r.failedPlugins).toContain(SENTINEL_PLUGIN_NAME);
+  });
+
+  it('tolerates a non-sentinel install failure (records it, still registered)', () => {
+    const plugins = [{ name: 'pm-extra' }, { name: SENTINEL_PLUGIN_NAME }] as unknown as PluginEntry[];
+    // remove ok, add ok, install pm-extra fails, install pm-os ok.
+    h.spawnSync
+      .mockReturnValueOnce(ok())
+      .mockReturnValueOnce(ok())
+      .mockReturnValueOnce(nonZero(1))
+      .mockReturnValueOnce(ok());
+    const r = registerMarketplaceAndInstall(params({ plugins }));
+    expect(r.outcome.kind).toBe('registered');
+    expect(r.failedPlugins).toEqual(['pm-extra']);
+  });
+
+  it('returns timed_out without spawning when the deadline already passed', () => {
+    h.spawnSync.mockReturnValue(ok());
+    const r = registerMarketplaceAndInstall(params({ deadlineMs: Date.now() - 1 }));
+    expect(r.outcome.kind).toBe('timed_out');
+    expect(h.spawnSync).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/scan-artifacts-hardening.test.ts
+++ b/tests/lib/scan-artifacts-hardening.test.ts
@@ -1,0 +1,49 @@
+// Codex blocking #1 regression: scanArtifacts must be safe to run as a per-turn
+// Stop sweep. walkArtifactDir now stats first, skips empties + anything over the
+// server's artifact cap, and catches read errors — so one giant/transient file
+// can't OOM or throw the whole `sync --push-only`.
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { scanArtifacts, ARTIFACT_PER_FILE_LIMIT } from '../../src/lib/payload.js';
+
+function tmpProject(): string {
+  return mkdtempSync(join(tmpdir(), 'mysecond-scan-'));
+}
+
+describe('scanArtifacts hardening', () => {
+  it('skips artifacts over the server size cap (OOM/stall guard)', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'work/specs/outputs'), { recursive: true });
+    writeFileSync(join(root, 'work/specs/outputs/small.md'), 'ok content');
+    writeFileSync(join(root, 'work/specs/outputs/huge.md'), 'x'.repeat(ARTIFACT_PER_FILE_LIMIT + 1));
+
+    const found = scanArtifacts(root).map((a) => a.file_path);
+    expect(found).toContain('work/specs/outputs/small.md');
+    expect(found.some((p) => p.endsWith('huge.md'))).toBe(false);
+  });
+
+  it('skips empty artifact files', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'work/specs/outputs'), { recursive: true });
+    writeFileSync(join(root, 'work/specs/outputs/empty.md'), '');
+    writeFileSync(join(root, 'work/specs/outputs/real.md'), 'content');
+
+    const found = scanArtifacts(root).map((a) => a.file_path);
+    expect(found.some((p) => p.endsWith('empty.md'))).toBe(false);
+    expect(found.some((p) => p.endsWith('real.md'))).toBe(true);
+  });
+
+  it('keeps a file exactly at the cap (boundary: skip only when strictly over)', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, 'work/specs/outputs'), { recursive: true });
+    writeFileSync(join(root, 'work/specs/outputs/atcap.md'), 'x'.repeat(ARTIFACT_PER_FILE_LIMIT));
+
+    const found = scanArtifacts(root).map((a) => a.file_path);
+    expect(found.some((p) => p.endsWith('atcap.md'))).toBe(true);
+  });
+});

--- a/tests/lib/sync-state-update.test.ts
+++ b/tests/lib/sync-state-update.test.ts
@@ -1,0 +1,79 @@
+// Tests for the installedPluginVersion field (back-compat) and updateSyncState
+// (Codex blocking #4 — safe concurrent writes). The realtime fix adds a second
+// hot writer (Stop `sync --push-only`) alongside PostToolUse `artifact-sync`;
+// both go through updateSyncState, which locks + re-reads so neither clobbers
+// the other's whole-file replacement.
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { readSyncState, updateSyncState, writeSyncState } from '../../src/lib/sync-state.js';
+
+function tmpProject(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mysecond-state-'));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  return root;
+}
+
+describe('sync-state: installedPluginVersion back-compat', () => {
+  it('defaults installedPluginVersion to null for a pre-feature state file', () => {
+    const root = tmpProject();
+    writeFileSync(
+      join(root, '.claude/sync-state.json'),
+      JSON.stringify({ customerSlug: 'acme', lastSyncedAt: 'x' }),
+    );
+    const s = readSyncState(root);
+    expect(s.installedPluginVersion).toBeNull();
+    expect(s.customerSlug).toBe('acme');
+  });
+});
+
+describe('updateSyncState (locked read-modify-write)', () => {
+  it('merges a field without dropping existing keys', async () => {
+    const root = tmpProject();
+    const s = readSyncState(root);
+    s.customerSlug = 'acme';
+    s.artifacts = { 'a.md': { hash: 'h1', pushedAt: 't' } };
+    writeSyncState(root, s);
+
+    await updateSyncState(root, (st) => {
+      st.installedPluginVersion = '1.2.0';
+    });
+
+    const out = readSyncState(root);
+    expect(out.installedPluginVersion).toBe('1.2.0');
+    expect(out.customerSlug).toBe('acme');
+    expect(out.artifacts['a.md']).toBeTruthy();
+  });
+
+  it('creates the state file when none exists yet', async () => {
+    const root = tmpProject();
+    await updateSyncState(root, (st) => {
+      st.installedPluginVersion = '9.9.9';
+    });
+    expect(readSyncState(root).installedPluginVersion).toBe('9.9.9');
+  });
+
+  it('concurrent calls do not clobber each other (Codex #4)', async () => {
+    const root = tmpProject();
+    writeSyncState(root, readSyncState(root));
+
+    await Promise.all([
+      updateSyncState(root, (st) => {
+        st.artifacts['x.md'] = { hash: 'hx', pushedAt: 't' };
+      }),
+      updateSyncState(root, (st) => {
+        st.contextFiles['y.md'] = { hash: 'hy', pushedAt: 't' };
+      }),
+    ]);
+
+    const out = readSyncState(root);
+    // Both writers' keys survive — the lock + re-read prevented a whole-file
+    // overwrite from dropping the other's mutation.
+    expect(out.artifacts['x.md']).toBeTruthy();
+    expect(out.contextFiles['y.md']).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Customer impact

On **Claude Code Desktop / npx-only installs** (the default for non-technical PMs), skill + workflow **outputs** and **context files** now sync to the mySecond app **within the turn** — no reopening Claude Code, no manual `sync --push-all`. Previously the realtime hook ran a bare `mysecond` that no-ops without a global binary, so nothing appeared until a reopen.

This is the **CLI half** (publish first; the app's `Stop`/`SubagentStop` hooks call these). Shipped to `@latest` as **1.5.0**.

## What's in it

- **`sync --push-only` + `push` subcommand** — incremental up-sync (changed artifacts + context, no pull). The realtime turn-end hook targets the `push` *subcommand* (not a flag) so an OLD CLI exits non-zero on it → the hook's `|| npx @latest` fallback fires for every install cohort.
- **`plugin-refresh`** — re-installs the latest plugin so an *already-installed* customer picks up new hooks (Claude Code caches the install + won't auto-update a local-dir marketplace). Fully degradable: any failure leaves the working install untouched and exits 0; a failed swap can't destroy the marketplace (backup-restore, not rm-then-rename).
- **`plugin-register.ts`** — shared, structured-result registration mechanics (marketplace remove→add→install) reused by `plugin-refresh`; step-9 keeps its own (init-only concerns) and shares the path/spec builders so the command contract can't drift.
- **Hardening (from review):** `scanArtifacts` is size-capped + read-error-safe for the per-turn sweep; `updateSyncState` is a locked read-modify-write (skips on contention, never unlocked-clobbers) so the Stop sweep + PostToolUse don't lose each other's hashes; `installedPluginVersion` records the *actually-installed* version.

## Files

**New:** `src/commands/plugin-refresh.ts`, `src/lib/plugin-register.ts`, `tests/commands/{plugin-refresh,sync-push-only}.test.ts`, `tests/lib/{plugin-register,scan-artifacts-hardening,sync-state-update}.test.ts`
**Modified:** `src/commands/sync.ts`, `src/commands/artifact-sync.ts`, `src/lib/{sync-state,payload,context}.ts`, `src/lib/steps/step-9.ts`, `src/index.ts`, `package.json` (→ 1.5.0)

## Reviews

- **Codex** — reviewed the plan AND the implementation diff (2 rounds). All blocking findings fixed: scanArtifacts hardening, actual-version persistence, sync-state locking, the hook-footgun (subcommand vs flag), backup-restore swap, degradable lock/cache. Each fix is regression-locked with a test.
- **PMKit CTO** — ship-ready, confidence HIGH, nothing to cut.

## Test evidence

- Full suite **537/537** (42 files), `tsc --noEmit` + `npm run build` green.
- Published **1.5.0 → `@latest`** (rc-staged first + smoke-tested via `npx @rc`: `--version`, `--help` lists `push`/`plugin-refresh`, both degrade cleanly in an empty dir).

## Known limitation (pre-existing, not a regression)

Locally hand-editing a **custom skill/workflow *definition*** file (`.claude/skills/*`, `.claude/workflows/*`) inside Claude Code on npx-only installs doesn't up-sync (it relies on the bare per-file hook). Customers customize these in the web app, which flows down fine. Clean follow-up if local definition-editing becomes a real workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
