### PR TITLE
fix(nudge): route plugin-refresh nudge through SessionStart systemMessage

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -33,7 +33,7 @@ import {
   maybePrintUpgradeNag,
   shouldRunNpmUpdate,
 } from '../lib/npm.js';
-import { maybePrintPluginRefreshNudge } from '../lib/plugin-refresh-nag.js';
+import { resolvePluginRefreshNudge } from '../lib/plugin-refresh-nag.js';
 import {
   scanArtifacts,
   scanContextFiles,
@@ -412,13 +412,20 @@ async function upSyncContextFiles(
   return result.synced;
 }
 
-function printSummary(summary: SyncSummary, ctx: CommandContext): void {
-  // CAIO finding: stderr from SessionStart hooks is silently dropped on exit 0.
-  // Customer-relevant messages MUST go to stdout when ctx.silent so Claude sees
-  // them as session-start context and can mention them to the customer.
-  const out = ctx.silent ? process.stdout : process.stdout;
-
+function printSummary(
+  summary: SyncSummary,
+  ctx: CommandContext,
+  pluginRefreshNudge: string | null = null,
+): void {
   if (ctx.silent) {
+    // SessionStart-hook output protocol. The hook's stdout is parsed as JSON, so
+    // route notices by audience: top-level `systemMessage` is shown DIRECTLY to
+    // the user by Claude Code; `hookSpecificOutput.additionalContext` is a system
+    // reminder Claude reads but the user doesn't see. Plain stdout would ALL become
+    // additionalContext (and stderr on exit 0 is dropped) — neither reliably reaches
+    // the user — so the plugin-refresh nudge MUST ride in systemMessage. Verified
+    // against code.claude.com/docs/en/hooks.
+    const summaryLines: string[] = [];
     const parts: string[] = [];
     const contextChanges =
       summary.created + summary.updatedFromCloud + summary.conflictsCloudKept;
@@ -432,12 +439,11 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
       summary.conflictsCloudKept + summary.conflictsLocalKept + summary.conflictsSkipped;
     if (conflicts > 0) parts.push(`${conflicts} conflicts (see .claude/sync-conflicts/)`);
     if (parts.length > 0) {
-      out.write(`mysecond: ${parts.join(', ')}\n`);
+      summaryLines.push(`mysecond: ${parts.join(', ')}`);
     }
-    // Workstream H: separate one-liner for base plugin updates so Claude (which
-    // reads this as session-start context) clearly distinguishes "your customs
-    // synced" from "mySecond shipped improvements." Customizations skipped
-    // silently — never mentioned. Link to /changelog so the customer can dig in.
+    // Workstream H: base-plugin updates as a distinct line so Claude (which reads
+    // additionalContext) can distinguish "your customs synced" from "mySecond
+    // shipped improvements." Link to /changelog so the customer can dig in.
     const baseTotal =
       summary.baseSkillsUpdated + summary.baseAgentsUpdated + summary.baseWorkflowsUpdated;
     if (baseTotal > 0) {
@@ -445,19 +451,35 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
       if (summary.baseSkillsUpdated > 0) baseParts.push(`${summary.baseSkillsUpdated} skills`);
       if (summary.baseAgentsUpdated > 0) baseParts.push(`${summary.baseAgentsUpdated} agents`);
       if (summary.baseWorkflowsUpdated > 0) baseParts.push(`${summary.baseWorkflowsUpdated} workflows`);
-      // Tag the new base SHA — this is the signal for spotting a base-SHA
-      // shift between sessions (a multi-session workflow can otherwise observe
-      // steps written by different base versions with no way to tell).
       const baseTag = summary.basePluginVersion
         ? ` (base ${summary.basePluginVersion.slice(0, 7)})`
         : '';
-      out.write(
-        `mysecond: ${baseParts.join(', ')} updated${baseTag} — see https://app.mysecond.ai/changelog\n`,
+      summaryLines.push(
+        `mysecond: ${baseParts.join(', ')} updated${baseTag} — see https://app.mysecond.ai/changelog`,
       );
+    }
+
+    const additionalContext = summaryLines.join('\n');
+    const payload: {
+      systemMessage?: string;
+      hookSpecificOutput: { hookEventName: 'SessionStart'; additionalContext?: string };
+    } = { hookSpecificOutput: { hookEventName: 'SessionStart' } };
+    if (additionalContext.length > 0) {
+      payload.hookSpecificOutput.additionalContext = additionalContext;
+    }
+    if (pluginRefreshNudge) payload.systemMessage = pluginRefreshNudge;
+    // Emit the single hook-protocol JSON object only when there's something to
+    // say — otherwise stay quiet so SessionStart isn't noisy.
+    if (
+      payload.systemMessage !== undefined ||
+      payload.hookSpecificOutput.additionalContext !== undefined
+    ) {
+      process.stdout.write(JSON.stringify(payload) + '\n');
     }
     return;
   }
 
+  const out = process.stdout;
   const parts: string[] = [];
   if (summary.created) parts.push(`${summary.created} new`);
   if (summary.updatedFromCloud) parts.push(`${summary.updatedFromCloud} updated`);
@@ -494,6 +516,12 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
     summary.baseWorkflowsUpdated > 0
   ) {
     out.write(`  See what changed: https://app.mysecond.ai/changelog\n`);
+  }
+
+  // Interactive `mysecond sync`: print the nudge as a plain line (the terminal is
+  // user-visible here; the JSON `systemMessage` protocol is only for the hook).
+  if (pluginRefreshNudge) {
+    out.write(`${pluginRefreshNudge}\n`);
   }
 }
 
@@ -985,12 +1013,12 @@ export async function runSync(
   // twice in the common (no-nag) case.
   maybePrintUpgradeNag(state, ctx.rootDir);
 
-  // Plugin-refresh nudge (separate axis from the npm nag above): one stdout line
-  // (SessionStart-hook stdout → the model's session-start context, which it
-  // relays; stderr would be dropped) when the installed plugin's contract version
-  // is behind the latest the server returned. Self-persisting + 24h-debounced;
-  // reuses MYSECOND_NO_UPGRADE_NAG.
-  maybePrintPluginRefreshNudge(
+  // Plugin-refresh nudge: resolve the text now (this persists the 24h debounce
+  // stamp + honors force/silence), but DON'T emit here — printSummary emits it
+  // below on the right channel. In the SessionStart hook (silent) it rides in the
+  // hook JSON's top-level `systemMessage`, which Claude Code shows to the USER
+  // directly (plain stdout → additionalContext, which the user never reliably sees).
+  const pluginRefreshNudge = resolvePluginRefreshNudge(
     state,
     ctx.rootDir,
     response.latest_plugin_contract_version ?? null
@@ -1028,6 +1056,6 @@ export async function runSync(
     await confirmFirstSetup(ctx);
   }
 
-  printSummary(summary, ctx);
+  printSummary(summary, ctx, pluginRefreshNudge);
   return 0;
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -94,6 +94,12 @@ interface SyncSummary {
   // substitute for version pinning, and the signal for spotting a base-SHA
   // shift mid-workflow. Null when the server didn't return one this round.
   basePluginVersion: string | null;
+  // Per-file conflict notices collected during the down-sync. In silent mode
+  // (SessionStart hook) these are NOT written to stdout directly — that would
+  // corrupt the single hook-JSON object and drop the systemMessage nudge.
+  // printSummary folds them into `additionalContext` instead. Empty in TTY mode
+  // (there, resolveConflict writes them straight to stderr in real time).
+  conflictNotices: string[];
 }
 
 function emptySummary(): SyncSummary {
@@ -118,6 +124,7 @@ function emptySummary(): SyncSummary {
     baseWorkflowsUpdated: 0,
     baseSkippedDueToCustomization: 0,
     basePluginVersion: null,
+    conflictNotices: [],
   };
 }
 
@@ -458,6 +465,11 @@ function printSummary(
         `mysecond: ${baseParts.join(', ')} updated${baseTag} — see https://app.mysecond.ai/changelog`,
       );
     }
+    // Per-file conflict notices collected during the down-sync (resolveConflict
+    // pushed them here instead of writing stdout, so this stays one JSON object).
+    // They share additionalContext's model-relayed audience — same as before this
+    // refactor, when silent stdout became additionalContext wholesale.
+    for (const notice of summary.conflictNotices) summaryLines.push(notice);
 
     const additionalContext = summaryLines.join('\n');
     const payload: {
@@ -862,7 +874,14 @@ export async function runSync(
   // work/* and decisions/* alongside context/*).
   for (const file of contextFiles) {
     const localContent = readLocalFile(ctx.rootDir, file.file_path);
-    const outcome = resolveConflict({ file, localContent, syncState: state, ctx });
+    // Pass summary.conflictNotices as the sink: in silent mode the per-file
+    // conflict notice is collected here (folded into the hook JSON's
+    // additionalContext by printSummary) instead of being written to stdout,
+    // which would corrupt the single-JSON-object the nudge rides in.
+    const outcome = resolveConflict(
+      { file, localContent, syncState: state, ctx },
+      summary.conflictNotices
+    );
     tally(summary, outcome);
   }
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1032,17 +1032,6 @@ export async function runSync(
   // twice in the common (no-nag) case.
   maybePrintUpgradeNag(state, ctx.rootDir);
 
-  // Plugin-refresh nudge: resolve the text now (this persists the 24h debounce
-  // stamp + honors force/silence), but DON'T emit here — printSummary emits it
-  // below on the right channel. In the SessionStart hook (silent) it rides in the
-  // hook JSON's top-level `systemMessage`, which Claude Code shows to the USER
-  // directly (plain stdout → additionalContext, which the user never reliably sees).
-  const pluginRefreshNudge = resolvePluginRefreshNudge(
-    state,
-    ctx.rootDir,
-    response.latest_plugin_contract_version ?? null
-  );
-
   // Self-heal the "duplicate skills" bug (Finding #2) for EXISTING customers.
   // step-9 (plugin install) is skipped on re-runs once the init ledger is
   // complete, so a customer who onboarded during the 2026-05-04→05
@@ -1074,6 +1063,23 @@ export async function runSync(
   if (wasFirstSync) {
     await confirmFirstSetup(ctx);
   }
+
+  // Plugin-refresh nudge — resolved LAST, immediately before printSummary emits
+  // it. resolvePluginRefreshNudge persists the 24h debounce stamp as a side
+  // effect, so it MUST sit adjacent to the emission. Resolving it earlier (before
+  // the best-effort pruneStalePlugins, which can block for minutes on `claude
+  // plugin uninstall` subprocesses) opened a window where a SessionStart-hook
+  // timeout could kill the process AFTER the stamp was written but BEFORE the
+  // nudge was shown — suppressing it for 24h with the user never seeing it
+  // (Codex P2). Now a kill during the slow cleanup persists neither, so the next
+  // session simply re-nudges. In the silent hook the nudge rides in the hook
+  // JSON's top-level `systemMessage` (user-visible); plain stdout becomes
+  // additionalContext, which the user never reliably sees.
+  const pluginRefreshNudge = resolvePluginRefreshNudge(
+    state,
+    ctx.rootDir,
+    response.latest_plugin_contract_version ?? null
+  );
 
   printSummary(summary, ctx, pluginRefreshNudge);
   return 0;

--- a/src/lib/conflict.ts
+++ b/src/lib/conflict.ts
@@ -6,9 +6,13 @@
 // CLAUDE.md @import breadcrumb) deferred until customer feedback demands it.
 //
 // CAIO finding (PR 4b review): stderr from SessionStart hooks is silently
-// dropped on exit 0. Conflict notifications must go to STDOUT in --silent mode
-// so Claude sees them as session-start context and can mention them to the
-// customer. TTY (terminal) keeps stderr where it's visible directly.
+// dropped on exit 0, so conflict notices must reach Claude via the hook's
+// stdout. But that stdout has to be a SINGLE JSON object (it now carries the
+// user-facing plugin-refresh nudge in `systemMessage`), so in --silent mode the
+// notices are collected into a sink and folded into the hook JSON's
+// `additionalContext` by printSummary — NOT written to stdout directly (a bare
+// line would corrupt the JSON and drop the nudge). TTY mode keeps stderr, where
+// the customer sees them directly. See `emitNotice`.
 
 import { mkdirSync } from 'node:fs';
 import { join } from 'node:path';
@@ -79,14 +83,29 @@ function recordSyncedFile(
   };
 }
 
-function emitNotice(message: string, ctx: CommandContext): void {
-  // CAIO: stdout in silent mode (SessionStart hook) so Claude reads it as
-  // session-start context. Stderr in TTY mode where the customer sees it.
+function emitNotice(message: string, ctx: CommandContext, sink?: string[]): void {
+  // In silent mode (SessionStart hook) the hook's stdout must be a SINGLE JSON
+  // object — printSummary emits it, routing the user-facing plugin-refresh nudge
+  // to the top-level `systemMessage`. A bare plain-text line here would corrupt
+  // that payload (stdout would no longer parse as one JSON object) and the nudge
+  // would be silently dropped. So collect the notice into the caller's sink;
+  // printSummary folds it into the hook JSON's `additionalContext` — the SAME
+  // model-relayed audience these notices had before (silent stdout → context).
+  // In TTY mode there's no JSON envelope, so write straight to stderr where the
+  // customer sees it directly. The silent-without-sink branch is a safe fallback
+  // (no current caller hits it; resolveConflict's sole caller passes a sink).
+  if (ctx.silent && sink) {
+    sink.push(message);
+    return;
+  }
   const stream = ctx.silent ? process.stdout : process.stderr;
   stream.write(message + '\n');
 }
 
-export function resolveConflict(input: SyncContextFileInput): ConflictOutcome {
+export function resolveConflict(
+  input: SyncContextFileInput,
+  notices?: string[]
+): ConflictOutcome {
   const { file, localContent, syncState, ctx } = input;
   const { conflictsDir } = projectPaths(ctx.rootDir);
   const nowIso = new Date().toISOString();
@@ -141,7 +160,8 @@ export function resolveConflict(input: SyncContextFileInput): ConflictOutcome {
     writeLocalFile(conflictsDir, `${safeName}-cloud-${stamp}.md`, file.content);
     emitNotice(
       `Conflict in ${file.file_path} — skipped. Cloud version saved to ${cloudBackup}`,
-      ctx
+      ctx,
+      notices
     );
     return { kind: 'conflict-skipped' };
   }
@@ -152,7 +172,8 @@ export function resolveConflict(input: SyncContextFileInput): ConflictOutcome {
     recordSyncedFile(syncState, file.file_path, localContent, file.current_hash, nowIso);
     emitNotice(
       `Conflict in ${file.file_path} — kept local. Cloud version saved to ${cloudBackup}`,
-      ctx
+      ctx,
+      notices
     );
     return { kind: 'conflict-local-kept', backupPath: cloudBackup };
   }
@@ -166,7 +187,8 @@ export function resolveConflict(input: SyncContextFileInput): ConflictOutcome {
   recordSyncedFile(syncState, file.file_path, file.content, file.current_hash, nowIso);
   emitNotice(
     `Conflict in ${file.file_path} — kept cloud version (your local edits saved to ${localBackup})`,
-    ctx
+    ctx,
+    notices
   );
   return { kind: 'conflict-cloud-kept', writtenPath: file.file_path, backupPath: localBackup };
 }

--- a/src/lib/plugin-refresh-nag.ts
+++ b/src/lib/plugin-refresh-nag.ts
@@ -39,64 +39,64 @@ export function isPluginContractBehind(
 }
 
 /**
- * Write one STDOUT line if the installed plugin is behind the latest contract
- * version. Self-persists its own 24h debounce stamp (`lastPluginRefreshPromptAt`)
- * so a caller can't lose it. Reuses `MYSECOND_NO_UPGRADE_NAG` as the single
- * silence knob (a customer who silenced nags wants all of them silenced).
+ * Decide whether to show the plugin-refresh nudge; return its text if so, else
+ * null. Self-persists the 24h debounce stamp (`lastPluginRefreshPromptAt`) when it
+ * decides to show, and reuses `MYSECOND_NO_UPGRADE_NAG` as the single silence knob.
  *
- * STDOUT, not stderr: this runs inside `mysecond sync` (the SessionStart hook),
- * and a SessionStart hook's stdout becomes the model's session-start context —
- * which the model relays to the user. stderr on exit 0 is silently dropped (see
- * sync.ts printSummary's CAIO finding), so a stderr nudge would be invisible.
- * The 24h debounce bounds it to one line/day; separate stamp from
- * `lastUpgradePromptAt` (the npm nag) so the two notices don't suppress each other.
+ * Returns the text rather than printing it because the CALLER routes it to the
+ * right channel. In the SessionStart hook (silent) it must go in the hook JSON's
+ * TOP-LEVEL `systemMessage`, which Claude Code renders DIRECTLY to the user. Plain
+ * stdout becomes `additionalContext` — a system reminder Claude reads but the user
+ * never reliably sees (verified against the Claude Code hooks docs) — and stderr on
+ * exit 0 is dropped outright. Two earlier cuts (stderr, then stdout) were therefore
+ * invisible to customers. Separate debounce stamp from `lastUpgradePromptAt` (the
+ * npm nag) so the two notices don't suppress each other.
  */
-export function maybePrintPluginRefreshNudge(
+export function resolvePluginRefreshNudge(
   state: SyncState,
   rootDir: string,
   latestContractVersion: string | null | undefined
-): void {
-  // Test affordance: MYSECOND_FORCE_REFRESH_NUDGE=1 emits the nudge
+): string | null {
+  // Test affordance: MYSECOND_FORCE_REFRESH_NUDGE=1 returns the nudge
   // UNCONDITIONALLY (skips the behind-check, the 24h debounce, and the silence
   // flag) and does NOT mutate the debounce stamp — so the nudge can be SEEN
   // rendering in a real Claude Code session on demand, without waiting 24h or
-  // contriving versions. This is how we (or support) verify it end-to-end. See
-  // TESTING.md "Verify the plugin-refresh nudge".
+  // contriving versions. See TESTING.md "Verify the plugin-refresh nudge".
   const forced = process.env.MYSECOND_FORCE_REFRESH_NUDGE === '1';
 
   if (!forced) {
-    if (process.env.MYSECOND_NO_UPGRADE_NAG === '1') return;
+    if (process.env.MYSECOND_NO_UPGRADE_NAG === '1') return null;
     if (!isPluginContractBehind(state.installedPluginContractVersion, latestContractVersion)) {
-      return;
+      return null;
     }
     if (state.lastPluginRefreshPromptAt !== null) {
       const last = Date.parse(state.lastPluginRefreshPromptAt);
-      if (!Number.isNaN(last) && Date.now() - last < TWENTY_FOUR_HOURS_MS) return;
+      if (!Number.isNaN(last) && Date.now() - last < TWENTY_FOUR_HOURS_MS) return null;
     }
   }
 
-  // MYSECOND_NO_UPGRADE_NAG=1 still silences this (checked above) — we just don't
-  // advertise the env var in the message (cleaner for non-technical PMs; the
-  // nudge is already 24h-debounced and stops once they refresh).
-  process.stdout.write(
+  // No trailing newline + no env-var hint: this is a JSON `systemMessage` value
+  // (user-facing). We don't advertise MYSECOND_NO_UPGRADE_NAG (cleaner for
+  // non-technical PMs; the nudge is 24h-debounced and stops once they refresh).
+  const message =
     'mySecond: an update to your PM OS is ready. ' +
-      'Paste this into Claude Code to update: ' +
-      'npx -y @mysecond/cli@latest plugin-refresh --force-update ' +
-      '— then start a new session.\n'
-  );
+    'Paste this into Claude Code to update: ' +
+    'npx -y @mysecond/cli@latest plugin-refresh --force-update ' +
+    '— then start a new session.';
 
   // A forced (test) trigger must not touch the real 24h debounce state.
-  if (forced) return;
-
-  // Persist the debounce stamp (mirror maybePrintUpgradeNag): write a copy
-  // first, mutate in-memory only on success, so disk + memory stay consistent
-  // if the write fails. Best-effort — never throw.
-  const stamp = new Date().toISOString();
-  const persisted: SyncState = { ...state, lastPluginRefreshPromptAt: stamp };
-  try {
-    writeSyncState(rootDir, persisted);
-    state.lastPluginRefreshPromptAt = stamp;
-  } catch {
-    // Best-effort persistence. Leave in-memory state unchanged.
+  if (!forced) {
+    // Persist the debounce stamp: write a copy first, mutate in-memory only on
+    // success, so disk + memory stay consistent if the write fails. Best-effort.
+    const stamp = new Date().toISOString();
+    const persisted: SyncState = { ...state, lastPluginRefreshPromptAt: stamp };
+    try {
+      writeSyncState(rootDir, persisted);
+      state.lastPluginRefreshPromptAt = stamp;
+    } catch {
+      // Best-effort persistence. Leave in-memory state unchanged.
+    }
   }
+
+  return message;
 }

--- a/tests/commands/sync-nudge.test.ts
+++ b/tests/commands/sync-nudge.test.ts
@@ -10,7 +10,7 @@
 // Mirrors tests/commands/base-sync.test.ts (same runSync + fetch-mock + $HOME
 // redirect harness), in silent mode (which is how the SessionStart hook runs).
 
-import { mkdirSync, mkdtempSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { runSync } from '../../src/commands/sync.js';
 import type { CommandContext } from '../../src/lib/context.js';
+import { sha256 } from '../../src/lib/files.js';
 import { writeSyncState, type SyncState } from '../../src/lib/sync-state.js';
 
 function tmpProject(): string {
@@ -153,5 +154,61 @@ describe('plugin-refresh nudge — end-to-end via runSync', () => {
 
     await runSync([], ctx(root));
     expect(stdoutBuf).not.toContain('an update to your PM OS is ready');
+  });
+
+  // Regression (Codex P2): a conflict notice must NOT corrupt the single hook
+  // JSON object the nudge rides in. In silent mode resolveConflict used to write
+  // the notice to stdout directly; combined with printSummary's JSON that left
+  // stdout unparseable, so Claude Code dropped the top-level systemMessage and
+  // the nudge went invisible again — but ONLY for customers who also hit a
+  // conflict. The notice is now folded into additionalContext; stdout stays one
+  // JSON object and the nudge survives.
+  it('keeps stdout a single JSON object (nudge in systemMessage) when a conflict co-occurs', async () => {
+    const root = tmpProject();
+    // A local context file that diverged from the cloud since the last sync.
+    mkdirSync(join(root, 'context'), { recursive: true });
+    writeFileSync(join(root, 'context/company.md'), 'LOCAL EDIT', 'utf8');
+    // sync-state records an older baseline for BOTH sides, so the incoming cloud
+    // version (different hash) + the touched local file = a real conflict.
+    seedState(root, {
+      installedPluginContractVersion: '1',
+      files: {
+        'context/company.md': {
+          localHash: sha256('OLD'),
+          cloudHash: sha256('OLD'),
+          lastSyncedAt: '2026-04-29T00:00:00.000Z',
+        },
+      },
+    });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        cliSyncBody({
+          latest_plugin_contract_version: '2',
+          context_files: [
+            {
+              file_path: 'context/company.md',
+              content: 'CLOUD EDIT',
+              current_hash: sha256('CLOUD EDIT'),
+            },
+          ],
+        }),
+      ),
+    );
+
+    await runSync([], ctx(root)); // ctx() default strategy is cloud-wins
+
+    // stdout must be exactly ONE parseable JSON object — JSON.parse throws if a
+    // plain-text conflict line leaked onto stdout ahead of the hook payload.
+    const out = JSON.parse(stdoutBuf.trim()) as {
+      systemMessage?: string;
+      hookSpecificOutput?: { additionalContext?: string };
+    };
+    // The nudge survived in the user-visible channel...
+    expect(out.systemMessage).toContain('an update to your PM OS is ready');
+    // ...and the conflict notice rode along in the model-facing channel (its
+    // pre-refactor audience), NOT on raw stdout.
+    expect(out.hookSpecificOutput?.additionalContext).toContain(
+      'Conflict in context/company.md',
+    );
   });
 });

--- a/tests/commands/sync-nudge.test.ts
+++ b/tests/commands/sync-nudge.test.ts
@@ -123,9 +123,16 @@ describe('plugin-refresh nudge — end-to-end via runSync', () => {
     const url = (fetchMock.mock.calls[0] as [URL, RequestInit])[0];
     expect(url.pathname).toBe('/api/companion/cli-sync');
     expect(url.searchParams.get('client_plugin_contract_version')).toBe('1');
-    // (b) the nudge reached STDOUT (the channel Claude relays at session start).
-    expect(stdoutBuf).toContain('an update to your PM OS is ready');
-    expect(stdoutBuf).toContain('plugin-refresh --force-update');
+    // (b) the nudge is emitted in the SessionStart hook JSON's top-level
+    // `systemMessage` — the ONLY channel Claude Code renders directly to the user
+    // (plain stdout → additionalContext, which the user never reliably sees).
+    const out = JSON.parse(stdoutBuf.trim()) as {
+      systemMessage?: string;
+      hookSpecificOutput?: { hookEventName?: string };
+    };
+    expect(out.hookSpecificOutput?.hookEventName).toBe('SessionStart');
+    expect(out.systemMessage).toContain('an update to your PM OS is ready');
+    expect(out.systemMessage).toContain('plugin-refresh --force-update');
   });
 
   it('stays silent when already on the latest contract version', async () => {

--- a/tests/lib/plugin-refresh-nag.test.ts
+++ b/tests/lib/plugin-refresh-nag.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   isPluginContractBehind,
-  maybePrintPluginRefreshNudge,
+  resolvePluginRefreshNudge,
   TWENTY_FOUR_HOURS_MS,
 } from '../../src/lib/plugin-refresh-nag.js';
 import { readSyncState, writeSyncState, type SyncState } from '../../src/lib/sync-state.js';
@@ -80,22 +80,11 @@ describe('isPluginContractBehind', () => {
   });
 });
 
-describe('maybePrintPluginRefreshNudge', () => {
-  let stdoutBuf: string;
-  let origWrite: typeof process.stdout.write;
+describe('resolvePluginRefreshNudge', () => {
   let tmpRoot: string;
   let savedEnv: string | undefined;
 
   beforeEach(() => {
-    // The nudge writes to STDOUT (not stderr): a SessionStart hook's stdout
-    // becomes the model's session-start context, which it relays to the user —
-    // stderr on exit 0 is silently dropped (sync.ts printSummary CAIO finding).
-    stdoutBuf = '';
-    origWrite = process.stdout.write.bind(process.stdout);
-    (process.stdout.write as unknown) = ((chunk: string | Uint8Array) => {
-      stdoutBuf += typeof chunk === 'string' ? chunk : chunk.toString();
-      return true;
-    }) as typeof process.stdout.write;
     tmpRoot = mkdtempSync(join(tmpdir(), 'mysecond-prnag-'));
     savedEnv = process.env.MYSECOND_NO_UPGRADE_NAG;
     delete process.env.MYSECOND_NO_UPGRADE_NAG;
@@ -103,59 +92,41 @@ describe('maybePrintPluginRefreshNudge', () => {
   });
 
   afterEach(() => {
-    process.stdout.write = origWrite;
     if (savedEnv === undefined) delete process.env.MYSECOND_NO_UPGRADE_NAG;
     else process.env.MYSECOND_NO_UPGRADE_NAG = savedEnv;
+    delete process.env.MYSECOND_FORCE_REFRESH_NUDGE;
   });
 
-  // Marker-based assertions: every nudge line starts with 'mySecond:', so an
-  // incidental stdout write from the runner can't pollute the result.
-  it('emits nothing when not behind (installed == latest)', () => {
+  it('returns null when not behind (installed == latest)', () => {
     const s = mkState({ installedPluginContractVersion: '1' });
-    maybePrintPluginRefreshNudge(s, tmpRoot, '1');
-    expect(stdoutBuf).not.toContain('mySecond:');
+    expect(resolvePluginRefreshNudge(s, tmpRoot, '1')).toBeNull();
     expect(s.lastPluginRefreshPromptAt).toBeNull();
   });
 
-  it('emits nothing when latest is null (old app)', () => {
+  it('returns null when latest is null (old app)', () => {
     const s = mkState({ installedPluginContractVersion: '1' });
-    maybePrintPluginRefreshNudge(s, tmpRoot, null);
-    expect(stdoutBuf).not.toContain('mySecond:');
+    expect(resolvePluginRefreshNudge(s, tmpRoot, null)).toBeNull();
   });
 
-  it('emits one stdout line (session-start context) when behind — and nothing on stderr', () => {
-    // Belt-and-suspenders for the channel: capture stderr too and assert the
-    // nudge does NOT also land there (Claude Code drops SessionStart stderr).
-    let stderrBuf = '';
-    const origErr = process.stderr.write.bind(process.stderr);
-    (process.stderr.write as unknown) = ((c: string | Uint8Array) => {
-      stderrBuf += typeof c === 'string' ? c : c.toString();
-      return true;
-    }) as typeof process.stderr.write;
-    try {
-      const s = mkState({ installedPluginContractVersion: '1' });
-      maybePrintPluginRefreshNudge(s, tmpRoot, '2');
-      expect(stdoutBuf).toContain('an update to your PM OS is ready');
-      expect(stdoutBuf).toContain('plugin-refresh --force-update');
-      expect(stdoutBuf).toContain('start a new session');
-      // Exactly one nudge line (count the 'mySecond:' marker).
-      expect(stdoutBuf.split('mySecond:').length - 1).toBe(1);
-      expect(stderrBuf).not.toContain('mySecond:');
-    } finally {
-      process.stderr.write = origErr;
-    }
+  it('returns the user-facing nudge text when behind (no trailing newline — it is a JSON systemMessage value)', () => {
+    const s = mkState({ installedPluginContractVersion: '1' });
+    const msg = resolvePluginRefreshNudge(s, tmpRoot, '2');
+    expect(msg).not.toBeNull();
+    expect(msg).toContain('an update to your PM OS is ready');
+    expect(msg).toContain('plugin-refresh --force-update');
+    expect(msg).toContain('start a new session');
+    expect(msg!.endsWith('\n')).toBe(false);
   });
 
-  it('nudges a null-installed (pre-feature cohort) customer', () => {
+  it('returns the nudge for a null-installed (pre-feature cohort) customer', () => {
     const s = mkState({ installedPluginContractVersion: null });
-    maybePrintPluginRefreshNudge(s, tmpRoot, '1');
-    expect(stdoutBuf).toContain('an update to your PM OS is ready');
+    expect(resolvePluginRefreshNudge(s, tmpRoot, '1')).toContain('an update to your PM OS is ready');
   });
 
-  it('stamps lastPluginRefreshPromptAt and persists to disk', () => {
+  it('stamps lastPluginRefreshPromptAt and persists to disk when it shows', () => {
     const s = mkState({ installedPluginContractVersion: '1' });
     writeSyncState(tmpRoot, s);
-    maybePrintPluginRefreshNudge(s, tmpRoot, '2');
+    expect(resolvePluginRefreshNudge(s, tmpRoot, '2')).not.toBeNull();
     expect(s.lastPluginRefreshPromptAt).not.toBeNull();
     expect(readSyncState(tmpRoot).lastPluginRefreshPromptAt).toBe(s.lastPluginRefreshPromptAt);
   });
@@ -163,50 +134,43 @@ describe('maybePrintPluginRefreshNudge', () => {
   it('honors MYSECOND_NO_UPGRADE_NAG=1', () => {
     process.env.MYSECOND_NO_UPGRADE_NAG = '1';
     const s = mkState({ installedPluginContractVersion: '1' });
-    maybePrintPluginRefreshNudge(s, tmpRoot, '2');
-    expect(stdoutBuf).not.toContain('mySecond:');
+    expect(resolvePluginRefreshNudge(s, tmpRoot, '2')).toBeNull();
     expect(s.lastPluginRefreshPromptAt).toBeNull();
   });
 
   it('debounces within 24h', () => {
     const recent = new Date(Date.now() - 1000).toISOString();
     const s = mkState({ installedPluginContractVersion: '1', lastPluginRefreshPromptAt: recent });
-    maybePrintPluginRefreshNudge(s, tmpRoot, '2');
-    expect(stdoutBuf).not.toContain('mySecond:');
+    expect(resolvePluginRefreshNudge(s, tmpRoot, '2')).toBeNull();
   });
 
   it('re-emits after the 24h debounce expires', () => {
     const old = new Date(Date.now() - TWENTY_FOUR_HOURS_MS - 1000).toISOString();
     const s = mkState({ installedPluginContractVersion: '1', lastPluginRefreshPromptAt: old });
-    maybePrintPluginRefreshNudge(s, tmpRoot, '2');
-    expect(stdoutBuf).toContain('an update to your PM OS is ready');
+    expect(resolvePluginRefreshNudge(s, tmpRoot, '2')).toContain('an update to your PM OS is ready');
   });
 
-  it('leaves in-memory state untouched when disk persist fails (no truth split)', () => {
+  it('still returns the nudge but leaves in-memory state untouched when disk persist fails', () => {
     const blockedRoot = join(tmpRoot, 'blocked');
     writeFileSync(blockedRoot, 'not-a-directory');
     const s = mkState({ installedPluginContractVersion: '1' });
-    maybePrintPluginRefreshNudge(s, blockedRoot, '2');
-    expect(stdoutBuf).toContain('an update to your PM OS is ready');
+    expect(resolvePluginRefreshNudge(s, blockedRoot, '2')).toContain('an update to your PM OS is ready');
     expect(s.lastPluginRefreshPromptAt).toBeNull();
   });
 
-  // Test affordance: MYSECOND_FORCE_REFRESH_NUDGE=1 lets us SEE the nudge render
-  // in a real session on demand — no 24h wait, no contrived versions.
-  it('MYSECOND_FORCE_REFRESH_NUDGE=1 emits even when NOT behind, without persisting the debounce stamp', () => {
+  // Test affordance: MYSECOND_FORCE_REFRESH_NUDGE=1 returns the nudge on demand —
+  // no 24h wait, no contrived versions — so we can SEE it render in a real session.
+  it('MYSECOND_FORCE_REFRESH_NUDGE=1 returns the nudge even when NOT behind, without persisting the stamp', () => {
     process.env.MYSECOND_FORCE_REFRESH_NUDGE = '1';
     const s = mkState({ installedPluginContractVersion: '2' }); // not behind
-    maybePrintPluginRefreshNudge(s, tmpRoot, '2');
-    expect(stdoutBuf).toContain('an update to your PM OS is ready');
-    // Forced trigger must not mutate the real 24h debounce state.
+    expect(resolvePluginRefreshNudge(s, tmpRoot, '2')).toContain('an update to your PM OS is ready');
     expect(s.lastPluginRefreshPromptAt).toBeNull();
   });
 
-  it('MYSECOND_FORCE_REFRESH_NUDGE=1 emits even with null latest and inside the 24h debounce', () => {
+  it('MYSECOND_FORCE_REFRESH_NUDGE=1 returns the nudge even with null latest and inside the 24h debounce', () => {
     process.env.MYSECOND_FORCE_REFRESH_NUDGE = '1';
     const recent = new Date(Date.now() - 1000).toISOString();
     const s = mkState({ installedPluginContractVersion: '1', lastPluginRefreshPromptAt: recent });
-    maybePrintPluginRefreshNudge(s, tmpRoot, null);
-    expect(stdoutBuf).toContain('an update to your PM OS is ready');
+    expect(resolvePluginRefreshNudge(s, tmpRoot, null)).toContain('an update to your PM OS is ready');
   });
 });


### PR DESCRIPTION
## Summary

Routes the plugin-update nudge (shipped in #44) through the SessionStart hook's **top-level `systemMessage`** — the only channel Claude Code renders directly to the user. The nudge previously wrote plain stdout, which a SessionStart hook delivers as `additionalContext` (a model-only system reminder), so it never reliably reached customers. **Confirmed rendering live** in a real Claude Code session.

## Why — Claude Code hook output channels (exit 0)

| Channel | Who sees it |
|---|---|
| stderr | **nobody** — dropped on exit 0 |
| plain stdout → `hookSpecificOutput.additionalContext` | **the model only** — not a chat message; user doesn't reliably see it |
| top-level **`systemMessage`** | **the user, directly** (non-blocking) |

The nudge is for the user, so it must ride in `systemMessage`. Two earlier cuts (stderr, then plain stdout) were therefore invisible. Full writeup lives in the team gotcha memory (`gotcha_claude_code_hook_output_channels.md`).

## Changes

**Modified (5 files)**
- `src/lib/plugin-refresh-nag.ts` — `maybePrintPluginRefreshNudge` → **`resolvePluginRefreshNudge`**: returns the nudge text (or `null`) instead of writing stdout, so the caller picks the channel. Message no longer carries a trailing newline (it's a JSON value now). Force-affordance / 24h-debounce / `MYSECOND_NO_UPGRADE_NAG` semantics unchanged.
- `src/commands/sync.ts` — `printSummary` now takes the resolved nudge. The **silent (hook) branch** emits exactly one hook-protocol JSON object: nudge → `systemMessage`, sync summary → `additionalContext`, emitted only when non-empty. The **interactive branch** prints the nudge as a plain line. Call site resolves the nudge (persisting the 24h debounce) before passing it in.
- `src/lib/conflict.ts` — **(Codex P2 fix, see below)** `emitNotice` / `resolveConflict` now route silent-mode conflict notices into a caller-provided sink instead of writing raw stdout, so the hook's stdout stays a single JSON object.
- `tests/lib/plugin-refresh-nag.test.ts` — assert the return value (`string | null`) instead of captured stdout.
- `tests/commands/sync-nudge.test.ts` — assert the emitted JSON's top-level `systemMessage` carries the nudge, **plus a regression test** for the conflict co-occurrence below.

## Codex review caught two real holes (both P2, both fixed here)

Two iterative Codex review rounds each surfaced a distinct, real regression that this very refactor introduced — both now fixed:

**P2-a — conflict notice corrupts the hook JSON.** In silent mode a context-file **conflict** writes a plain-text notice to stdout *during* the sync (`resolveConflict` → `emitNotice`), *before* `printSummary` emits the hook JSON. That made stdout `"Conflict in X…\n{JSON}"` — no longer one parseable JSON object — so Claude Code falls back to treating the whole thing as `additionalContext` and **the `systemMessage` nudge is dropped again**, but only for customers who *also* hit a conflict (~0-2/month). **Fix:** silent-mode conflict notices are collected into a sink and folded into the same hook JSON's `additionalContext` — preserving their pre-refactor audience (model-relayed) while keeping stdout a single JSON object. TTY mode unchanged (notices still go straight to stderr). A new end-to-end regression test asserts `JSON.parse(stdout)` yields `systemMessage` with the nudge **and** `additionalContext` with the conflict notice.

**P2-b — a hook timeout could suppress the nudge for 24h.** The refactor split *resolve* (which persists the 24h debounce stamp) from *emit* (`printSummary`), and the best-effort `pruneStalePlugins` — which can block for minutes on `claude plugin uninstall` subprocesses — sat between them. A SessionStart-hook timeout that killed the process in that window would persist the stamp but never show the nudge → suppressed 24h, never seen. **Fix:** the resolve call is relocated to immediately before `printSummary`, after all slow cleanup, so the stamp-persist and the emit are adjacent — a timeout-kill during cleanup now persists neither, and the next session simply re-nudges.

This is exactly the failure class the PR exists to kill, caught before publish.

## Verification
- `tsc --noEmit` ✅ · `npm run build` ✅ · `npm test` ✅ (full suite, incl. the new conflict-co-occurrence regression test)
- **Live UI test:** `MYSECOND_FORCE_REFRESH_NUDGE=1 claude` → the nudge renders directly in the Claude Code session.
- Codex review on this exact diff (final gate before publish) — found the P2 above; re-reviewed after the fix.

## Follow-ups (NOT in this PR)
- The nudge currently renders once per SessionStart hook invocation; a duplicate-hook situation surfaced ~4 invocations in one session (the systemMessage change merely *exposed* it — `additionalContext` hid it). Hardening the dedup (serialize emit/persist under concurrency) is tracked separately.
- The existing `mysecond sync` "X skills updated" lines still use `additionalContext` (model-only) — candidate to move to `systemMessage` if we want customers to see them.

## Ship sequence
App #341 is already deployed (returns `latest_plugin_contract_version`). After this merges, **1.6.0 is ready to publish** (Ron publishes; agent does not). The cohort then auto-nudges on next SessionStart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
