### PR TITLE
CLI 1.7.0: `mysecond emit-event` usage-tracking hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/emit-event.ts
+++ b/src/commands/emit-event.ts
@@ -1,0 +1,302 @@
+// `mysecond emit-event --silent` — usage-tracking hook dispatcher. The TS
+// sibling of the bash hooks it replaces:
+//   - emit-event.sh        (PostToolUse)         — autonomous Skill/Task tool
+//                                                  calls + session_start
+//   - emit-event-slash.sh  (UserPromptSubmit)     — user-typed slash commands
+//
+// Tool event arrives as JSON on stdin. ALWAYS exits 0 — this is best-effort
+// hook plumbing and the customer's tool call shouldn't get blamed for our
+// problems. Mirrors artifact-sync's guards (no credential → silent skip) and
+// its best-effort posture (v1: no retry queue).
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { dirname, join } from 'node:path';
+
+import { emitHookEvent, type HookEventPayload } from '../lib/api.js';
+import type { CommandContext } from '../lib/context.js';
+import { mysecondHome } from '../lib/mysecond-paths.js';
+
+const HOOK_VERSION = 'v1' as const;
+const MAX_STDIN_BYTES = 1_000_000;
+
+// Stdin event shape (Claude Code hook payload). All fields optional — a
+// best-effort dispatcher must tolerate any subset.
+interface HookEvent {
+  hook_event_name?: string;
+  tool_name?: string;
+  tool_use_id?: string;
+  tool_call_id?: string;
+  session_id?: string;
+  cwd?: string;
+  tool_input?: {
+    skill?: string;
+    skill_name?: string;
+    subagent_type?: string;
+  };
+  tool_response?: { is_error?: boolean } | unknown;
+  // UserPromptExpansion: structured slash-command name + raw prompt fallback.
+  command_name?: string;
+  prompt?: string;
+}
+
+// Known workflow slugs. Their names do NOT contain the word "workflow"
+// (competitive-intel-pack, problem-to-prd, …) — a bare *workflow* substring
+// check misses every one — so match them explicitly. Keep in sync with the
+// bash hooks (emit-event.sh / emit-event-slash.sh) and PMKit content/workflows/.
+const WORKFLOWS: ReadonlySet<string> = new Set([
+  'batch-interview-analysis',
+  'competitive-intel-pack',
+  'hypothesis-tester',
+  'market-sizing-analyzer',
+  'multi-review',
+  'problem-to-prd',
+  'voice-of-customer-analysis',
+]);
+
+// Subagent-spawn tool names. TaskCreate is the current Claude Code tool;
+// Task/Agent are older names. Match all three so subagent_run is not dropped.
+const SUBAGENT_TOOLS: ReadonlySet<string> = new Set(['Task', 'Agent', 'TaskCreate']);
+
+// Claude Code's self-management slash commands. These manage Claude Code
+// itself, not "PM work" worth surfacing on the adoption dashboard — skip them.
+// Conservative by design: a false negative is one harmless extra leaderboard
+// row; a false positive silently drops a real skill. Keep in sync with
+// emit-event-slash.sh.
+const SLASH_DENYLIST: ReadonlySet<string> = new Set([
+  'help', 'clear', 'cost', 'exit', 'quit', 'undo', 'login', 'logout',
+  'permissions', 'config', 'model', 'release-notes', 'bug', 'doctor',
+  'memory', 'compact', 'status', 'verbose', 'mcp', 'reset', 'history',
+  'terminal-setup', 'approved-tools',
+]);
+
+async function readStdin(): Promise<string> {
+  let buf = '';
+  process.stdin.setEncoding('utf8');
+  for await (const chunk of process.stdin) {
+    buf += chunk;
+    if (buf.length > MAX_STDIN_BYTES) break;
+  }
+  return buf;
+}
+
+function parseEvent(raw: string): HookEvent | null {
+  if (raw.trim().length === 0) return null;
+  try {
+    return JSON.parse(raw) as HookEvent;
+  } catch {
+    return null;
+  }
+}
+
+// Drop the plugin namespace so the same skill/agent records under one
+// canonical name regardless of which plugin shipped it
+// (pm-os:prd-generator, customer-x:prd-generator → prd-generator).
+function stripNamespace(name: string): string {
+  const idx = name.lastIndexOf(':');
+  return idx === -1 ? name : name.slice(idx + 1);
+}
+
+// Strip a leading `workflow-` prefix from a name (plugin-exported workflows
+// carry it; content/workflows/ slugs do not).
+function stripWorkflowPrefix(name: string): string {
+  return name.startsWith('workflow-') ? name.slice('workflow-'.length) : name;
+}
+
+// Classify a skill/slash name into workflow_run vs skill_run + its emitted
+// name (workflow names get the `workflow-` prefix stripped).
+function classifySkill(name: string): { eventType: 'workflow_run' | 'skill_run'; name: string } {
+  const isWorkflow = WORKFLOWS.has(name) || name.includes('workflow');
+  return {
+    eventType: isWorkflow ? 'workflow_run' : 'skill_run',
+    name: stripWorkflowPrefix(name),
+  };
+}
+
+// Scope guard: only emit inside a synced mySecond PM-OS project — a project
+// marked by a .claude/sync-state.json that carries a "customerId" (written by
+// init/sync to bind the project to an account). A bare sync-state.json with no
+// customerId (e.g. a stale stub in an unrelated repo) does NOT count. Walk up
+// from `startDir`; no marker → unrelated Claude Code session → skip. Mirrors
+// the bash hooks' _in_pmos_project. Cheap string check (not JSON.parse) to
+// match the bash `grep -q '"customerId"'` and tolerate a half-written file.
+function inSyncedProject(startDir: string): boolean {
+  let dir = startDir;
+  while (dir.length > 0) {
+    const f = join(dir, '.claude', 'sync-state.json');
+    try {
+      if (existsSync(f) && readFileSync(f, 'utf8').includes('"customerId"')) {
+        return true;
+      }
+    } catch {
+      // Unreadable — keep walking up.
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return false;
+}
+
+// session_start is emitted once per session, on the FIRST emit-event fire of a
+// session, via a marker file under ~/.mysecond/sessions/<session_id> (shared
+// with the bash hooks so only the first to fire — regardless of which branch —
+// emits it). Returns true if this call won the race (marker did not exist).
+function claimSessionStart(sessionId: string): boolean {
+  const dir = join(mysecondHome(), 'sessions');
+  const marker = join(dir, sessionId);
+  try {
+    if (existsSync(marker)) return false;
+    mkdirSync(dir, { recursive: true });
+    // Touch the marker. Best-effort: if two fires race, both may pass the
+    // existsSync check and emit session_start — the server dedups on
+    // (user_id, session_id, tool_call_id) where session_start's tool_call_id
+    // is null, so NULLS NOT DISTINCT collapses the duplicate.
+    writeFileSync(marker, '');
+    return true;
+  } catch {
+    // Couldn't read/create the marker — skip the session_start emit rather
+    // than risk a duplicate every fire.
+    return false;
+  }
+}
+
+// Build the type-specific event from a parsed hook payload. Returns null when
+// the payload carries no trackable type-specific event (session_start is
+// handled separately by the caller). Exported for unit tests.
+export function buildTypeEvent(
+  event: HookEvent,
+  cwd: string,
+  sessionId: string | null
+): HookEventPayload | null {
+  const hookName = event.hook_event_name;
+
+  if (hookName === 'UserPromptSubmit' || hookName === 'UserPromptExpansion') {
+    // Typed slash command. UserPromptSubmit (the event the plugin registers —
+    // universal across Claude Code versions) carries the raw `prompt`;
+    // UserPromptExpansion (accepted for forward-compat) carries a structured
+    // `command_name`. Prefer command_name; fall back to a regex on the prompt.
+    let name = '';
+    if (typeof event.command_name === 'string' && event.command_name.length > 0) {
+      name = event.command_name;
+    } else if (typeof event.prompt === 'string') {
+      const m = event.prompt.match(/^\/(?:[A-Za-z0-9_-]+:)?([A-Za-z][A-Za-z0-9_-]*)/);
+      if (m && m[1] !== undefined) name = m[1];
+    }
+    name = stripNamespace(name.toLowerCase());
+    if (name.length === 0) return null;
+    if (SLASH_DENYLIST.has(name)) return null;
+
+    const classified = classifySkill(name);
+    return {
+      event_type: classified.eventType,
+      name: classified.name,
+      session_id: sessionId,
+      // Synthetic unique id — UserPromptExpansion has no real tool call. Must
+      // be non-null + globally unique to respect the server's
+      // (user_id, session_id, tool_call_id) dedup.
+      tool_call_id: `prompt-${randomUUID()}`,
+      cwd,
+      error: false,
+      hook_version: HOOK_VERSION,
+    };
+  }
+
+  if (hookName === 'PostToolUse') {
+    const toolName = event.tool_name;
+    if (toolName === undefined) return null;
+
+    const error =
+      typeof event.tool_response === 'object' &&
+      event.tool_response !== null &&
+      (event.tool_response as { is_error?: boolean }).is_error === true;
+    // Synthesize a unique id when the payload carries none, so an ID-less event
+    // doesn't collide with session_start (also tool_call_id: null) or with other
+    // ID-less events under the server's (user_id, session_id, tool_call_id)
+    // NULLS-NOT-DISTINCT dedup — which would silently drop the real run (Codex P2).
+    // A real tool_use_id is preferred (keeps proper dedup on retries).
+    const toolCallId = event.tool_use_id ?? event.tool_call_id ?? `tool-${randomUUID()}`;
+
+    if (toolName === 'Skill') {
+      const rawName = event.tool_input?.skill ?? event.tool_input?.skill_name ?? '';
+      const name = stripNamespace(rawName);
+      if (name.length === 0) return null;
+      const classified = classifySkill(name);
+      return {
+        event_type: classified.eventType,
+        name: classified.name,
+        session_id: sessionId,
+        tool_call_id: toolCallId,
+        cwd,
+        error,
+        hook_version: HOOK_VERSION,
+      };
+    }
+
+    if (SUBAGENT_TOOLS.has(toolName)) {
+      const name = stripNamespace(event.tool_input?.subagent_type ?? '');
+      if (name.length === 0) return null;
+      return {
+        event_type: 'subagent_run',
+        name,
+        session_id: sessionId,
+        tool_call_id: toolCallId,
+        cwd,
+        error,
+        hook_version: HOOK_VERSION,
+      };
+    }
+
+    // Other PostToolUse tools carry no type-specific event (session_start is
+    // still handled by the caller).
+    return null;
+  }
+
+  return null;
+}
+
+export async function runEmitEvent(
+  _args: readonly string[],
+  ctx: CommandContext
+): Promise<number> {
+  // No credential → silent skip (mirror artifact-sync's first guard).
+  if (ctx.apiKey.length === 0) return 0;
+
+  const raw = await readStdin();
+  const event = parseEvent(raw);
+  if (event === null) return 0;
+
+  // cwd from the payload when present, else the resolved project root.
+  const cwd = typeof event.cwd === 'string' && event.cwd.length > 0 ? event.cwd : ctx.rootDir;
+
+  // Scope guard: only inside a synced mySecond project. Walk up from the
+  // event's cwd (where the tool actually ran), falling back to rootDir.
+  if (!inSyncedProject(cwd)) return 0;
+
+  const sessionId =
+    typeof event.session_id === 'string' && event.session_id.length > 0
+      ? event.session_id
+      : null;
+
+  // session_start: once per session, on the FIRST fire regardless of branch.
+  // Emitted even when the type-specific branch produces nothing.
+  if (sessionId !== null && claimSessionStart(sessionId)) {
+    await emitHookEvent(ctx, {
+      event_type: 'session_start',
+      name: null,
+      session_id: sessionId,
+      tool_call_id: null,
+      cwd,
+      error: false,
+      hook_version: HOOK_VERSION,
+    });
+  }
+
+  // Type-specific event (skill_run / workflow_run / subagent_run).
+  const typeEvent = buildTypeEvent(event, cwd, sessionId);
+  if (typeEvent !== null) {
+    await emitHookEvent(ctx, typeEvent);
+  }
+
+  return 0;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { runInit } from './commands/init.js';
 import { runPushOnly, runSync } from './commands/sync.js';
 import { runArtifactSync } from './commands/artifact-sync.js';
+import { runEmitEvent } from './commands/emit-event.js';
 import { runPluginRefresh } from './commands/plugin-refresh.js';
 import { runWhereami } from './commands/whereami.js';
 import { runCredentials } from './commands/credentials.js';
@@ -44,6 +45,11 @@ const SUBCOMMANDS: readonly Subcommand[] = [
     name: 'artifact-sync',
     summary: 'Push a changed artifact (skill output, doc, plan) up to mysecond.ai.',
     run: runArtifactSync,
+  },
+  {
+    name: 'emit-event',
+    summary: 'Emit a Claude Code usage event (skill/workflow/subagent run) for adoption tracking. Used by the tracking hook.',
+    run: runEmitEvent,
   },
   {
     name: 'plugin-refresh',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -185,6 +185,52 @@ export async function contextFilesPush(
   return response.body as ContextFilesResponse;
 }
 
+// Usage-tracking event payload posted by the `emit-event` hook dispatcher.
+// Wire shape matches the bash hooks it replaces (emit-event.sh /
+// emit-event-slash.sh) and the receiver at mysecond-app /api/hooks/events.
+export interface HookEventPayload {
+  event_type: 'skill_run' | 'workflow_run' | 'subagent_run' | 'session_start';
+  // null for session_start (no name); otherwise the namespace-stripped slug.
+  name: string | null;
+  session_id: string | null;
+  // null for session_start; otherwise the tool_use_id (or a synthetic
+  // `prompt-<uuid>` for typed slash commands). Server dedups on
+  // (user_id, session_id, tool_call_id) NULLS NOT DISTINCT.
+  tool_call_id: string | null;
+  cwd: string;
+  error: boolean;
+  hook_version: 'v1';
+}
+
+// POST /api/hooks/events — best-effort usage-tracking emit (team adoption
+// dashboard). Returns true on success (204, also tolerate 200), false on any
+// failure. This is the TS sibling of the curl in emit-event.sh.
+//
+// Failure policy (v1: best-effort, no retry queue — matches artifact-sync's
+// best-effort model):
+//   - 204/200            → success
+//   - 401/400            → permanent; drop (caller does NOT retry)
+//   - 429 / 5xx / network → drop for v1 (no local queue)
+// Short timeout (3s) so a slow/hung network never blocks the hook. Never
+// throws — a thrown network error is caught and reported as `false`.
+export async function emitHookEvent(
+  ctx: CommandContext,
+  payload: HookEventPayload
+): Promise<boolean> {
+  try {
+    const response = await companionFetch(ctx, '/api/hooks/events', {
+      method: 'POST',
+      body: payload,
+      timeoutMs: 3_000,
+    });
+    return response.status === 204 || response.status === 200;
+  } catch {
+    // Network/timeout (companionFetch throws MysecondError.networkUnreachable
+    // on those). Best-effort: drop, no queue.
+    return false;
+  }
+}
+
 // POST /api/setup/confirm — first-sync confirmation. Best-effort; non-critical
 // if it fails (web app reconciles on next poll).
 export async function confirmFirstSetup(ctx: CommandContext): Promise<boolean> {

--- a/tests/commands/emit-event.test.ts
+++ b/tests/commands/emit-event.test.ts
@@ -1,0 +1,543 @@
+// Tests for runEmitEvent — the usage-tracking hook dispatcher. Mocks the fetch
+// transport and stubs process.stdin so each test exercises the real path:
+// parse stdin → scope guard → classify → POST /api/hooks/events. Mirrors the
+// artifact-sync.test.ts template (fetch mock + stdin stub + tmp project).
+//
+// HOME is redirected to a per-test tmpdir so the ~/.mysecond/sessions/<id>
+// session_start marker writes never touch the real home or leak across tests
+// (pool: 'forks' isolates process.env per file — see vitest.config.ts).
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runEmitEvent } from '../../src/commands/emit-event.js';
+import type { CommandContext } from '../../src/lib/context.js';
+
+// A synced PM-OS project: .claude/sync-state.json carrying a "customerId".
+function tmpProject(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mysecond-emit-event-'));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  writeFileSync(
+    join(root, '.claude/sync-state.json'),
+    JSON.stringify({ customerId: 'cust_test_123' }, null, 2)
+  );
+  return root;
+}
+
+// A project tree with NO customerId marker (unrelated Claude Code session).
+function tmpNonProject(): string {
+  return mkdtempSync(join(tmpdir(), 'mysecond-emit-event-bare-'));
+}
+
+function ctx(rootDir: string, overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    apiBase: 'https://app.mysecond.ai',
+    apiKey: 'test-key',
+    rootDir,
+    silent: true,
+    dryRun: false,
+    forceUpdate: false,
+    fix: false,
+    strategy: 'cloud-wins',
+    ...overrides,
+  };
+}
+
+function emptyResponse(status = 204): Response {
+  return new Response(status === 204 ? null : '', { status });
+}
+
+function stubStdin(payload: string): void {
+  const stream = Readable.from([payload]);
+  (stream as unknown as { setEncoding: (e: string) => void }).setEncoding = () => {};
+  Object.defineProperty(process, 'stdin', { value: stream, configurable: true });
+}
+
+let uniqueCounter = 0;
+function uniqueSession(): string {
+  uniqueCounter += 1;
+  return `sess_${Date.now()}_${uniqueCounter}`;
+}
+
+// Find the fetch call whose body has the given event_type. session_start may
+// be POSTed alongside the type event, so tests select the call they care about.
+function callForEventType(
+  fetchMock: ReturnType<typeof vi.fn>,
+  eventType: string
+): { url: URL; body: Record<string, unknown> } | null {
+  for (const call of fetchMock.mock.calls) {
+    const [url, init] = call as [URL, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    if (body.event_type === eventType) return { url, body };
+  }
+  return null;
+}
+
+describe('runEmitEvent', () => {
+  let originalFetch: typeof fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalStdin: NodeJS.ReadStream;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn().mockResolvedValue(emptyResponse(204));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    originalStdin = process.stdin;
+    // Redirect ~/.mysecond/sessions to an isolated tmp home per test.
+    originalHome = process.env.HOME;
+    process.env.HOME = mkdtempSync(join(tmpdir(), 'mysecond-emit-home-'));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true });
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+  });
+
+  // ---- guards -------------------------------------------------------------
+
+  it('exits 0 immediately when apiKey is empty (no fetch)', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'prd-generator' },
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+
+    const code = await runEmitEvent([], ctx(root, { apiKey: '' }));
+    expect(code).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('exits 0 with no fetch when not inside a synced PM-OS project', async () => {
+    const root = tmpNonProject(); // no .claude/sync-state.json customerId
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'prd-generator' },
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+
+    const code = await runEmitEvent([], ctx(root));
+    expect(code).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('exits 0 on empty/garbage stdin (no fetch)', async () => {
+    const root = tmpProject();
+    stubStdin('not json at all');
+
+    const code = await runEmitEvent([], ctx(root));
+    expect(code).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // ---- PostToolUse: Skill -> skill_run -----------------------------------
+
+  it('classifies a Skill tool call as skill_run with the correct POST body shape', async () => {
+    const root = tmpProject();
+    const sessionId = uniqueSession();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'prd-generator' },
+        tool_use_id: 'toolu_abc',
+        session_id: sessionId,
+        cwd: root,
+        tool_response: { is_error: false },
+      })
+    );
+
+    const code = await runEmitEvent([], ctx(root));
+    expect(code).toBe(0);
+
+    const hit = callForEventType(fetchMock, 'skill_run');
+    expect(hit).not.toBeNull();
+    expect(hit!.url.toString()).toBe('https://app.mysecond.ai/api/hooks/events');
+    // Bearer auth header.
+    const init = fetchMock.mock.calls.find(
+      (c) => JSON.parse((c[1] as RequestInit).body as string).event_type === 'skill_run'
+    )![1] as RequestInit;
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer test-key');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect(init.method).toBe('POST');
+
+    expect(hit!.body).toEqual({
+      event_type: 'skill_run',
+      name: 'prd-generator',
+      session_id: sessionId,
+      tool_call_id: 'toolu_abc',
+      cwd: root,
+      error: false,
+      hook_version: 'v1',
+    });
+  });
+
+  it('reads skill_name when skill is absent, and reports error from tool_response.is_error', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill_name: 'roadmap-builder' },
+        tool_use_id: 'toolu_err',
+        session_id: uniqueSession(),
+        cwd: root,
+        tool_response: { is_error: true },
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    const hit = callForEventType(fetchMock, 'skill_run');
+    expect(hit!.body.name).toBe('roadmap-builder');
+    expect(hit!.body.error).toBe(true);
+  });
+
+  // ---- namespace stripping ------------------------------------------------
+
+  it('strips the plugin namespace from a Skill name (pm-os:prd-generator -> prd-generator)', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'pm-os:prd-generator' },
+        tool_use_id: 'toolu_ns',
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    const hit = callForEventType(fetchMock, 'skill_run');
+    expect(hit!.body.name).toBe('prd-generator');
+  });
+
+  // ---- workflow classification -------------------------------------------
+
+  it('classifies a known workflow slug as workflow_run', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'competitive-intel-pack' },
+        tool_use_id: 'toolu_wf',
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    const hit = callForEventType(fetchMock, 'workflow_run');
+    expect(hit).not.toBeNull();
+    expect(hit!.body.name).toBe('competitive-intel-pack');
+    expect(callForEventType(fetchMock, 'skill_run')).toBeNull();
+  });
+
+  it('classifies a *workflow* substring name as workflow_run and strips the workflow- prefix', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'pm-specs:workflow-problem-to-prd' },
+        tool_use_id: 'toolu_wfp',
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    const hit = callForEventType(fetchMock, 'workflow_run');
+    expect(hit).not.toBeNull();
+    // namespace stripped -> 'workflow-problem-to-prd' -> matches *workflow* ->
+    // workflow- prefix stripped -> 'problem-to-prd'.
+    expect(hit!.body.name).toBe('problem-to-prd');
+  });
+
+  // ---- subagent_run (Task / Agent / TaskCreate) --------------------------
+
+  it.each(['Task', 'Agent', 'TaskCreate'])(
+    'classifies %s tool as subagent_run with the subagent_type as name',
+    async (toolName) => {
+      const root = tmpProject();
+      stubStdin(
+        JSON.stringify({
+          hook_event_name: 'PostToolUse',
+          tool_name: toolName,
+          tool_input: { subagent_type: 'pm-os:cto-tech-lead' },
+          tool_use_id: `toolu_${toolName}`,
+          session_id: uniqueSession(),
+          cwd: root,
+        })
+      );
+
+      await runEmitEvent([], ctx(root));
+      const hit = callForEventType(fetchMock, 'subagent_run');
+      expect(hit).not.toBeNull();
+      // namespace stripped.
+      expect(hit!.body.name).toBe('cto-tech-lead');
+      expect(hit!.body.tool_call_id).toBe(`toolu_${toolName}`);
+    }
+  );
+
+  it('does NOT emit a type event for a non-tracked PostToolUse tool (e.g. Bash)', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: {},
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    expect(callForEventType(fetchMock, 'skill_run')).toBeNull();
+    expect(callForEventType(fetchMock, 'workflow_run')).toBeNull();
+    expect(callForEventType(fetchMock, 'subagent_run')).toBeNull();
+    // session_start still fires (first fire of the session).
+    expect(callForEventType(fetchMock, 'session_start')).not.toBeNull();
+  });
+
+  it('synthesizes a tool_call_id for an ID-less PostToolUse event (avoids session_start collision)', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'prd-generator' },
+        session_id: uniqueSession(),
+        cwd: root,
+        // NB: no tool_use_id / tool_call_id in the payload.
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    const hit = callForEventType(fetchMock, 'skill_run');
+    expect(hit).not.toBeNull();
+    // Synthetic id, not null — so it can't dedup-collide with session_start.
+    expect(hit!.body.tool_call_id).toMatch(/^tool-[0-9a-f-]{36}$/);
+  });
+
+  // ---- UserPromptSubmit / UserPromptExpansion (typed slash commands) -------
+
+  it('classifies a typed slash command via UserPromptSubmit (raw prompt) as skill_run', async () => {
+    // UserPromptSubmit is the event the plugin actually registers (universal
+    // across Claude Code versions). It carries the raw prompt, not command_name.
+    const root = tmpProject();
+    const sessionId = uniqueSession();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'UserPromptSubmit',
+        prompt: '/prd-generator draft the spec',
+        session_id: sessionId,
+        cwd: root,
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    const hit = callForEventType(fetchMock, 'skill_run');
+    expect(hit).not.toBeNull();
+    expect(hit!.body.name).toBe('prd-generator');
+    expect(hit!.body.tool_call_id).toMatch(/^prompt-[0-9a-f-]{36}$/);
+    expect(hit!.body.session_id).toBe(sessionId);
+  });
+
+  it('classifies a typed slash command (command_name) as skill_run with a synthetic prompt- id', async () => {
+    const root = tmpProject();
+    const sessionId = uniqueSession();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'UserPromptExpansion',
+        command_name: 'PRD-Generator',
+        session_id: sessionId,
+        cwd: root,
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    const hit = callForEventType(fetchMock, 'skill_run');
+    expect(hit).not.toBeNull();
+    expect(hit!.body.name).toBe('prd-generator'); // lowercased
+    expect(hit!.body.tool_call_id).toMatch(/^prompt-[0-9a-f-]{36}$/);
+    expect(hit!.body.error).toBe(false);
+    expect(hit!.body.session_id).toBe(sessionId);
+  });
+
+  it('falls back to the prompt regex when command_name is absent, stripping the namespace', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'UserPromptExpansion',
+        prompt: '/pm-os:roadmap-builder build me a roadmap',
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    const hit = callForEventType(fetchMock, 'skill_run');
+    expect(hit).not.toBeNull();
+    expect(hit!.body.name).toBe('roadmap-builder');
+  });
+
+  it('skips denylisted built-in slash commands (e.g. /help) — no type event', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'UserPromptExpansion',
+        command_name: 'help',
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    expect(callForEventType(fetchMock, 'skill_run')).toBeNull();
+    expect(callForEventType(fetchMock, 'workflow_run')).toBeNull();
+  });
+
+  it('classifies a typed slash workflow command as workflow_run', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'UserPromptExpansion',
+        command_name: 'multi-review',
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    const hit = callForEventType(fetchMock, 'workflow_run');
+    expect(hit).not.toBeNull();
+    expect(hit!.body.name).toBe('multi-review');
+  });
+
+  // ---- session_start once-per-session ------------------------------------
+
+  it('emits session_start exactly once per session (second fire does not re-emit)', async () => {
+    const root = tmpProject();
+    const sessionId = uniqueSession();
+
+    // First fire — should emit session_start + skill_run.
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'prd-generator' },
+        tool_use_id: 'toolu_1',
+        session_id: sessionId,
+        cwd: root,
+      })
+    );
+    await runEmitEvent([], ctx(root));
+
+    const firstStart = fetchMock.mock.calls.filter(
+      (c) => JSON.parse((c[1] as RequestInit).body as string).event_type === 'session_start'
+    );
+    expect(firstStart).toHaveLength(1);
+    // session_start carries null name + null tool_call_id.
+    expect(JSON.parse((firstStart[0]![1] as RequestInit).body as string)).toEqual({
+      event_type: 'session_start',
+      name: null,
+      session_id: sessionId,
+      tool_call_id: null,
+      cwd: root,
+      error: false,
+      hook_version: 'v1',
+    });
+
+    // Second fire, SAME session — must NOT emit session_start again.
+    fetchMock.mockClear();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'roadmap-builder' },
+        tool_use_id: 'toolu_2',
+        session_id: sessionId,
+        cwd: root,
+      })
+    );
+    await runEmitEvent([], ctx(root));
+
+    expect(callForEventType(fetchMock, 'session_start')).toBeNull();
+    expect(callForEventType(fetchMock, 'skill_run')).not.toBeNull();
+  });
+
+  it('does not emit session_start when session_id is missing', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'prd-generator' },
+        tool_use_id: 'toolu_nosess',
+        cwd: root,
+        // no session_id
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    expect(callForEventType(fetchMock, 'session_start')).toBeNull();
+    // Type event still fires, with null session_id.
+    const hit = callForEventType(fetchMock, 'skill_run');
+    expect(hit!.body.session_id).toBeNull();
+  });
+
+  // ---- best-effort: never throws on transport failure --------------------
+
+  it('returns 0 even when the POST fails (5xx) — best-effort, no throw', async () => {
+    const root = tmpProject();
+    fetchMock.mockResolvedValue(new Response('boom', { status: 500 }));
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'prd-generator' },
+        tool_use_id: 'toolu_5xx',
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+
+    const code = await runEmitEvent([], ctx(root));
+    expect(code).toBe(0);
+  });
+
+  it('returns 0 even when the network throws — best-effort, no throw', async () => {
+    const root = tmpProject();
+    fetchMock.mockRejectedValue(new Error('offline'));
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'prd-generator' },
+        tool_use_id: 'toolu_off',
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+
+    const code = await runEmitEvent([], ctx(root));
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Ships the CLI half of the **/track usage** fix: a new `mysecond emit-event` subcommand that the regenerated customer plugin calls on tool events, POSTing usage to `app.mysecond.ai/api/hooks/events` with the companion **device token**. This is what makes the Usage dashboard populate on install — no extra setup skill needed.

Pairs with the already-merged app side (mysecond-app PR #346) which taught `/api/hooks/events` to accept the device token (multi-team-safe) and registers this hook via regen.

## Customer impact
When a customer installs the companion, usage tracking now **just works** — running a skill/workflow/sub-agent emits an event tied to their team, and `/track/usage` shows real adoption data. Previously the page was empty because no customer ever emitted (the emitter only lived in PMKit, never shipped). Non-fatal by design: on an old CLI or missing token the hook silently no-ops (`|| true`), never blocking the user's session.

## What's in this release
- **`feat`: `mysecond emit-event`** — reads the tool event on stdin, resolves the device token via `buildContext`→`getDeviceToken`, classifies it (Skill→skill_run/workflow_run, Task|Agent|TaskCreate→subagent_run, UserPromptSubmit→skill_run with built-ins denylisted, session_start once/session), synthesizes a `tool_call_id` for ID-less events, always exits 0. (`src/commands/emit-event.ts`, `src/lib/api.ts` `emitHookEvent`, `src/index.ts`)
- Carries forward the staged-but-unpublished **1.6.0** work already on `main` (plugin-refresh nudge + contract-version reporting, PR #44) — the contract-version bump is what prompts customers to refresh their plugin and pick up this new hook.

## Files
**New:** `src/commands/emit-event.ts`, `tests/commands/emit-event.test.ts` (22 tests)
**Modified:** `src/lib/api.ts`, `src/index.ts`, `package.json` (1.6.0 → 1.7.0)

## Verification
- `npm run typecheck` clean, `npm run build` clean.
- Full suite: **47 files / 590 tests passed, 0 failed** (emit-event's 22 included).
- Codex-reviewed: subcommand PASS; found+fixed **[P2]** (ID-less dedup collision under NULLS-NOT-DISTINCT).

## Release mechanism
Merge → push tag `v1.7.0` → `publish.yml` runs `prepublishOnly` (typecheck+build+test) then `npm publish`.

## Notes / out of scope
- Open nudge PR #45 (`fix/nudge-system-message`) is **independent** — no file overlap, deliberately not bundled; ships on its own track.
- emit-event commit is cherry-picked clean onto `main` (not the tangled `feat/emit-event-hook` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)