### PR TITLE
feat(nudge): plugin-refresh nudge + contract-version reporting (v1.6.0)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,85 @@
+# Testing the mySecond CLI
+
+Most behavior is covered by `npm test` (vitest). This doc covers the things that
+**automation can't** — behaviors that depend on Claude Code's own runtime (hook
+output rendering) and therefore need a real session to confirm.
+
+---
+
+## Verify the plugin-refresh nudge
+
+The "an update to your PM OS is ready — run `plugin-refresh`" notice is printed by
+`maybePrintPluginRefreshNudge` (`src/lib/plugin-refresh-nag.ts`) from inside
+`mysecond sync`, which runs as the plugin's **SessionStart** hook.
+
+### Why this needs a manual check
+
+A SessionStart hook's **stdout** becomes the model's session-start context (Claude
+relays it to the user); its **stderr is silently dropped on exit 0**. Unit/integration
+tests assert we write to **stdout** — but only a real Claude Code session confirms
+Claude actually surfaces it. (The first version wrote to stderr and was invisible;
+nothing but a real session caught that.) So: **run the smoke test below before every
+publish to `@latest`, and after any change to the nudge or the sync hook.**
+
+### Smoke test (≈30 seconds, no 24h wait)
+
+`MYSECOND_FORCE_REFRESH_NUDGE=1` emits the nudge **unconditionally** — it skips the
+behind-check, the 24h debounce, and the silence flag, and does not mutate any real
+state. Use it to see the nudge render on demand.
+
+1. In a project that has the mySecond plugin installed, start Claude Code with the
+   env var set, e.g. launch it from a shell where:
+   ```bash
+   export MYSECOND_FORCE_REFRESH_NUDGE=1
+   ```
+2. Start a **new session** (SessionStart fires).
+3. **Confirm:** Claude's first turn surfaces the update notice (it may paraphrase —
+   it's relayed context, not a fixed banner). The literal line `mySecond: an update
+   to your PM OS is ready. …` is what Claude sees.
+4. Unset the var (`unset MYSECOND_FORCE_REFRESH_NUDGE`) and start another session →
+   confirm the nudge is **gone** (i.e. it only fires for real when actually behind).
+
+### Verify the REAL trigger path (optional, more thorough)
+
+To exercise the actual version comparison (not the force bypass):
+1. Edit `<project>/.claude/sync-state.json`: set `"installedPluginContractVersion": "0"`
+   (a value below the server's current `PLUGIN_CONTRACT_VERSION`).
+2. Start a new session → the nudge should appear (server returns a higher
+   `latest_plugin_contract_version`).
+3. Run the `plugin-refresh` command it suggests, then start a new session → the
+   nudge should be **gone** (sync-state now records the current contract version).
+4. Start one more session within 24h → still gone (24h debounce + already current).
+
+---
+
+## What the automated tests cover (so you know the gaps)
+
+`npm test` locks the logic and the wiring — these fail in CI if regressed, so you
+don't have to remember them:
+
+- `tests/lib/plugin-refresh-nag.test.ts` — the behind/not-behind decision
+  (fail-closed on null/malformed versions), the 24h debounce (timestamp-injected,
+  no waiting), the silence flag, self-persist, and the `MYSECOND_FORCE_REFRESH_NUDGE`
+  affordance.
+- `tests/lib/plugin-meta.test.ts` — reading the contract version from an installed
+  plugin's `_meta.json` (fail-safe to null on missing/garbage).
+- `tests/commands/sync-nudge.test.ts` — **end-to-end** through the real `runSync`:
+  that it reports `client_plugin_contract_version` to cli-sync, and that the nudge
+  actually lands on **stdout** (not stderr) when the server reports a newer version.
+  This is the regression guard for the channel bug.
+- `tests/lib/api.test.ts` — `cliSync` sends/omits the `client_plugin_contract_version`
+  query param.
+
+**The one thing tests cannot assert** is that Claude Code renders SessionStart-hook
+stdout to the user — that's the smoke test above. Do it before publish.
+
+---
+
+## Pre-publish checklist (CLI → `@latest`)
+
+1. `npm test` green + `npm run build` clean.
+2. App side deployed first (returns `latest_plugin_contract_version` + embeds it in
+   `_meta.json`) — the CLI nudge no-ops against an old app, but the cohort won't be
+   nudged until the app is live.
+3. **Run the nudge smoke test above in a real Claude Code session.** Confirm Claude
+   surfaces it. Do not publish on green unit tests alone.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/plugin-refresh.ts
+++ b/src/commands/plugin-refresh.ts
@@ -35,6 +35,7 @@ import {
   pluginTmpExtractDir,
   validateSlug,
 } from '../lib/mysecond-paths.js';
+import { readInstalledPluginContractVersion } from '../lib/plugin-meta.js';
 import { registerMarketplaceAndInstall } from '../lib/plugin-register.js';
 import { fetchAndExtractPlugin } from '../lib/plugin-tarball.js';
 import { readSyncState, updateSyncState } from '../lib/sync-state.js';
@@ -127,6 +128,9 @@ export async function runPluginRefresh(
     mkdirSync(tmpExtractDir, { recursive: true });
 
     await fetchAndExtractPlugin(ctx, meta, tmpTarballPath, tmpExtractDir);
+    // Byte-accurate: read the contract version from the bytes we just extracted
+    // (not the server response), so what we record == what's actually installed.
+    const installedContractVersion = readInstalledPluginContractVersion(tmpExtractDir);
     const plugins = listMarketplacePluginsFromExtractDir(tmpExtractDir);
     mkdirSync(join(tmpMarketplaceDir, '.claude-plugin'), { recursive: true });
     writeFileSync(
@@ -192,6 +196,7 @@ export async function runPluginRefresh(
       ctx.rootDir,
       (s) => {
         s.installedPluginVersion = meta.version;
+        s.installedPluginContractVersion = installedContractVersion;
         s.lastClaudeBinPath = claudeBin;
       },
       { retries: 10 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -33,6 +33,7 @@ import {
   maybePrintUpgradeNag,
   shouldRunNpmUpdate,
 } from '../lib/npm.js';
+import { maybePrintPluginRefreshNudge } from '../lib/plugin-refresh-nag.js';
 import {
   scanArtifacts,
   scanContextFiles,
@@ -797,6 +798,7 @@ export async function runSync(
       ...cliSyncOpts,
       clientBasePluginVersion: installState.base_plugin_version,
       teamId: readTeamIdFromCreds(ctx.rootDir),
+      clientPluginContractVersion: state.installedPluginContractVersion,
     });
   } catch (err) {
     const httpCode = err instanceof MysecondError ? err.exitCode : -1;
@@ -982,6 +984,15 @@ export async function runSync(
   // Called AFTER the writeSyncState above so the same persist isn't done
   // twice in the common (no-nag) case.
   maybePrintUpgradeNag(state, ctx.rootDir);
+
+  // Plugin-refresh nudge (separate axis from the npm nag above): one stderr line
+  // when the installed plugin's contract version is behind the latest the server
+  // returned. Self-persisting + 24h-debounced; reuses MYSECOND_NO_UPGRADE_NAG.
+  maybePrintPluginRefreshNudge(
+    state,
+    ctx.rootDir,
+    response.latest_plugin_contract_version ?? null
+  );
 
   // Self-heal the "duplicate skills" bug (Finding #2) for EXISTING customers.
   // step-9 (plugin install) is skipped on re-runs once the init ledger is

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -985,9 +985,11 @@ export async function runSync(
   // twice in the common (no-nag) case.
   maybePrintUpgradeNag(state, ctx.rootDir);
 
-  // Plugin-refresh nudge (separate axis from the npm nag above): one stderr line
-  // when the installed plugin's contract version is behind the latest the server
-  // returned. Self-persisting + 24h-debounced; reuses MYSECOND_NO_UPGRADE_NAG.
+  // Plugin-refresh nudge (separate axis from the npm nag above): one stdout line
+  // (SessionStart-hook stdout → the model's session-start context, which it
+  // relays; stderr would be dropped) when the installed plugin's contract version
+  // is behind the latest the server returned. Self-persisting + 24h-debounced;
+  // reuses MYSECOND_NO_UPGRADE_NAG.
   maybePrintPluginRefreshNudge(
     state,
     ctx.rootDir,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -92,6 +92,7 @@ export async function cliSync(
     timeoutMs?: number;
     clientBasePluginVersion?: string | null;
     teamId?: string | null;
+    clientPluginContractVersion?: string | null;
   } = {}
 ): Promise<CliSyncResponse> {
   const query: Record<string, string | undefined> = {};
@@ -113,6 +114,12 @@ export async function cliSync(
   // and the server treats that as "fully behind".
   if (opts.clientBasePluginVersion) {
     query['client_base_plugin_version'] = opts.clientBasePluginVersion;
+  }
+  // Report the plugin contract version we have installed (read from the
+  // installed _meta.json) so the server can log fleet visibility. Truthy guard
+  // mirrors the others — omit when null so we never send an empty param.
+  if (opts.clientPluginContractVersion) {
+    query['client_plugin_contract_version'] = opts.clientPluginContractVersion;
   }
   const response = await companionFetch(ctx, '/api/companion/cli-sync', {
     query,

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -62,6 +62,10 @@ export interface CliSyncResponse {
   // last). Absent when the server predates Track B or for legacy API keys with
   // no member identity — sync degrades gracefully to leaving the block as-is.
   resolved_imports?: string[];
+  // Latest curated plugin contract version (server code constant). Absent when
+  // the app predates this feature → the CLI no-ops the plugin-refresh nudge.
+  // Compared against sync-state.installedPluginContractVersion.
+  latest_plugin_contract_version?: string;
 }
 
 export interface ArtifactPayload {

--- a/src/lib/plugin-meta.ts
+++ b/src/lib/plugin-meta.ts
@@ -1,0 +1,25 @@
+// Read the curated plugin contract version embedded in an extracted/installed
+// plugin's `_meta.json` (the app's manifest.ts generateMetaJson writes it at the
+// plugin root; the tarball extracts with strip:0 so it sits at the extract-dir
+// root). Reading from the extracted BYTES — not a server response — guarantees
+// the version we record equals what was ACTUALLY installed, so a stale tarball
+// (built before a contract bump) is recorded as its real, older version and the
+// nudge keeps firing until the customer truly has the new bytes (no skew bug).
+//
+// Fail-safe: any problem (missing file, bad JSON, missing/blank field) → null,
+// which the nudge treats as "unknown installed version". NEVER throws —
+// recording the contract version must never break install/refresh.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function readInstalledPluginContractVersion(pluginRootDir: string): string | null {
+  try {
+    const raw = readFileSync(join(pluginRootDir, '_meta.json'), 'utf8');
+    const parsed = JSON.parse(raw) as { plugin_contract_version?: unknown };
+    const v = parsed.plugin_contract_version;
+    return typeof v === 'string' && v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/plugin-refresh-nag.ts
+++ b/src/lib/plugin-refresh-nag.ts
@@ -1,0 +1,97 @@
+// Plugin-refresh nudge — the "a plugin update is available, run plugin-refresh"
+// notice printed once per SessionStart when the installed plugin's contract
+// version is behind the latest the server returns. Mirrors npm.ts's
+// maybePrintUpgradeNag 1:1 (the CLI-self-upgrade nag) but on a DIFFERENT axis:
+// the plugin cache, not the CLI binary. See ~/.claude/plans/cryptic-puzzling-rainbow.md.
+
+import type { SyncState } from './sync-state.js';
+import { writeSyncState } from './sync-state.js';
+
+export const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Is the installed contract version behind the latest? Fail-CLOSED: any
+ * ambiguity returns false (no nudge), so a malformed value never spams.
+ *   - latest null/empty/malformed (old app, or bad new-app data) → false
+ *   - installed null (pre-feature) AND latest valid → true (behind; the nudge
+ *     itself is 24h-debounced, so it shows once/day until they refresh)
+ *   - non-positive / non-integer / non-safe-integer either side → false
+ */
+export function isPluginContractBehind(
+  installed: string | null,
+  latest: string | null | undefined
+): boolean {
+  if (latest === null || latest === undefined || latest.length === 0) return false;
+  // Validate `latest` BEFORE the null-installed branch (Codex review): a
+  // malformed latest from a new app (e.g. 'abc', '0', '1.5') must fail closed —
+  // no nudge — even for a pre-feature (installed === null) cohort install.
+  const l = Number(latest);
+  if (!Number.isSafeInteger(l) || l < 1) return false;
+  if (installed === null) return true; // pre-feature install + valid latest → behind
+  const i = Number(installed);
+  if (!Number.isSafeInteger(i) || i < 1) return false;
+  return i < l;
+}
+
+/**
+ * Write one STDOUT line if the installed plugin is behind the latest contract
+ * version. Self-persists its own 24h debounce stamp (`lastPluginRefreshPromptAt`)
+ * so a caller can't lose it. Reuses `MYSECOND_NO_UPGRADE_NAG` as the single
+ * silence knob (a customer who silenced nags wants all of them silenced).
+ *
+ * STDOUT, not stderr: this runs inside `mysecond sync` (the SessionStart hook),
+ * and a SessionStart hook's stdout becomes the model's session-start context —
+ * which the model relays to the user. stderr on exit 0 is silently dropped (see
+ * sync.ts printSummary's CAIO finding), so a stderr nudge would be invisible.
+ * The 24h debounce bounds it to one line/day; separate stamp from
+ * `lastUpgradePromptAt` (the npm nag) so the two notices don't suppress each other.
+ */
+export function maybePrintPluginRefreshNudge(
+  state: SyncState,
+  rootDir: string,
+  latestContractVersion: string | null | undefined
+): void {
+  // Test affordance: MYSECOND_FORCE_REFRESH_NUDGE=1 emits the nudge
+  // UNCONDITIONALLY (skips the behind-check, the 24h debounce, and the silence
+  // flag) and does NOT mutate the debounce stamp — so the nudge can be SEEN
+  // rendering in a real Claude Code session on demand, without waiting 24h or
+  // contriving versions. This is how we (or support) verify it end-to-end. See
+  // TESTING.md "Verify the plugin-refresh nudge".
+  const forced = process.env.MYSECOND_FORCE_REFRESH_NUDGE === '1';
+
+  if (!forced) {
+    if (process.env.MYSECOND_NO_UPGRADE_NAG === '1') return;
+    if (!isPluginContractBehind(state.installedPluginContractVersion, latestContractVersion)) {
+      return;
+    }
+    if (state.lastPluginRefreshPromptAt !== null) {
+      const last = Date.parse(state.lastPluginRefreshPromptAt);
+      if (!Number.isNaN(last) && Date.now() - last < TWENTY_FOUR_HOURS_MS) return;
+    }
+  }
+
+  // MYSECOND_NO_UPGRADE_NAG=1 still silences this (checked above) — we just don't
+  // advertise the env var in the message (cleaner for non-technical PMs; the
+  // nudge is already 24h-debounced and stops once they refresh).
+  process.stdout.write(
+    'mySecond: an update to your PM OS is ready. ' +
+      'Paste this into Claude Code to update: ' +
+      'npx -y @mysecond/cli@latest plugin-refresh --force-update ' +
+      '— then start a new session.\n'
+  );
+
+  // A forced (test) trigger must not touch the real 24h debounce state.
+  if (forced) return;
+
+  // Persist the debounce stamp (mirror maybePrintUpgradeNag): write a copy
+  // first, mutate in-memory only on success, so disk + memory stay consistent
+  // if the write fails. Best-effort — never throw.
+  const stamp = new Date().toISOString();
+  const persisted: SyncState = { ...state, lastPluginRefreshPromptAt: stamp };
+  try {
+    writeSyncState(rootDir, persisted);
+    state.lastPluginRefreshPromptAt = stamp;
+  } catch {
+    // Best-effort persistence. Leave in-memory state unchanged.
+  }
+}

--- a/src/lib/plugin-refresh-nag.ts
+++ b/src/lib/plugin-refresh-nag.ts
@@ -21,13 +21,18 @@ export function isPluginContractBehind(
   installed: string | null,
   latest: string | null | undefined
 ): boolean {
-  if (latest === null || latest === undefined || latest.length === 0) return false;
-  // Validate `latest` BEFORE the null-installed branch (Codex review): a
-  // malformed latest from a new app (e.g. 'abc', '0', '1.5') must fail closed —
-  // no nudge — even for a pre-feature (installed === null) cohort install.
+  // Runtime type-guard (Codex review): `latest`/`installed` are typed as strings,
+  // but they arrive from JSON (the cli-sync response) and sync-state.json with no
+  // runtime validation. A non-string value (the app returns `2` not `'2'`, or a
+  // corrupted state file) must fail closed — "any ambiguity returns false".
+  if (typeof latest !== 'string' || latest.length === 0) return false;
+  // Validate `latest` BEFORE the null-installed branch: a malformed latest from a
+  // new app (e.g. 'abc', '0', '1.5') must fail closed — no nudge — even for a
+  // pre-feature (installed === null) cohort install.
   const l = Number(latest);
   if (!Number.isSafeInteger(l) || l < 1) return false;
   if (installed === null) return true; // pre-feature install + valid latest → behind
+  if (typeof installed !== 'string') return false; // corrupted sync-state → fail closed
   const i = Number(installed);
   if (!Number.isSafeInteger(i) || i < 1) return false;
   return i < l;

--- a/src/lib/steps/step-9.ts
+++ b/src/lib/steps/step-9.ts
@@ -22,6 +22,7 @@ import { emitTelemetry, pluginTarball } from '../api.js';
 import { atomicRenameDir } from '../atomic-write.js';
 import { resolveClaudeBin } from '../claude-bin.js';
 import { staleCacheBanner } from '../copy.js';
+import { readInstalledPluginContractVersion } from '../plugin-meta.js';
 import { MysecondError } from '../errors.js';
 import {
   cacheLastKnownGood,
@@ -540,6 +541,12 @@ async function doStep9(
   // cached version and intentionally leaves this null, so a future refresh
   // upgrades the customer off that stale cache rather than recording it as current.
   state.installedPluginVersion = meta.version;
+  // Byte-accurate contract version from the just-installed plugin's _meta.json
+  // (same normal-success path as installedPluginVersion; LKG fallback leaves it
+  // null so a future refresh self-heals). Powers the plugin-refresh nudge.
+  state.installedPluginContractVersion = readInstalledPluginContractVersion(
+    join(marketplaceDir(slug), 'plugin')
+  );
   state.step9Auth401RetryCount = 0;
   writeSyncState(ctx.rootDir, state);
 

--- a/src/lib/sync-state.ts
+++ b/src/lib/sync-state.ts
@@ -70,6 +70,17 @@ export interface SyncState {
   // available version against this to decide whether a re-install is needed.
   // Null on installs that predate this field → treated as "refresh once".
   installedPluginVersion: string | null;
+  // Curated plugin CONTRACT version (PLUGIN_CONTRACT_VERSION) baked into the
+  // plugin the CLI ACTUALLY installed — read back from the installed plugin's
+  // _meta.json by step-9 and `plugin-refresh` (byte-accurate). Compared against
+  // the latest contract version returned by cli-sync to decide whether to nudge
+  // the user to run `plugin-refresh`. Null on pre-feature installs (→ nudged
+  // once/day until they refresh) or when the server didn't embed one.
+  installedPluginContractVersion: string | null;
+  // Debounces the plugin-refresh nudge (24h), separate from `lastUpgradePromptAt`
+  // (which debounces the npm CLI-upgrade nag) so the two notices don't suppress
+  // each other.
+  lastPluginRefreshPromptAt: string | null;
 }
 
 function freshEmptyState(): SyncState {
@@ -88,6 +99,8 @@ function freshEmptyState(): SyncState {
     lastUpgradePromptAt: null,
     lastClaudeBinPath: null,
     installedPluginVersion: null,
+    installedPluginContractVersion: null,
+    lastPluginRefreshPromptAt: null,
   };
 }
 

--- a/tests/commands/sync-nudge.test.ts
+++ b/tests/commands/sync-nudge.test.ts
@@ -1,0 +1,150 @@
+// End-to-end wiring test for the plugin-refresh nudge. Drives the REAL runSync
+// with a mocked cli-sync response and asserts the two things unit tests of the
+// nudge function alone CANNOT cover — the exact gaps that let the first version
+// ship invisible:
+//   (a) sync.ts plumbs sync-state.installedPluginContractVersion → the cli-sync
+//       query param (the report-up), and
+//   (b) the nudge actually reaches STDOUT (the SessionStart context Claude
+//       relays) — NOT stderr (which Claude Code silently drops on exit 0).
+//
+// Mirrors tests/commands/base-sync.test.ts (same runSync + fetch-mock + $HOME
+// redirect harness), in silent mode (which is how the SessionStart hook runs).
+
+import { mkdirSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runSync } from '../../src/commands/sync.js';
+import type { CommandContext } from '../../src/lib/context.js';
+import { writeSyncState, type SyncState } from '../../src/lib/sync-state.js';
+
+function tmpProject(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mysecond-sync-nudge-'));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  return root;
+}
+
+function ctx(rootDir: string): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'test-key',
+    rootDir,
+    silent: true, // silent === the SessionStart hook context
+    dryRun: false,
+    forceUpdate: false,
+    fix: false,
+    strategy: 'cloud-wins',
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function seedState(rootDir: string, partial: Partial<SyncState> = {}): void {
+  const base: SyncState = {
+    files: {},
+    artifacts: {},
+    contextFiles: {},
+    lastSyncedAt: '2026-04-29T00:00:00.000Z',
+    lastNpmUpdateAt: new Date().toISOString(), // skip the npm registry probe
+    initCompletedSteps: [],
+    step9Auth401RetryCount: 0,
+    customerId: null,
+    workspaceScope: null,
+    customerSlug: null,
+    lastKnownLatestNpmVersion: null,
+    lastUpgradePromptAt: null,
+    lastClaudeBinPath: null,
+    installedPluginVersion: null,
+    installedPluginContractVersion: null,
+    lastPluginRefreshPromptAt: null,
+  };
+  writeSyncState(rootDir, { ...base, ...partial });
+}
+
+function cliSyncBody(extra: Record<string, unknown>) {
+  return {
+    context_files: [],
+    custom_skills: [],
+    custom_agents: [],
+    custom_workflows: [],
+    base_plugin_version: 'b'.repeat(40),
+    syncedAt: new Date().toISOString(),
+    ...extra,
+  };
+}
+
+describe('plugin-refresh nudge — end-to-end via runSync', () => {
+  let originalFetch: typeof fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalHome: string | undefined;
+  let stdoutBuf: string;
+  let origStdout: typeof process.stdout.write;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    originalHome = process.env.HOME;
+    process.env.HOME = mkdtempSync(join(tmpdir(), 'mysecond-sync-nudge-home-'));
+    stdoutBuf = '';
+    origStdout = process.stdout.write.bind(process.stdout);
+    (process.stdout.write as unknown) = ((c: string | Uint8Array) => {
+      stdoutBuf += typeof c === 'string' ? c : c.toString();
+      return true;
+    }) as typeof process.stdout.write;
+    delete process.env.MYSECOND_NO_UPGRADE_NAG;
+    delete process.env.MYSECOND_FORCE_REFRESH_NUDGE;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.stdout.write = origStdout;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+  });
+
+  it('reports the installed contract version AND emits the nudge when the server reports a newer one', async () => {
+    const root = tmpProject();
+    seedState(root, { installedPluginContractVersion: '1' });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(cliSyncBody({ latest_plugin_contract_version: '2' })),
+    );
+
+    await runSync([], ctx(root));
+
+    // (a) wiring: sync.ts plumbed sync-state → the cli-sync query param.
+    const url = (fetchMock.mock.calls[0] as [URL, RequestInit])[0];
+    expect(url.pathname).toBe('/api/companion/cli-sync');
+    expect(url.searchParams.get('client_plugin_contract_version')).toBe('1');
+    // (b) the nudge reached STDOUT (the channel Claude relays at session start).
+    expect(stdoutBuf).toContain('an update to your PM OS is ready');
+    expect(stdoutBuf).toContain('plugin-refresh --force-update');
+  });
+
+  it('stays silent when already on the latest contract version', async () => {
+    const root = tmpProject();
+    seedState(root, { installedPluginContractVersion: '2' });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(cliSyncBody({ latest_plugin_contract_version: '2' })),
+    );
+
+    await runSync([], ctx(root));
+    expect(stdoutBuf).not.toContain('an update to your PM OS is ready');
+  });
+
+  it('stays silent against an old app that returns no contract version', async () => {
+    const root = tmpProject();
+    seedState(root, { installedPluginContractVersion: '1' });
+    fetchMock.mockResolvedValueOnce(jsonResponse(cliSyncBody({})));
+
+    await runSync([], ctx(root));
+    expect(stdoutBuf).not.toContain('an update to your PM OS is ready');
+  });
+});

--- a/tests/lib/api.test.ts
+++ b/tests/lib/api.test.ts
@@ -194,4 +194,20 @@ describe('cliSync — team_id query param', () => {
     expect(url.searchParams.get('previous_paths')).toBe('context/a.md,context/b.md');
     expect(url.searchParams.get('client_base_plugin_version')).toBe('sha123');
   });
+
+  it('sends client_plugin_contract_version when set', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ context_files: [], syncedAt: 'now' }));
+    await cliSync(ctx(), [], { clientPluginContractVersion: '1' });
+
+    const [url] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.searchParams.get('client_plugin_contract_version')).toBe('1');
+  });
+
+  it('omits client_plugin_contract_version when null', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ context_files: [], syncedAt: 'now' }));
+    await cliSync(ctx(), [], { clientPluginContractVersion: null });
+
+    const [url] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.searchParams.has('client_plugin_contract_version')).toBe(false);
+  });
 });

--- a/tests/lib/plugin-meta.test.ts
+++ b/tests/lib/plugin-meta.test.ts
@@ -1,0 +1,43 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { readInstalledPluginContractVersion } from '../../src/lib/plugin-meta.js';
+
+describe('readInstalledPluginContractVersion', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'mysecond-meta-'));
+  });
+
+  it('reads plugin_contract_version from _meta.json', () => {
+    writeFileSync(
+      join(dir, '_meta.json'),
+      JSON.stringify({ schema_version: '1.1', plugin_contract_version: '2' })
+    );
+    expect(readInstalledPluginContractVersion(dir)).toBe('2');
+  });
+
+  it('returns null when _meta.json is missing', () => {
+    expect(readInstalledPluginContractVersion(dir)).toBeNull();
+  });
+
+  it('returns null when the field is absent (old tarball, pre-feature)', () => {
+    writeFileSync(join(dir, '_meta.json'), JSON.stringify({ schema_version: '1.1' }));
+    expect(readInstalledPluginContractVersion(dir)).toBeNull();
+  });
+
+  it('returns null on a blank or non-string field', () => {
+    writeFileSync(join(dir, '_meta.json'), JSON.stringify({ plugin_contract_version: '' }));
+    expect(readInstalledPluginContractVersion(dir)).toBeNull();
+    writeFileSync(join(dir, '_meta.json'), JSON.stringify({ plugin_contract_version: 2 }));
+    expect(readInstalledPluginContractVersion(dir)).toBeNull();
+  });
+
+  it('returns null on malformed JSON (never throws)', () => {
+    writeFileSync(join(dir, '_meta.json'), 'not json{');
+    expect(readInstalledPluginContractVersion(dir)).toBeNull();
+  });
+});

--- a/tests/lib/plugin-refresh-nag.test.ts
+++ b/tests/lib/plugin-refresh-nag.test.ts
@@ -53,6 +53,12 @@ describe('isPluginContractBehind', () => {
     expect(isPluginContractBehind(null, '1.5')).toBe(false);
   });
 
+  it('fail-closed on non-string inputs — JSON/sync-state can lie at runtime (Codex review)', () => {
+    expect(isPluginContractBehind(null, 2 as unknown as string)).toBe(false);
+    expect(isPluginContractBehind('1', 2 as unknown as string)).toBe(false);
+    expect(isPluginContractBehind(2 as unknown as string, '3')).toBe(false);
+  });
+
   it('installed < latest → true', () => {
     expect(isPluginContractBehind('1', '2')).toBe(true);
   });
@@ -117,14 +123,27 @@ describe('maybePrintPluginRefreshNudge', () => {
     expect(stdoutBuf).not.toContain('mySecond:');
   });
 
-  it('emits one stdout line (session-start context) when behind', () => {
-    const s = mkState({ installedPluginContractVersion: '1' });
-    maybePrintPluginRefreshNudge(s, tmpRoot, '2');
-    expect(stdoutBuf).toContain('an update to your PM OS is ready');
-    expect(stdoutBuf).toContain('plugin-refresh --force-update');
-    expect(stdoutBuf).toContain('start a new session');
-    // Exactly one nudge line (count the 'mySecond:' marker).
-    expect(stdoutBuf.split('mySecond:').length - 1).toBe(1);
+  it('emits one stdout line (session-start context) when behind — and nothing on stderr', () => {
+    // Belt-and-suspenders for the channel: capture stderr too and assert the
+    // nudge does NOT also land there (Claude Code drops SessionStart stderr).
+    let stderrBuf = '';
+    const origErr = process.stderr.write.bind(process.stderr);
+    (process.stderr.write as unknown) = ((c: string | Uint8Array) => {
+      stderrBuf += typeof c === 'string' ? c : c.toString();
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const s = mkState({ installedPluginContractVersion: '1' });
+      maybePrintPluginRefreshNudge(s, tmpRoot, '2');
+      expect(stdoutBuf).toContain('an update to your PM OS is ready');
+      expect(stdoutBuf).toContain('plugin-refresh --force-update');
+      expect(stdoutBuf).toContain('start a new session');
+      // Exactly one nudge line (count the 'mySecond:' marker).
+      expect(stdoutBuf.split('mySecond:').length - 1).toBe(1);
+      expect(stderrBuf).not.toContain('mySecond:');
+    } finally {
+      process.stderr.write = origErr;
+    }
   });
 
   it('nudges a null-installed (pre-feature cohort) customer', () => {

--- a/tests/lib/plugin-refresh-nag.test.ts
+++ b/tests/lib/plugin-refresh-nag.test.ts
@@ -1,0 +1,193 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  isPluginContractBehind,
+  maybePrintPluginRefreshNudge,
+  TWENTY_FOUR_HOURS_MS,
+} from '../../src/lib/plugin-refresh-nag.js';
+import { readSyncState, writeSyncState, type SyncState } from '../../src/lib/sync-state.js';
+
+// Structurally-complete SyncState (mirrors npm.test.ts's nagState) so reads of
+// other fields never get undefined.
+function mkState(overrides: Partial<SyncState> = {}): SyncState {
+  return {
+    files: {},
+    artifacts: {},
+    contextFiles: {},
+    lastSyncedAt: null,
+    lastNpmUpdateAt: null,
+    initCompletedSteps: [],
+    step9Auth401RetryCount: 0,
+    customerId: null,
+    workspaceScope: null,
+    customerSlug: null,
+    lastKnownLatestNpmVersion: null,
+    lastUpgradePromptAt: null,
+    lastClaudeBinPath: null,
+    installedPluginVersion: null,
+    installedPluginContractVersion: null,
+    lastPluginRefreshPromptAt: null,
+    ...overrides,
+  };
+}
+
+describe('isPluginContractBehind', () => {
+  it('null/empty latest (old app) → false', () => {
+    expect(isPluginContractBehind('1', null)).toBe(false);
+    expect(isPluginContractBehind('1', undefined)).toBe(false);
+    expect(isPluginContractBehind('1', '')).toBe(false);
+  });
+
+  it('null installed (pre-feature) → true when latest is a valid positive int', () => {
+    expect(isPluginContractBehind(null, '1')).toBe(true);
+  });
+
+  it('fail-closed for a null install when latest is malformed (Codex review)', () => {
+    expect(isPluginContractBehind(null, 'abc')).toBe(false);
+    expect(isPluginContractBehind(null, '0')).toBe(false);
+    expect(isPluginContractBehind(null, '-1')).toBe(false);
+    expect(isPluginContractBehind(null, '1.5')).toBe(false);
+  });
+
+  it('installed < latest → true', () => {
+    expect(isPluginContractBehind('1', '2')).toBe(true);
+  });
+
+  it('installed == latest → false', () => {
+    expect(isPluginContractBehind('2', '2')).toBe(false);
+  });
+
+  it('installed > latest → false (post-refresh / pinned ahead)', () => {
+    expect(isPluginContractBehind('3', '2')).toBe(false);
+  });
+
+  it('fail-closed on decimal / non-numeric / non-positive', () => {
+    expect(isPluginContractBehind('1.5', '2')).toBe(false);
+    expect(isPluginContractBehind('abc', '2')).toBe(false);
+    expect(isPluginContractBehind('1', 'abc')).toBe(false);
+    expect(isPluginContractBehind('0', '2')).toBe(false);
+    expect(isPluginContractBehind('-1', '2')).toBe(false);
+  });
+});
+
+describe('maybePrintPluginRefreshNudge', () => {
+  let stdoutBuf: string;
+  let origWrite: typeof process.stdout.write;
+  let tmpRoot: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    // The nudge writes to STDOUT (not stderr): a SessionStart hook's stdout
+    // becomes the model's session-start context, which it relays to the user —
+    // stderr on exit 0 is silently dropped (sync.ts printSummary CAIO finding).
+    stdoutBuf = '';
+    origWrite = process.stdout.write.bind(process.stdout);
+    (process.stdout.write as unknown) = ((chunk: string | Uint8Array) => {
+      stdoutBuf += typeof chunk === 'string' ? chunk : chunk.toString();
+      return true;
+    }) as typeof process.stdout.write;
+    tmpRoot = mkdtempSync(join(tmpdir(), 'mysecond-prnag-'));
+    savedEnv = process.env.MYSECOND_NO_UPGRADE_NAG;
+    delete process.env.MYSECOND_NO_UPGRADE_NAG;
+    delete process.env.MYSECOND_FORCE_REFRESH_NUDGE;
+  });
+
+  afterEach(() => {
+    process.stdout.write = origWrite;
+    if (savedEnv === undefined) delete process.env.MYSECOND_NO_UPGRADE_NAG;
+    else process.env.MYSECOND_NO_UPGRADE_NAG = savedEnv;
+  });
+
+  // Marker-based assertions: every nudge line starts with 'mySecond:', so an
+  // incidental stdout write from the runner can't pollute the result.
+  it('emits nothing when not behind (installed == latest)', () => {
+    const s = mkState({ installedPluginContractVersion: '1' });
+    maybePrintPluginRefreshNudge(s, tmpRoot, '1');
+    expect(stdoutBuf).not.toContain('mySecond:');
+    expect(s.lastPluginRefreshPromptAt).toBeNull();
+  });
+
+  it('emits nothing when latest is null (old app)', () => {
+    const s = mkState({ installedPluginContractVersion: '1' });
+    maybePrintPluginRefreshNudge(s, tmpRoot, null);
+    expect(stdoutBuf).not.toContain('mySecond:');
+  });
+
+  it('emits one stdout line (session-start context) when behind', () => {
+    const s = mkState({ installedPluginContractVersion: '1' });
+    maybePrintPluginRefreshNudge(s, tmpRoot, '2');
+    expect(stdoutBuf).toContain('an update to your PM OS is ready');
+    expect(stdoutBuf).toContain('plugin-refresh --force-update');
+    expect(stdoutBuf).toContain('start a new session');
+    // Exactly one nudge line (count the 'mySecond:' marker).
+    expect(stdoutBuf.split('mySecond:').length - 1).toBe(1);
+  });
+
+  it('nudges a null-installed (pre-feature cohort) customer', () => {
+    const s = mkState({ installedPluginContractVersion: null });
+    maybePrintPluginRefreshNudge(s, tmpRoot, '1');
+    expect(stdoutBuf).toContain('an update to your PM OS is ready');
+  });
+
+  it('stamps lastPluginRefreshPromptAt and persists to disk', () => {
+    const s = mkState({ installedPluginContractVersion: '1' });
+    writeSyncState(tmpRoot, s);
+    maybePrintPluginRefreshNudge(s, tmpRoot, '2');
+    expect(s.lastPluginRefreshPromptAt).not.toBeNull();
+    expect(readSyncState(tmpRoot).lastPluginRefreshPromptAt).toBe(s.lastPluginRefreshPromptAt);
+  });
+
+  it('honors MYSECOND_NO_UPGRADE_NAG=1', () => {
+    process.env.MYSECOND_NO_UPGRADE_NAG = '1';
+    const s = mkState({ installedPluginContractVersion: '1' });
+    maybePrintPluginRefreshNudge(s, tmpRoot, '2');
+    expect(stdoutBuf).not.toContain('mySecond:');
+    expect(s.lastPluginRefreshPromptAt).toBeNull();
+  });
+
+  it('debounces within 24h', () => {
+    const recent = new Date(Date.now() - 1000).toISOString();
+    const s = mkState({ installedPluginContractVersion: '1', lastPluginRefreshPromptAt: recent });
+    maybePrintPluginRefreshNudge(s, tmpRoot, '2');
+    expect(stdoutBuf).not.toContain('mySecond:');
+  });
+
+  it('re-emits after the 24h debounce expires', () => {
+    const old = new Date(Date.now() - TWENTY_FOUR_HOURS_MS - 1000).toISOString();
+    const s = mkState({ installedPluginContractVersion: '1', lastPluginRefreshPromptAt: old });
+    maybePrintPluginRefreshNudge(s, tmpRoot, '2');
+    expect(stdoutBuf).toContain('an update to your PM OS is ready');
+  });
+
+  it('leaves in-memory state untouched when disk persist fails (no truth split)', () => {
+    const blockedRoot = join(tmpRoot, 'blocked');
+    writeFileSync(blockedRoot, 'not-a-directory');
+    const s = mkState({ installedPluginContractVersion: '1' });
+    maybePrintPluginRefreshNudge(s, blockedRoot, '2');
+    expect(stdoutBuf).toContain('an update to your PM OS is ready');
+    expect(s.lastPluginRefreshPromptAt).toBeNull();
+  });
+
+  // Test affordance: MYSECOND_FORCE_REFRESH_NUDGE=1 lets us SEE the nudge render
+  // in a real session on demand — no 24h wait, no contrived versions.
+  it('MYSECOND_FORCE_REFRESH_NUDGE=1 emits even when NOT behind, without persisting the debounce stamp', () => {
+    process.env.MYSECOND_FORCE_REFRESH_NUDGE = '1';
+    const s = mkState({ installedPluginContractVersion: '2' }); // not behind
+    maybePrintPluginRefreshNudge(s, tmpRoot, '2');
+    expect(stdoutBuf).toContain('an update to your PM OS is ready');
+    // Forced trigger must not mutate the real 24h debounce state.
+    expect(s.lastPluginRefreshPromptAt).toBeNull();
+  });
+
+  it('MYSECOND_FORCE_REFRESH_NUDGE=1 emits even with null latest and inside the 24h debounce', () => {
+    process.env.MYSECOND_FORCE_REFRESH_NUDGE = '1';
+    const recent = new Date(Date.now() - 1000).toISOString();
+    const s = mkState({ installedPluginContractVersion: '1', lastPluginRefreshPromptAt: recent });
+    maybePrintPluginRefreshNudge(s, tmpRoot, null);
+    expect(stdoutBuf).toContain('an update to your PM OS is ready');
+  });
+});

--- a/tests/lib/sync-state-contract-fields.test.ts
+++ b/tests/lib/sync-state-contract-fields.test.ts
@@ -1,0 +1,40 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { projectPaths } from '../../src/lib/files.js';
+import { readSyncState, writeSyncState } from '../../src/lib/sync-state.js';
+
+describe('sync-state contract-version fields (back-compat + round-trip)', () => {
+  it('defaults new fields to null when reading an old-shape state file', () => {
+    const root = mkdtempSync(join(tmpdir(), 'mysecond-ss-'));
+    const p = projectPaths(root).syncStatePath;
+    mkdirSync(dirname(p), { recursive: true });
+    // Old file with NO installedPluginContractVersion / lastPluginRefreshPromptAt.
+    writeFileSync(
+      p,
+      JSON.stringify({ customerSlug: 'acme', installedPluginVersion: '1.123.0' })
+    );
+
+    const s = readSyncState(root);
+    expect(s.installedPluginContractVersion).toBeNull();
+    expect(s.lastPluginRefreshPromptAt).toBeNull();
+    // Existing fields still read through.
+    expect(s.customerSlug).toBe('acme');
+    expect(s.installedPluginVersion).toBe('1.123.0');
+  });
+
+  it('round-trips the new fields', () => {
+    const root = mkdtempSync(join(tmpdir(), 'mysecond-ss-'));
+    const s = readSyncState(root);
+    s.installedPluginContractVersion = '2';
+    s.lastPluginRefreshPromptAt = '2026-05-29T00:00:00.000Z';
+    writeSyncState(root, s);
+
+    const back = readSyncState(root);
+    expect(back.installedPluginContractVersion).toBe('2');
+    expect(back.lastPluginRefreshPromptAt).toBe('2026-05-29T00:00:00.000Z');
+  });
+});


### PR DESCRIPTION
## Customer impact

On Claude Code SessionStart, if a customer's installed plugin is behind on **hooks** (a refresh-worthy change), Claude relays a one-line notice: *"an update to your PM OS is ready — paste `npx -y @mysecond/cli@latest plugin-refresh --force-update` and start a new session."* At most once per 24h, and it stops once they refresh. **Only fires when a refresh actually matters** — never on routine content updates. For the current cohort (no contract version recorded yet), this one nudge delivers the realtime-sync hooks.

## How it surfaces (important nuance)

It writes to **stdout** from the SessionStart hook, which becomes the model's session-start context — Claude relays it (it's not a fixed UI banner, and may be paraphrased). **stderr would be silently dropped on exit 0** (Claude Code behavior, confirmed by a hooks review *and* the existing `CAIO finding` comment in our own `sync.ts`). The first cut wrote to stderr and would have been invisible; this is fixed and **locked by an end-to-end test**.

## What's in it (CLI half; pairs with app PR #341)

- **`plugin-refresh-nag.ts` (NEW):** `isPluginContractBehind` (fail-closed positive-safe-int compare — validates `latest` before the null-installed branch, per Codex) + `maybePrintPluginRefreshNudge` (stdout, 24h debounce, `MYSECOND_NO_UPGRADE_NAG` silence, self-persist). **`MYSECOND_FORCE_REFRESH_NUDGE=1`** emits unconditionally — a test affordance to verify rendering on demand.
- **`plugin-meta.ts` (NEW):** byte-accurate read of `plugin_contract_version` from the installed plugin's `_meta.json` (fail-safe → null). Recording from the bytes (not a server response) is why a stale tarball can't suppress the nudge.
- **`sync-state.ts`:** `+ installedPluginContractVersion + lastPluginRefreshPromptAt` (default null; back-compat automatic).
- **`step-9.ts` + `plugin-refresh.ts`:** record the contract version from the extracted `_meta.json` (normal-success path only).
- **`api.cliSync` + `sync.ts`:** report `client_plugin_contract_version` up (fleet-visibility log, no DB) + call the nudge after the npm nag.
- **`payload.ts`:** `CliSyncResponse += latest_plugin_contract_version`.
- **`TESTING.md` (NEW):** manual smoke-test recipe + pre-publish checklist.
- **`package.json`:** 1.5.0 → **1.6.0**.

## Testing (built to not silently rot)

- **Logic (unit):** behind/not-behind/null/old-app/malformed; 24h debounce via injected timestamps (no waiting); silence flag; force affordance. (nag 18, meta 5, sync-state 2, api 2)
- **Wiring + channel (end-to-end):** `tests/commands/sync-nudge.test.ts` drives the **real `runSync`** and asserts it (a) reports the param and (b) lands the nudge on **stdout** — so the invisible-nudge regression is now a **red build**, not a thing to remember. (3)
- **The one thing automation can't check** — that Claude renders it — is a 30-second smoke test via `MYSECOND_FORCE_REFRESH_NUDGE=1`, documented in `TESTING.md`. **Required before publish.**
- Full suite **567 green**; `tsc` + `npm run build` clean.

## Degradability

Old app (no `latest`, no `_meta` field) → no nudge, recorded null, param ignored. No crash either direction. **Requires app PR #341 deployed before publishing to `@latest`.**

## Reviews

Codex reviewed the diff (caught + fixed a fail-closed compare bug); PMKit CTO reviewed the plan. Final Codex pass on this diff is the merge gate.

## Rollout

1. Merge app #341 → deploy.
2. **Run the `TESTING.md` smoke test in a real Claude Code session** (do not ship on green unit tests alone).
3. Publish CLI to `@latest`. Cohort gets nudged automatically next SessionStart; also email the 4-5 paying customers directly (per plan).

## Follow-up flagged

The existing npm-upgrade nag (`npm.ts`) has the same stderr bug (invisible at SessionStart) — low impact (npx installs auto-update the CLI), spun out as a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
