### PR TITLE
Track usage fix (CLI): inject emit hook into .claude/settings.json so tracking fires for customers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/plugin-refresh.ts
+++ b/src/commands/plugin-refresh.ts
@@ -20,6 +20,7 @@ import { join } from 'node:path';
 
 import { pluginTarball } from '../lib/api.js';
 import { resolveClaudeBin } from '../lib/claude-bin.js';
+import { ensureCompanionHooks } from '../lib/companion-hooks.js';
 import type { CommandContext } from '../lib/context.js';
 import { cacheLastKnownGood } from '../lib/last-known-good.js';
 import {
@@ -69,6 +70,14 @@ export async function runPluginRefresh(
   } catch {
     return 0; // corrupt slug in sync-state — nothing safe to do
   }
+
+  // Ensure the usage-tracking hook is present in `.claude/settings.json`. Done
+  // HERE (after auth + slug validation = a confirmed install) so it runs on EVERY
+  // return path below — including the "plugin already up to date" early return,
+  // which a customer who's plugin-current but predates this hook would otherwise
+  // hit without ever getting the settings hook (Codex P1-4). Best-effort + never
+  // throws; independent of the plugin reinstall outcome.
+  await ensureCompanionHooks(ctx.rootDir, { silent: ctx.silent });
 
   // What version is available? Any error here (network/auth/revoked) leaves the
   // working install in place — we just try again next time.

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -11,6 +11,7 @@ import {
   confirmFirstSetup,
   emitTelemetry,
 } from '../lib/api.js';
+import { ensureCompanionHooks } from '../lib/companion-hooks.js';
 import type { CommandContext } from '../lib/context.js';
 import { resolveConflict, type ConflictOutcome } from '../lib/conflict.js';
 import { getProjectScopedCredsPath } from '../lib/creds-path.js';
@@ -753,6 +754,13 @@ export async function runSync(
   if (ctx.apiKey.length === 0) {
     throw MysecondError.invalidApiKey('COMPANION_API_KEY not set');
   }
+
+  // Ensure the usage-tracking hook is present in `.claude/settings.json` on EVERY
+  // sync path. Placed here — after credential resolution, before the `--push-all`
+  // / `--push-only` early returns — so a stranded customer's manual `mysecond sync`
+  // (or the realtime push-only hook) still self-heals the settings hook (Codex
+  // P2-7). Best-effort + never throws.
+  await ensureCompanionHooks(ctx.rootDir, { silent: ctx.silent });
 
   // `--push-all`: explicit local→server catch-up, independent of the pull
   // reconcile and the hook side effects. Return early — push-all is a

--- a/src/lib/companion-hooks.ts
+++ b/src/lib/companion-hooks.ts
@@ -1,0 +1,283 @@
+// companion-hooks — the SINGLE owner of every mySecond-managed mutation to a
+// project's `.claude/settings.json`: the env block (SLASH_COMMAND_TOOL_CHAR_BUDGET)
+// AND the usage-tracking `UserPromptSubmit` hook. One locked, strict-parse,
+// fail-closed, stable-marker read-modify-write.
+//
+// WHY THIS EXISTS (root cause). Usage hooks were moved OUT of `.claude/settings.json`
+// and INTO the plugin manifest (decision CAIO-Y1, v1.3) — but plugin-delivered
+// hooks do NOT fire in Claude Code (empirically A/B tested 2026-06-06: a hook in
+// `~/.claude/settings.json` fired + posted a real event; the same hook in the
+// plugin's `hooks/hooks.json` fired nothing). Corroborating open CC issues:
+// #10225 (plugin UserPromptSubmit "match but never execute"), #29767 (plugin Stop
+// never fires while SessionStart does). `settings.json` hooks DO fire, so the CLI
+// re-injects the emit hook here. (Reverts CAIO-Y1 for the emit hook only.)
+//
+// We register `UserPromptSubmit` ONLY. NOT `PostToolUse:"Skill"` (the Skill tool is
+// a prompt-expansion that dispatches no PostToolUse event — confirmed no-op, CC
+// issue #43630). NOT `UserPromptExpansion` (a typed slash command fires BOTH it and
+// `UserPromptSubmit`; emit-event would record one row for each with distinct
+// synthetic ids the server dedup can't collapse → double-count). NOT `SubagentStop`
+// (emit-event's dispatcher reads `tool_input.subagent_type`, the PostToolUse shape,
+// not SubagentStop's top-level `agent_type` → it would emit nothing). Subagent
+// tracking is a deliberate fast-follow.
+//
+// Reviewed CTO + CAIO + Codex (2026-06-06). Codex P0s folded:
+//   P0-1  buffer + replay stdin in the command: a stale global `mysecond` that
+//         starts, drains the event JSON off stdin, then exits non-zero would leave
+//         the npx fallback reading EMPTY stdin (useless exactly when it fires). We
+//         buffer once (`json=$(cat)`) and replay the SAME bytes to whichever arm
+//         runs. `&& exit 0` takes the global arm only on success; otherwise the
+//         pinned npx arm runs with the replayed stdin.
+//   P0-2  strict parse + write-nothing-on-error: this helper OWNS the env write too,
+//         so init no longer routes through a lenient reader that would erase a
+//         corrupt-but-present settings.json before we ran.
+//   P0-3  STABLE version-independent marker (`# mysecond-companion-usage-hook`): a
+//         version bump REPLACES our hook in place instead of appending a second one
+//         (the exact command string can't be the marker — it carries the version).
+
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import lockfile from 'proper-lockfile';
+
+import { atomicWriteFile } from './atomic-write.js';
+import { projectPaths } from './files.js';
+
+// esbuild injects __VERSION__ at build time; vitest defines it from package.json.
+declare const __VERSION__: string;
+
+// Env block — was step-6's sole job; now owned here so one strict reader guards
+// the whole file (Codex P0-2).
+const ENV_KEY = 'SLASH_COMMAND_TOOL_CHAR_BUDGET';
+const ENV_VALUE = '20000';
+
+// Stable, VERSION-INDEPENDENT marker carried as a trailing shell comment in the
+// injected command. The injector finds OUR hook by this substring (never the exact
+// command string, which carries the version) so a version bump replaces in place
+// instead of appending a duplicate (Codex P0-3).
+export const HOOK_MARKER = 'mysecond-companion-usage-hook';
+
+// UserPromptSubmit is SYNCHRONOUS and BLOCKS the prompt (default 30s — per
+// code.claude.com/docs/en/hooks). Cap our hook at 8s so a cold-npx spawn can never
+// inherit the 30s block.
+const HOOK_TIMEOUT = 8;
+
+// Lock tuning — mirror sync-state.ts / marketplace-lock proven values.
+const LOCK_STALE_MS = 30_000;
+const LOCK_RETRIES = 5;
+const LOCK_MIN_TIMEOUT_MS = 100;
+
+interface SettingsShape {
+  env?: unknown;
+  hooks?: unknown;
+  [key: string]: unknown;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+// The injected UserPromptSubmit command. Buffers stdin once, tries a global
+// `mysecond` of the running version, and on ANY miss/failure replays the SAME
+// buffered stdin to a version-pinned npx fallback. (Codex P0-1.) `<version>` pins
+// the npx arm so it doesn't hit the registry for @latest and is reproducible. The
+// trailing `# <marker>` is the stable idempotency marker (Codex P0-3). Exported
+// for tests.
+export function buildHookCommand(version: string): string {
+  return (
+    `bash -lc 'json=$(cat); ` +
+    `printf "%s" "$json" | mysecond emit-event --silent 2>/dev/null && exit 0; ` +
+    `printf "%s" "$json" | npx -y @mysecond/cli@${version} emit-event --silent 2>/dev/null || true` +
+    `  # ${HOOK_MARKER}'`
+  );
+}
+
+export type PlanResult =
+  | { action: 'write'; next: SettingsShape }
+  | { action: 'noop' }
+  | { action: 'skip'; reason: 'not-an-object' };
+
+// Pure merge — no IO, no lock. Given the parsed settings object + the version to
+// pin, returns the next settings object (or noop/skip). Exported for unit tests so
+// every merge case is covered without touching disk.
+export function planCompanionSettings(
+  current: unknown,
+  version: string,
+  silent = false
+): PlanResult {
+  if (!isPlainObject(current)) {
+    // Root isn't a JSON object — never clobber it (Codex P0-2 / fail-closed).
+    return { action: 'skip', reason: 'not-an-object' };
+  }
+
+  // Deep clone so we never mutate the caller's parsed object (plain JSON in).
+  const next = JSON.parse(JSON.stringify(current)) as SettingsShape;
+  let changed = false;
+
+  if (mergeEnvBlock(next, silent)) changed = true;
+  if (mergeUserPromptSubmitHook(next, buildHookCommand(version), silent)) changed = true;
+
+  return changed ? { action: 'write', next } : { action: 'noop' };
+}
+
+// Env block merge. Absent → set. Present + plain object → ensure our key
+// (customer-authored different value WINS, per the original step-6 §6.3a rule).
+// Present but NOT a plain object → fail closed (skip, never clobber). Returns true
+// if it changed `next`.
+function mergeEnvBlock(next: SettingsShape, silent: boolean): boolean {
+  if (next.env === undefined) {
+    next.env = { [ENV_KEY]: ENV_VALUE };
+    return true;
+  }
+  if (!isPlainObject(next.env)) {
+    if (!silent) {
+      process.stderr.write(
+        'mysecond: .claude/settings.json "env" is not an object — leaving it untouched.\n'
+      );
+    }
+    return false;
+  }
+  const env = next.env;
+  if (!(ENV_KEY in env)) {
+    env[ENV_KEY] = ENV_VALUE;
+    return true;
+  }
+  if (env[ENV_KEY] !== ENV_VALUE && !silent) {
+    process.stderr.write(
+      `mysecond: noted .claude/settings.json env.${ENV_KEY}=${String(env[ENV_KEY])} ` +
+        `(customer value preserved over our default ${ENV_VALUE})\n`
+    );
+  }
+  return false;
+}
+
+// UserPromptSubmit hook merge. Creates only MISSING containers; fails closed
+// (skip, never overwrite) if a present container has the wrong type (Codex P1-5);
+// finds our entry by the stable marker and rewrites in place on a version change,
+// else appends our OWN group (customer hooks untouched). Returns true if it changed
+// `next`.
+function mergeUserPromptSubmitHook(
+  next: SettingsShape,
+  desiredCommand: string,
+  silent: boolean
+): boolean {
+  if (next.hooks === undefined) {
+    next.hooks = {};
+  } else if (!isPlainObject(next.hooks)) {
+    if (!silent) {
+      process.stderr.write(
+        'mysecond: .claude/settings.json "hooks" is not an object — skipping usage-hook injection (left as-is).\n'
+      );
+    }
+    return false;
+  }
+  const hooks = next.hooks as Record<string, unknown>;
+
+  if (hooks.UserPromptSubmit === undefined) {
+    hooks.UserPromptSubmit = [];
+  } else if (!Array.isArray(hooks.UserPromptSubmit)) {
+    if (!silent) {
+      process.stderr.write(
+        'mysecond: .claude/settings.json hooks.UserPromptSubmit is not an array — skipping usage-hook injection (left as-is).\n'
+      );
+    }
+    return false;
+  }
+  const groups = hooks.UserPromptSubmit as unknown[];
+
+  // Find OUR hook by the stable marker (version-independent).
+  for (const group of groups) {
+    if (!isPlainObject(group)) continue;
+    const inner = group.hooks;
+    if (!Array.isArray(inner)) continue;
+    for (const h of inner) {
+      if (
+        isPlainObject(h) &&
+        typeof h.command === 'string' &&
+        h.command.includes(HOOK_MARKER)
+      ) {
+        if (h.command === desiredCommand) return false; // already current → no-op
+        // Version (or shape) drift → rewrite in place; preserve everything else.
+        h.command = desiredCommand;
+        h.type = 'command';
+        h.timeout = HOOK_TIMEOUT;
+        return true;
+      }
+    }
+  }
+
+  // Not present — append our OWN group so customer groups/hooks are never touched.
+  groups.push({
+    matcher: '',
+    hooks: [{ type: 'command', command: desiredCommand, timeout: HOOK_TIMEOUT }],
+  });
+  return true;
+}
+
+// Ensure the mySecond env block + usage hook are present in the project's
+// `.claude/settings.json`. BEST-EFFORT by contract: never throws into init /
+// refresh / sync. Locked read-modify-write (the file is also written by env init;
+// concurrent `mysecond` processes must not clobber each other — Codex P1-6). On a
+// lock miss or unparseable file: writes NOTHING and returns (Codex P0-2).
+export async function ensureCompanionHooks(
+  rootDir: string,
+  opts: { silent?: boolean; version?: string } = {}
+): Promise<void> {
+  const silent = opts.silent ?? false;
+  const version = opts.version ?? __VERSION__;
+  const settingsPath = projectPaths(rootDir).settingsPath;
+
+  try {
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    // proper-lockfile requires the target to exist before lock(). Materialize an
+    // empty object if absent — valid JSON, clobbers nothing.
+    if (!existsSync(settingsPath)) {
+      atomicWriteFile(settingsPath, '{}\n');
+    }
+
+    let release: (() => Promise<void>) | null = null;
+    try {
+      release = await lockfile.lock(settingsPath, {
+        retries: { retries: LOCK_RETRIES, minTimeout: LOCK_MIN_TIMEOUT_MS },
+        stale: LOCK_STALE_MS,
+      });
+    } catch {
+      // Couldn't acquire the lock — SKIP rather than an unlocked read-modify-write
+      // that could clobber a concurrent locked writer. Re-done next run.
+      return;
+    }
+
+    try {
+      // Read FRESH under the lock. STRICT parse: on ANY parse error write NOTHING
+      // (never clobber a present settings.json — Codex P0-2). An existing empty /
+      // whitespace-only file is NOT valid JSON, so it is left byte-for-byte
+      // untouched too. The legitimate "no settings yet" case is the ABSENT file,
+      // already materialized to `{}` above — so a fresh install still gets the hook.
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(readFileSync(settingsPath, 'utf8'));
+      } catch {
+        if (!silent) {
+          process.stderr.write(
+            'mysecond: .claude/settings.json is not valid JSON — leaving it untouched (usage tracking not installed).\n'
+          );
+        }
+        return;
+      }
+
+      const plan = planCompanionSettings(parsed, version, silent);
+      if (plan.action === 'write') {
+        atomicWriteFile(settingsPath, JSON.stringify(plan.next, null, 2) + '\n');
+      }
+      // noop / skip → write nothing.
+    } finally {
+      try {
+        await release();
+      } catch {
+        // best-effort lock release
+      }
+    }
+  } catch {
+    // Best-effort by contract — never throw into init / refresh / sync.
+  }
+}

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -103,6 +103,7 @@ export interface ProjectPaths {
   workflowsDir: string;
   claudeMdPath: string;
   syncStatePath: string;
+  settingsPath: string;
   conflictsDir: string;
 }
 
@@ -114,6 +115,7 @@ export function projectPaths(rootDir: string): ProjectPaths {
     workflowsDir: join(rootDir, 'workflows'),
     claudeMdPath: join(rootDir, 'CLAUDE.md'),
     syncStatePath: join(rootDir, '.claude', 'sync-state.json'),
+    settingsPath: join(rootDir, '.claude', 'settings.json'),
     conflictsDir: join(rootDir, '.claude', 'sync-conflicts'),
   };
 }

--- a/src/lib/steps/step-6.ts
+++ b/src/lib/steps/step-6.ts
@@ -1,64 +1,19 @@
-// Step 6: Write `.claude/settings.json` env block — only the
-// SLASH_COMMAND_TOOL_CHAR_BUDGET=20000 key. Hooks live in plugin manifest per
-// CAIO-Y1 (v1.3); this step now only writes the env block. Spec §6.3a merge
-// rules: single-key update, preserve all other env entries verbatim,
-// customer-authored value wins on conflict (PostHog event fires; no override).
+// Step 6: Ensure the mySecond-managed `.claude/settings.json` surface — the env
+// block (SLASH_COMMAND_TOOL_CHAR_BUDGET) AND the usage-tracking `UserPromptSubmit`
+// hook. Both are owned by `ensureCompanionHooks` (one strict-parse, locked,
+// fail-closed read-modify-write), so init never routes settings.json through a
+// lenient reader that could clobber a corrupt-but-present file (Codex P0-2).
+//
+// History: hooks used to live here, were moved to the plugin manifest (CAIO-Y1,
+// v1.3) — which silently broke delivery because plugin-delivered hooks don't fire
+// in Claude Code — and are now re-injected here. Full root-cause writeup in
+// `companion-hooks.ts`.
 
-import { existsSync, readFileSync } from 'node:fs';
-
-import { atomicWriteFile } from '../atomic-write.js';
-import { projectPaths } from '../files.js';
+import { ensureCompanionHooks } from '../companion-hooks.js';
 
 import type { StepFn } from './types.js';
 
-const ENV_KEY = 'SLASH_COMMAND_TOOL_CHAR_BUDGET';
-const ENV_VALUE = '20000';
-
-interface SettingsShape {
-  env?: Record<string, string>;
-  [key: string]: unknown;
-}
-
-function readSettings(path: string): SettingsShape {
-  if (!existsSync(path)) return {};
-  try {
-    const raw = readFileSync(path, 'utf8');
-    if (raw.trim().length === 0) return {};
-    const parsed = JSON.parse(raw) as unknown;
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
-    return parsed as SettingsShape;
-  } catch {
-    return {};
-  }
-}
-
 export const step6: StepFn = async ({ ctx }) => {
-  const settingsPath = projectPaths(ctx.rootDir).syncStatePath.replace(
-    /sync-state\.json$/,
-    'settings.json'
-  );
-
-  const settings = readSettings(settingsPath);
-  const env = { ...(settings.env ?? {}) };
-
-  // Idempotency: matching value → no-op.
-  if (env[ENV_KEY] === ENV_VALUE) {
-    return { step: 6, outcome: { kind: 'completed' } };
-  }
-
-  // Conflict (customer-authored different value): preserve customer's value,
-  // log conflict, continue. Spec §6.3a — customer wins.
-  if (env[ENV_KEY] !== undefined && env[ENV_KEY] !== ENV_VALUE) {
-    if (!ctx.silent) {
-      process.stderr.write(
-        `mysecond: noted .claude/settings.json env.${ENV_KEY}=${env[ENV_KEY]} (customer value preserved over our default ${ENV_VALUE})\n`
-      );
-    }
-    return { step: 6, outcome: { kind: 'completed' } };
-  }
-
-  env[ENV_KEY] = ENV_VALUE;
-  const next: SettingsShape = { ...settings, env };
-  atomicWriteFile(settingsPath, JSON.stringify(next, null, 2) + '\n', { mkdirRecursive: true });
+  await ensureCompanionHooks(ctx.rootDir, { silent: ctx.silent });
   return { step: 6, outcome: { kind: 'completed' } };
 };

--- a/tests/lib/companion-hooks.test.ts
+++ b/tests/lib/companion-hooks.test.ts
@@ -1,0 +1,288 @@
+// Tests for companion-hooks — the locked, strict-parse, fail-closed, stable-marker
+// merge that injects the usage-tracking UserPromptSubmit hook (+ the env block)
+// into a project's `.claude/settings.json`. Covers every Codex round-3 finding:
+//  P0-1 the buffered-replay command shape; P0-2 strict-parse / never-clobber;
+//  P0-3 stable marker → version bump replaces in place (no duplicate);
+//  P1-5 fail-closed on schema-invalid containers; P1-6 concurrent writes serialize.
+
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import lockfile from 'proper-lockfile';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildHookCommand,
+  ensureCompanionHooks,
+  HOOK_MARKER,
+  planCompanionSettings,
+  type PlanResult,
+} from '../../src/lib/companion-hooks.js';
+
+const ENV_KEY = 'SLASH_COMMAND_TOOL_CHAR_BUDGET';
+
+function tmpProject(): string {
+  return mkdtempSync(join(tmpdir(), 'mysecond-companion-'));
+}
+
+function settingsPathOf(root: string): string {
+  return join(root, '.claude', 'settings.json');
+}
+
+function readSettings(root: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(settingsPathOf(root), 'utf8')) as Record<string, unknown>;
+}
+
+// Count hooks (across all UserPromptSubmit groups) whose command carries our marker.
+function countMarkedHooks(settings: Record<string, unknown>): string[] {
+  const hooks = settings.hooks as { UserPromptSubmit?: unknown } | undefined;
+  const groups = hooks?.UserPromptSubmit;
+  if (!Array.isArray(groups)) return [];
+  const out: string[] = [];
+  for (const g of groups) {
+    const inner = (g as { hooks?: unknown }).hooks;
+    if (!Array.isArray(inner)) continue;
+    for (const h of inner) {
+      const cmd = (h as { command?: unknown }).command;
+      if (typeof cmd === 'string' && cmd.includes(HOOK_MARKER)) out.push(cmd);
+    }
+  }
+  return out;
+}
+
+function expectWrite(r: PlanResult): Record<string, unknown> {
+  expect(r.action).toBe('write');
+  return (r as { action: 'write'; next: Record<string, unknown> }).next;
+}
+
+describe('buildHookCommand', () => {
+  it('buffers stdin, pins the version, falls back to npx, and carries the stable marker', () => {
+    const cmd = buildHookCommand('1.8.0');
+    expect(cmd).toContain('json=$(cat)'); // P0-1: buffer stdin once
+    expect(cmd).toContain('printf "%s" "$json" | mysecond emit-event'); // replay to global arm
+    expect(cmd).toContain('&& exit 0'); // global arm only on success
+    expect(cmd).toContain('printf "%s" "$json" | npx -y @mysecond/cli@1.8.0 emit-event'); // pinned npx replay
+    expect(cmd).toContain('|| true'); // non-fatal
+    expect(cmd).toContain(`# ${HOOK_MARKER}`); // P0-3: stable marker
+  });
+
+  it('the marker is independent of the version', () => {
+    expect(buildHookCommand('1.8.0')).toContain(HOOK_MARKER);
+    expect(buildHookCommand('2.0.0')).toContain(HOOK_MARKER);
+  });
+});
+
+describe('planCompanionSettings — fresh + idempotency', () => {
+  it('on an empty object: writes the env block and one UserPromptSubmit hook', () => {
+    const next = expectWrite(planCompanionSettings({}, '1.8.0', true));
+    expect((next.env as Record<string, string>)[ENV_KEY]).toBe('20000');
+    const marked = countMarkedHooks(next);
+    expect(marked).toHaveLength(1);
+    expect(marked[0]).toContain('@mysecond/cli@1.8.0');
+  });
+
+  it('is idempotent: re-planning the result is a noop', () => {
+    const next = expectWrite(planCompanionSettings({}, '1.8.0', true));
+    const again = planCompanionSettings(next, '1.8.0', true);
+    expect(again.action).toBe('noop');
+  });
+});
+
+describe('planCompanionSettings — version rewrite (P0-3)', () => {
+  it('a version bump replaces our command in place — never appends a second hook', () => {
+    const v1 = expectWrite(planCompanionSettings({}, '1.8.0', true));
+    expect(countMarkedHooks(v1)).toHaveLength(1);
+
+    const v2 = expectWrite(planCompanionSettings(v1, '1.9.0', true));
+    const marked = countMarkedHooks(v2);
+    expect(marked).toHaveLength(1); // still ONE, not two
+    expect(marked[0]).toContain('@mysecond/cli@1.9.0'); // updated
+    expect(marked[0]).not.toContain('@mysecond/cli@1.8.0');
+  });
+});
+
+describe('planCompanionSettings — customer config is preserved', () => {
+  it('appends our group while keeping a customer UserPromptSubmit hook', () => {
+    const customer = {
+      hooks: {
+        UserPromptSubmit: [
+          { matcher: '', hooks: [{ type: 'command', command: 'echo customer-hook' }] },
+        ],
+      },
+    };
+    const next = expectWrite(planCompanionSettings(customer, '1.8.0', true));
+    const allCommands = JSON.stringify(next.hooks);
+    expect(allCommands).toContain('echo customer-hook'); // customer preserved
+    expect(countMarkedHooks(next)).toHaveLength(1); // ours added
+  });
+
+  it('preserves a customer-authored env value (customer wins) and still adds the hook', () => {
+    const customer = { env: { [ENV_KEY]: '99999', OTHER: 'keep' } };
+    const next = expectWrite(planCompanionSettings(customer, '1.8.0', true));
+    const env = next.env as Record<string, string>;
+    expect(env[ENV_KEY]).toBe('99999'); // customer value untouched
+    expect(env.OTHER).toBe('keep');
+    expect(countMarkedHooks(next)).toHaveLength(1);
+  });
+
+  it('preserves unrelated top-level keys (e.g. permissions)', () => {
+    const customer = { permissions: { allow: ['Bash(ls)'] } };
+    const next = expectWrite(planCompanionSettings(customer, '1.8.0', true));
+    expect(next.permissions).toEqual({ allow: ['Bash(ls)'] });
+  });
+});
+
+describe('planCompanionSettings — fail closed (P0-2 / P1-5)', () => {
+  it('skips a non-object root and never produces a write', () => {
+    expect(planCompanionSettings([], '1.8.0', true)).toEqual({ action: 'skip', reason: 'not-an-object' });
+    expect(planCompanionSettings('nope', '1.8.0', true)).toEqual({ action: 'skip', reason: 'not-an-object' });
+    expect(planCompanionSettings(null, '1.8.0', true)).toEqual({ action: 'skip', reason: 'not-an-object' });
+  });
+
+  it('leaves a non-object "hooks" container untouched and skips the hook (still writes env)', () => {
+    const next = expectWrite(planCompanionSettings({ hooks: 'garbage' }, '1.8.0', true));
+    expect(next.hooks).toBe('garbage'); // not clobbered
+    expect((next.env as Record<string, string>)[ENV_KEY]).toBe('20000'); // env still ensured
+    expect(countMarkedHooks(next)).toHaveLength(0); // no hook injected into garbage
+  });
+
+  it('leaves a non-array UserPromptSubmit untouched and skips the hook', () => {
+    const input = { env: { [ENV_KEY]: '20000' }, hooks: { UserPromptSubmit: 'bad' } };
+    // env already set + hook skipped → nothing changes → noop.
+    expect(planCompanionSettings(input, '1.8.0', true).action).toBe('noop');
+    // and it definitely doesn't coerce the bad value:
+    const forced = planCompanionSettings({ hooks: { UserPromptSubmit: 'bad' } }, '1.8.0', true);
+    const next = expectWrite(forced); // env change forces a write
+    expect((next.hooks as { UserPromptSubmit: unknown }).UserPromptSubmit).toBe('bad');
+    expect(countMarkedHooks(next)).toHaveLength(0);
+  });
+});
+
+describe('ensureCompanionHooks — disk IO', () => {
+  it('creates settings.json with env + hook in a fresh project', async () => {
+    const root = tmpProject();
+    await ensureCompanionHooks(root, { silent: true, version: '1.8.0' });
+    const s = readSettings(root);
+    expect((s.env as Record<string, string>)[ENV_KEY]).toBe('20000');
+    expect(countMarkedHooks(s)).toHaveLength(1);
+  });
+
+  it('is idempotent on disk: running twice leaves exactly one hook', async () => {
+    const root = tmpProject();
+    await ensureCompanionHooks(root, { silent: true, version: '1.8.0' });
+    await ensureCompanionHooks(root, { silent: true, version: '1.8.0' });
+    expect(countMarkedHooks(readSettings(root))).toHaveLength(1);
+  });
+
+  it('a version bump on disk rewrites in place (one hook, new version)', async () => {
+    const root = tmpProject();
+    await ensureCompanionHooks(root, { silent: true, version: '1.8.0' });
+    await ensureCompanionHooks(root, { silent: true, version: '1.9.0' });
+    const marked = countMarkedHooks(readSettings(root));
+    expect(marked).toHaveLength(1);
+    expect(marked[0]).toContain('@mysecond/cli@1.9.0');
+  });
+
+  it('NEVER clobbers a corrupt-but-present settings.json (Codex P0-2)', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const corrupt = '{ this is not valid json ';
+    writeFileSync(settingsPathOf(root), corrupt);
+    await ensureCompanionHooks(root, { silent: true, version: '1.8.0' });
+    expect(readFileSync(settingsPathOf(root), 'utf8')).toBe(corrupt); // untouched
+  });
+
+  it('preserves existing customer settings + adds the hook', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    writeFileSync(
+      settingsPathOf(root),
+      JSON.stringify({ permissions: { allow: ['Bash(ls)'] }, env: { FOO: 'bar' } }, null, 2),
+    );
+    await ensureCompanionHooks(root, { silent: true, version: '1.8.0' });
+    const s = readSettings(root);
+    expect(s.permissions).toEqual({ allow: ['Bash(ls)'] });
+    expect((s.env as Record<string, string>).FOO).toBe('bar');
+    expect((s.env as Record<string, string>)[ENV_KEY]).toBe('20000');
+    expect(countMarkedHooks(s)).toHaveLength(1);
+  });
+
+  it('concurrent calls serialize and do not double-add the hook (Codex P1-6)', async () => {
+    const root = tmpProject();
+    await Promise.all([
+      ensureCompanionHooks(root, { silent: true, version: '1.8.0' }),
+      ensureCompanionHooks(root, { silent: true, version: '1.8.0' }),
+      ensureCompanionHooks(root, { silent: true, version: '1.8.0' }),
+    ]);
+    expect(countMarkedHooks(readSettings(root))).toHaveLength(1);
+  });
+
+  it('leaves an existing EMPTY settings.json byte-for-byte untouched (Codex P0-2)', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    writeFileSync(settingsPathOf(root), '');
+    await ensureCompanionHooks(root, { silent: true, version: '1.8.0' });
+    expect(readFileSync(settingsPathOf(root), 'utf8')).toBe('');
+  });
+
+  it('leaves an existing WHITESPACE-only settings.json byte-for-byte untouched (Codex P0-2)', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    writeFileSync(settingsPathOf(root), '   \n');
+    await ensureCompanionHooks(root, { silent: true, version: '1.8.0' });
+    expect(readFileSync(settingsPathOf(root), 'utf8')).toBe('   \n');
+  });
+
+  it('skips (writes nothing) when another process holds the settings.json lock (Codex P1-6)', async () => {
+    const root = tmpProject();
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const p = settingsPathOf(root);
+    writeFileSync(p, '{}\n');
+    const release = await lockfile.lock(p, { stale: 30_000 });
+    try {
+      await ensureCompanionHooks(root, { silent: true, version: '1.8.0' });
+      // Lock held elsewhere → helper retried, failed to acquire, skipped (never an
+      // unlocked write) → file unchanged.
+      expect(readFileSync(p, 'utf8')).toBe('{}\n');
+    } finally {
+      await release();
+    }
+  });
+});
+
+// Execution-level proof of the P0-1 stdin replay: the unit tests above check the
+// command STRING; this one RUNS it with a fake stale `mysecond` (drains stdin,
+// fails) and proves the npx fallback still receives the original event JSON.
+describe('the injected command replays buffered stdin to the npx fallback (Codex P0-1)', () => {
+  it('a stale global that drains stdin then fails does not starve the npx arm', () => {
+    const bin = mkdtempSync(join(tmpdir(), 'mysecond-bin-'));
+    const capture = join(bin, 'captured.json');
+    // Fake global `mysecond`: consume stdin, then EXIT NON-ZERO (the stale-global case).
+    const mysecondStub = join(bin, 'mysecond');
+    writeFileSync(mysecondStub, '#!/bin/sh\ncat >/dev/null\nexit 1\n');
+    chmodSync(mysecondStub, 0o755);
+    // Fake `npx`: ignore args, write whatever arrives on stdin to the capture file.
+    const npxStub = join(bin, 'npx');
+    writeFileSync(npxStub, `#!/bin/sh\ncat > "${capture}"\n`);
+    chmodSync(npxStub, 0o755);
+
+    // Run the REAL inner command (strip the `bash -lc '…'` wrapper) via `bash -c`
+    // with our stub bin on PATH. (`-c` not `-lc`: the login-shell PATH reset is
+    // irrelevant to the stdin-replay logic under test.)
+    const full = buildHookCommand('1.8.0');
+    const inner = full.slice("bash -lc '".length, full.length - 1);
+
+    const eventJson = '{"hook_event_name":"UserPromptSubmit","prompt":"/prd-generator"}';
+    execFileSync('bash', ['-c', inner], {
+      input: eventJson,
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ''}` },
+    });
+
+    // The npx arm received the ORIGINAL event JSON even though the global arm
+    // consumed its own copy first and failed. ($(cat) strips a trailing newline;
+    // we sent none, so the bytes match exactly.)
+    expect(readFileSync(capture, 'utf8')).toBe(eventJson);
+  });
+});


### PR DESCRIPTION
## Customer impact
Today a customer installs the companion and the **Track page stays empty** — the usage hook never runs. Two compounding causes: (1) the hook was moved into the plugin manifest, and plugin-delivered hooks silently **don't fire** in current Claude Code; (2) even if it fired, it called bare `mysecond`, which **isn't on PATH for npx-only customers** (everyone who didn't `npm i -g`). It only ever "worked" on a dev machine with a global CLI. After this change, the CLI writes the hook into `.claude/settings.json` (which Claude Code actually reads) with a command that reaches the CLI without a global install. Install → type slash commands → usage events fire.

## What this does
- **New `src/lib/companion-hooks.ts`** — `ensureCompanionHooks()`: a single **locked, strict-parse, fail-closed, stable-marker** merge that owns both the env block and the `UserPromptSubmit` emit hook in `.claude/settings.json`.
- **Wired into** `init` (step-6), `plugin-refresh` (ALL return paths incl. "already up to date"), and `sync` (early, before the `--push-all`/`--push-only`/network early-returns) — so new installs, existing customers refreshing, and a stranded customer's manual `sync` all self-heal the hook.
- The hook command **buffers stdin once and replays it** to a version-pinned `npx` fallback, so a stale global that drains stdin then fails doesn't starve the fallback, and **npx-only customers (no global binary) are reached**.

## Why settings.json (root cause)
Hooks were moved OUT of `.claude/settings.json` into the plugin manifest (decision CAIO-Y1, v1.3). Plugin-delivered hooks do NOT fire in Claude Code 2.1.159 — proven by an A/B isolating test (a hook in `settings.json` fired + posted a real event; the same hook in the plugin's `hooks/hooks.json` fired nothing). Corroborating open CC issues: **#10225**, **#29767**. We register `UserPromptSubmit` ONLY — `PostToolUse:"Skill"` is a confirmed no-op (**#43630**), and `UserPromptExpansion` would double-count.

## Review trail
Designed + reviewed by **CTO + CAIO + Codex** (3 rounds). All P0s folded:
- **P0-1** buffered-replay stdin (Codex verified shell-correct; an execution-level test proves it empirically).
- **P0-2** strict-parse → never clobber a corrupt/empty/whitespace `settings.json` (step-6 no longer uses a lenient reader).
- **P0-3** version-independent marker → a version bump replaces our hook in place, never appends a duplicate.
- **P1**: fail-closed merge on malformed containers; locked read-modify-write; inject on plugin-refresh's already-current path; sync early placement.

## Files
**New:** `src/lib/companion-hooks.ts`, `tests/lib/companion-hooks.test.ts` (21 tests).
**Modified:** `src/lib/steps/step-6.ts` (now routes through the helper), `src/commands/plugin-refresh.ts`, `src/commands/sync.ts` (wiring), `src/lib/files.ts` (+`settingsPath`), `package.json` (1.7.0 → 1.8.0).

## Test evidence
- `tsc --noEmit` clean.
- **Full suite green: 611 tests** (502 lib + 98 commands + 11 cli), incl. the caller tests for the modified `plugin-refresh` + `sync`.
- `companion-hooks.test.ts` (21): fresh/idempotent, version-rewrite (no dup), customer-config preserved, fail-closed (malformed root/hooks/array), corrupt + empty + whitespace files left byte-for-byte untouched, concurrent-no-double-add, lock-contention skip, and an **execution-level test** that runs the command with a fake stale `mysecond` (drains stdin, fails) and proves the `npx` arm still receives the original event JSON.

## Publish + demo (post-merge)
Tag-release flow: merge → push `v1.8.0` tag → CI `prepublishOnly` (typecheck+build+test) → `npm publish`. Then demo on ron+demo: `npx -y @mysecond/cli@latest plugin-refresh --force-update` → restart Claude Code → type a slash command → verify `skill_events` lands. (Demo proves firing on a machine with a global `mysecond`; the execution-level test covers the npx-only path.)

## Known limitations / follow-ups
- **Subagent tracking deferred** — `SubagentStop` carries top-level `agent_type` but `emit-event` reads `tool_input.subagent_type`; needs a dispatcher branch. UserPromptSubmit (skills/workflows) works now.
- **§7 — corrected (was over-flagged):** an earlier draft claimed `sync`/`artifact-sync`/`push` were all dead the same way → "auto-sync broken for all customers." That was an overclaim (extrapolated from the one tested hook). Plugin-hook firing is **hook-type-specific**: `SessionStart` sync and `PostToolUse` artifact-sync DO fire (a `/prd-generator` output syncs to the web app on creation; CC #29767 confirms SessionStart fires). Only `UserPromptSubmit` emit (this fix) and *possibly* the redundant `Stop` push are dead. **Companion auto-sync is NOT broken.** At most a small follow-up: confirm whether the `Stop` turn-end push fails (#29767) and whether it matters (artifact-sync already covers per-write output sync).
- **Display half:** `/track/usage` renders blank even with events because of a separate `device_tokens` RLS gap → fixed in the linked **mysecond-app** PR (must ship together for the visible win).

## Shared-file requests
None — no orchestrator-owned files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
