### PR TITLE
feat(track): track sub-agent runs via a SubagentStop hook (1.9.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysecond/cli",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "mySecond PM Operating System — CLI installer and sync agent",
   "type": "module",
   "bin": {

--- a/src/commands/emit-event.ts
+++ b/src/commands/emit-event.ts
@@ -34,6 +34,10 @@ interface HookEvent {
     skill_name?: string;
     subagent_type?: string;
   };
+  // SubagentStop: the subagent's type lives TOP-LEVEL as `agent_type` (per
+  // code.claude.com/docs/en/sub-agents) — NOT inside tool_input. It's the custom
+  // subagent's frontmatter `name` (e.g. "cto-tech-lead"), or "general-purpose".
+  agent_type?: string;
   tool_response?: { is_error?: boolean } | unknown;
   // UserPromptExpansion: structured slash-command name + raw prompt fallback.
   command_name?: string;
@@ -196,6 +200,34 @@ export function buildTypeEvent(
       // be non-null + globally unique to respect the server's
       // (user_id, session_id, tool_call_id) dedup.
       tool_call_id: `prompt-${randomUUID()}`,
+      cwd,
+      error: false,
+      hook_version: HOOK_VERSION,
+    };
+  }
+
+  if (hookName === 'SubagentStop') {
+    // A subagent finished. Its type is the top-level `agent_type` (per
+    // code.claude.com/docs/en/hooks + /sub-agents): the subagent's frontmatter
+    // `name` (e.g. "cto-tech-lead"), or "general-purpose" for ad-hoc spawns.
+    // Read tool_input.subagent_type as a defensive fallback — the exact field
+    // name burned us once (the old, dead PostToolUse path assumed
+    // tool_input.subagent_type), so accept both candidates until it's pinned
+    // empirically by a real SubagentStop payload.
+    const rawType =
+      (typeof event.agent_type === 'string' && event.agent_type) ||
+      (typeof event.tool_input?.subagent_type === 'string' && event.tool_input.subagent_type) ||
+      '';
+    const name = stripNamespace(rawType);
+    if (name.length === 0) return null;
+    return {
+      event_type: 'subagent_run',
+      name,
+      session_id: sessionId,
+      // SubagentStop carries no tool_use_id — synthesize a unique id so the
+      // server's (user_id, session_id, tool_call_id) dedup keeps each distinct
+      // subagent run as its own row (NULLS NOT DISTINCT would collapse nulls).
+      tool_call_id: `subagent-${randomUUID()}`,
       cwd,
       error: false,
       hook_version: HOOK_VERSION,

--- a/src/commands/emit-event.ts
+++ b/src/commands/emit-event.ts
@@ -38,6 +38,9 @@ interface HookEvent {
   // code.claude.com/docs/en/sub-agents) — NOT inside tool_input. It's the custom
   // subagent's frontmatter `name` (e.g. "cto-tech-lead"), or "general-purpose".
   agent_type?: string;
+  // SubagentStop also carries a per-run `agent_id` — used as the dedup key so a
+  // replayed SubagentStop for the same subagent collapses (vs a random UUID).
+  agent_id?: string;
   tool_response?: { is_error?: boolean } | unknown;
   // UserPromptExpansion: structured slash-command name + raw prompt fallback.
   command_name?: string;
@@ -224,10 +227,14 @@ export function buildTypeEvent(
       event_type: 'subagent_run',
       name,
       session_id: sessionId,
-      // SubagentStop carries no tool_use_id — synthesize a unique id so the
-      // server's (user_id, session_id, tool_call_id) dedup keeps each distinct
-      // subagent run as its own row (NULLS NOT DISTINCT would collapse nulls).
-      tool_call_id: `subagent-${randomUUID()}`,
+      // Dedup id: prefer the payload's per-run `agent_id` so a replayed
+      // SubagentStop for the same subagent collapses on the server's
+      // (user_id, session_id, tool_call_id) key; fall back to a synthetic UUID
+      // when absent (still unique → never wrongly collapsed by NULLS NOT DISTINCT).
+      tool_call_id:
+        typeof event.agent_id === 'string' && event.agent_id.length > 0
+          ? `subagent-${event.agent_id}`
+          : `subagent-${randomUUID()}`,
       cwd,
       error: false,
       hook_version: HOOK_VERSION,

--- a/src/lib/companion-hooks.ts
+++ b/src/lib/companion-hooks.ts
@@ -12,14 +12,16 @@
 // never fires while SessionStart does). `settings.json` hooks DO fire, so the CLI
 // re-injects the emit hook here. (Reverts CAIO-Y1 for the emit hook only.)
 //
-// We register `UserPromptSubmit` ONLY. NOT `PostToolUse:"Skill"` (the Skill tool is
-// a prompt-expansion that dispatches no PostToolUse event — confirmed no-op, CC
-// issue #43630). NOT `UserPromptExpansion` (a typed slash command fires BOTH it and
-// `UserPromptSubmit`; emit-event would record one row for each with distinct
-// synthetic ids the server dedup can't collapse → double-count). NOT `SubagentStop`
-// (emit-event's dispatcher reads `tool_input.subagent_type`, the PostToolUse shape,
-// not SubagentStop's top-level `agent_type` → it would emit nothing). Subagent
-// tracking is a deliberate fast-follow.
+// We register `UserPromptSubmit` (typed slash commands → skill_run/workflow_run)
+// AND `SubagentStop` (sub-agent completions → subagent_run) — one command for both;
+// emit-event dispatches on the hook_event_name it reads on stdin. NOT
+// `PostToolUse:"Skill"` (the Skill tool is a prompt-expansion that dispatches no
+// PostToolUse event — confirmed no-op, CC issue #43630). NOT `UserPromptExpansion`
+// (a typed slash command fires BOTH it and `UserPromptSubmit`; emit-event would
+// record one row for each with distinct synthetic ids the server dedup can't
+// collapse → double-count). `SubagentStop` carries the sub-agent's type as a
+// TOP-LEVEL `agent_type` (per code.claude.com/docs/en/sub-agents); emit-event reads
+// that — NOT the old `tool_input.subagent_type` guess that silently emitted nothing.
 //
 // Reviewed CTO + CAIO + Codex (2026-06-06). Codex P0s folded:
 //   P0-1  buffer + replay stdin in the command: a stale global `mysecond` that
@@ -115,7 +117,12 @@ export function planCompanionSettings(
   let changed = false;
 
   if (mergeEnvBlock(next, silent)) changed = true;
-  if (mergeUserPromptSubmitHook(next, buildHookCommand(version), silent)) changed = true;
+  // One command, two hook events: UserPromptSubmit captures typed slash commands
+  // (skill_run / workflow_run); SubagentStop captures sub-agent completions
+  // (subagent_run). emit-event dispatches on the hook_event_name it reads on stdin.
+  const command = buildHookCommand(version);
+  if (mergeEventHook(next, 'UserPromptSubmit', command, silent)) changed = true;
+  if (mergeEventHook(next, 'SubagentStop', command, silent)) changed = true;
 
   return changed ? { action: 'write', next } : { action: 'noop' };
 }
@@ -151,13 +158,14 @@ function mergeEnvBlock(next: SettingsShape, silent: boolean): boolean {
   return false;
 }
 
-// UserPromptSubmit hook merge. Creates only MISSING containers; fails closed
-// (skip, never overwrite) if a present container has the wrong type (Codex P1-5);
-// finds our entry by the stable marker and rewrites in place on a version change,
-// else appends our OWN group (customer hooks untouched). Returns true if it changed
-// `next`.
-function mergeUserPromptSubmitHook(
+// Hook merge for ONE event (UserPromptSubmit or SubagentStop). Creates only
+// MISSING containers; fails closed (skip, never overwrite) if a present container
+// has the wrong type (Codex P1-5); finds our entry by the stable marker and
+// rewrites in place on a version change, else appends our OWN group (customer
+// hooks untouched). Returns true if it changed `next`.
+function mergeEventHook(
   next: SettingsShape,
+  eventName: string,
   desiredCommand: string,
   silent: boolean
 ): boolean {
@@ -173,17 +181,17 @@ function mergeUserPromptSubmitHook(
   }
   const hooks = next.hooks as Record<string, unknown>;
 
-  if (hooks.UserPromptSubmit === undefined) {
-    hooks.UserPromptSubmit = [];
-  } else if (!Array.isArray(hooks.UserPromptSubmit)) {
+  if (hooks[eventName] === undefined) {
+    hooks[eventName] = [];
+  } else if (!Array.isArray(hooks[eventName])) {
     if (!silent) {
       process.stderr.write(
-        'mysecond: .claude/settings.json hooks.UserPromptSubmit is not an array — skipping usage-hook injection (left as-is).\n'
+        `mysecond: .claude/settings.json hooks.${eventName} is not an array — skipping usage-hook injection (left as-is).\n`
       );
     }
     return false;
   }
-  const groups = hooks.UserPromptSubmit as unknown[];
+  const groups = hooks[eventName] as unknown[];
 
   // Find OUR hook by the stable marker (version-independent).
   for (const group of groups) {

--- a/src/lib/companion-hooks.ts
+++ b/src/lib/companion-hooks.ts
@@ -86,9 +86,17 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 // trailing `# <marker>` is the stable idempotency marker (Codex P0-3). Exported
 // for tests.
 export function buildHookCommand(version: string): string {
+  // Use a GLOBAL `mysecond` only when it is EXACTLY the pinned version — otherwise
+  // a stale-but-functional global (e.g. an older `mysecond` that exits 0 but lacks
+  // a newer event branch) would handle the event, emit nothing, exit 0, and the
+  // pinned npx fallback would never run → the new behavior silently no-ops (Codex
+  // P1, the "stale global" class). The version check reads </dev/null so it never
+  // touches the buffered event stdin. npx-only customers (no global) skip straight
+  // to the pinned npx arm.
   return (
     `bash -lc 'json=$(cat); ` +
-    `printf "%s" "$json" | mysecond emit-event --silent 2>/dev/null && exit 0; ` +
+    `if command -v mysecond >/dev/null 2>&1 && [ "$(mysecond --version </dev/null 2>/dev/null)" = "${version}" ]; then ` +
+    `printf "%s" "$json" | mysecond emit-event --silent 2>/dev/null && exit 0; fi; ` +
     `printf "%s" "$json" | npx -y @mysecond/cli@${version} emit-event --silent 2>/dev/null || true` +
     `  # ${HOOK_MARKER}'`
   );

--- a/tests/commands/emit-event.test.ts
+++ b/tests/commands/emit-event.test.ts
@@ -296,6 +296,62 @@ describe('runEmitEvent', () => {
     }
   );
 
+  // ---- subagent_run via SubagentStop (the real settings.json-delivered path) ---
+
+  it('classifies a SubagentStop event as subagent_run, reading the TOP-LEVEL agent_type', async () => {
+    const root = tmpProject();
+    const sessionId = uniqueSession();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'SubagentStop',
+        agent_type: 'pm-os:cto-tech-lead', // top-level — NOT tool_input.subagent_type
+        session_id: sessionId,
+        cwd: root,
+      })
+    );
+
+    await runEmitEvent([], ctx(root));
+    const hit = callForEventType(fetchMock, 'subagent_run');
+    expect(hit).not.toBeNull();
+    expect(hit!.body.name).toBe('cto-tech-lead'); // namespace stripped
+    expect(hit!.body.session_id).toBe(sessionId);
+    // synthetic unique id so the server's (user,session,tool_call_id) dedup keeps
+    // each distinct subagent run as its own row.
+    expect(String(hit!.body.tool_call_id)).toMatch(/^subagent-/);
+    expect(hit!.body.error).toBe(false);
+  });
+
+  it('falls back to tool_input.subagent_type on SubagentStop when agent_type is absent', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'SubagentStop',
+        tool_input: { subagent_type: 'general-purpose' },
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+    await runEmitEvent([], ctx(root));
+    const hit = callForEventType(fetchMock, 'subagent_run');
+    expect(hit).not.toBeNull();
+    expect(hit!.body.name).toBe('general-purpose');
+  });
+
+  it('emits no subagent_run for a SubagentStop with no resolvable agent type', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'SubagentStop',
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+    await runEmitEvent([], ctx(root));
+    expect(callForEventType(fetchMock, 'subagent_run')).toBeNull();
+    // session_start still fires (first fire of the session).
+    expect(callForEventType(fetchMock, 'session_start')).not.toBeNull();
+  });
+
   it('does NOT emit a type event for a non-tracked PostToolUse tool (e.g. Bash)', async () => {
     const root = tmpProject();
     stubStdin(

--- a/tests/commands/emit-event.test.ts
+++ b/tests/commands/emit-event.test.ts
@@ -321,6 +321,23 @@ describe('runEmitEvent', () => {
     expect(hit!.body.error).toBe(false);
   });
 
+  it('uses the payload agent_id for the dedup tool_call_id when present', async () => {
+    const root = tmpProject();
+    stubStdin(
+      JSON.stringify({
+        hook_event_name: 'SubagentStop',
+        agent_type: 'cto',
+        agent_id: 'agent-abc-123',
+        session_id: uniqueSession(),
+        cwd: root,
+      })
+    );
+    await runEmitEvent([], ctx(root));
+    const hit = callForEventType(fetchMock, 'subagent_run');
+    // stable dedup key (not a random UUID) → a replayed SubagentStop collapses.
+    expect(hit!.body.tool_call_id).toBe('subagent-agent-abc-123');
+  });
+
   it('falls back to tool_input.subagent_type on SubagentStop when agent_type is absent', async () => {
     const root = tmpProject();
     stubStdin(

--- a/tests/lib/companion-hooks.test.ts
+++ b/tests/lib/companion-hooks.test.ts
@@ -6,7 +6,7 @@
 //  P1-5 fail-closed on schema-invalid containers; P1-6 concurrent writes serialize.
 
 import { execFileSync } from 'node:child_process';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -58,10 +58,12 @@ function expectWrite(r: PlanResult): Record<string, unknown> {
 }
 
 describe('buildHookCommand', () => {
-  it('buffers stdin, pins the version, falls back to npx, and carries the stable marker', () => {
+  it('buffers stdin, version-gates the global, pins npx, and carries the stable marker', () => {
     const cmd = buildHookCommand('1.8.0');
     expect(cmd).toContain('json=$(cat)'); // P0-1: buffer stdin once
-    expect(cmd).toContain('printf "%s" "$json" | mysecond emit-event'); // replay to global arm
+    expect(cmd).toContain('command -v mysecond'); // global fast-path requires a global...
+    expect(cmd).toContain('[ "$(mysecond --version </dev/null 2>/dev/null)" = "1.8.0" ]'); // ...of the EXACT pinned version (P1)
+    expect(cmd).toContain('printf "%s" "$json" | mysecond emit-event'); // global arm
     expect(cmd).toContain('&& exit 0'); // global arm only on success
     expect(cmd).toContain('printf "%s" "$json" | npx -y @mysecond/cli@1.8.0 emit-event'); // pinned npx replay
     expect(cmd).toContain('|| true'); // non-fatal
@@ -290,37 +292,56 @@ describe('ensureCompanionHooks — disk IO', () => {
   });
 });
 
-// Execution-level proof of the P0-1 stdin replay: the unit tests above check the
-// command STRING; this one RUNS it with a fake stale `mysecond` (drains stdin,
-// fails) and proves the npx fallback still receives the original event JSON.
-describe('the injected command replays buffered stdin to the npx fallback (Codex P0-1)', () => {
-  it('a stale global that drains stdin then fails does not starve the npx arm', () => {
-    const bin = mkdtempSync(join(tmpdir(), 'mysecond-bin-'));
-    const capture = join(bin, 'captured.json');
-    // Fake global `mysecond`: consume stdin, then EXIT NON-ZERO (the stale-global case).
-    const mysecondStub = join(bin, 'mysecond');
-    writeFileSync(mysecondStub, '#!/bin/sh\ncat >/dev/null\nexit 1\n');
-    chmodSync(mysecondStub, 0o755);
-    // Fake `npx`: ignore args, write whatever arrives on stdin to the capture file.
-    const npxStub = join(bin, 'npx');
-    writeFileSync(npxStub, `#!/bin/sh\ncat > "${capture}"\n`);
-    chmodSync(npxStub, 0o755);
-
-    // Run the REAL inner command (strip the `bash -lc '…'` wrapper) via `bash -c`
-    // with our stub bin on PATH. (`-c` not `-lc`: the login-shell PATH reset is
-    // irrelevant to the stdin-replay logic under test.)
-    const full = buildHookCommand('1.8.0');
+// Execution-level proof of the P0-1 stdin replay + the P1 version-gate: the unit
+// tests above check the command STRING; these RUN it with stub `mysecond`/`npx` on
+// PATH and prove which arm actually receives the buffered event JSON.
+describe('the injected command (stdin replay + version-gate)', () => {
+  // Strip the `bash -lc '…'` wrapper and run the inner command via `bash -c` with a
+  // stub bin on PATH (`-c` not `-lc`: the login-shell PATH reset is irrelevant here).
+  function runInner(version: string, eventJson: string, bin: string): void {
+    const full = buildHookCommand(version);
     const inner = full.slice("bash -lc '".length, full.length - 1);
-
-    const eventJson = '{"hook_event_name":"UserPromptSubmit","prompt":"/prd-generator"}';
     execFileSync('bash', ['-c', inner], {
       input: eventJson,
       env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ''}` },
     });
+  }
 
-    // The npx arm received the ORIGINAL event JSON even though the global arm
-    // consumed its own copy first and failed. ($(cat) strips a trailing newline;
-    // we sent none, so the bytes match exactly.)
-    expect(readFileSync(capture, 'utf8')).toBe(eventJson);
+  it('a STALE-version global is skipped and the npx arm gets the original stdin (P1)', () => {
+    const bin = mkdtempSync(join(tmpdir(), 'mysecond-bin-'));
+    const npxCapture = join(bin, 'npx.json');
+    // Stale global: `--version` reports a non-pinned version (gate skips it); any
+    // other call drains stdin + exits non-zero. Either way it must not handle the event.
+    writeFileSync(
+      join(bin, 'mysecond'),
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "0.0.0-stale"; exit 0; fi\ncat >/dev/null\nexit 1\n'
+    );
+    chmodSync(join(bin, 'mysecond'), 0o755);
+    writeFileSync(join(bin, 'npx'), `#!/bin/sh\ncat > "${npxCapture}"\n`);
+    chmodSync(join(bin, 'npx'), 0o755);
+
+    const eventJson = '{"hook_event_name":"UserPromptSubmit","prompt":"/prd-generator"}';
+    runInner('1.8.0', eventJson, bin);
+    // npx (pinned) got the ORIGINAL json; the stale global never handled it.
+    expect(readFileSync(npxCapture, 'utf8')).toBe(eventJson);
+  });
+
+  it('a MATCHING-version global handles the event and npx never runs (fast path)', () => {
+    const bin = mkdtempSync(join(tmpdir(), 'mysecond-bin-'));
+    const globalCapture = join(bin, 'global.json');
+    const npxCapture = join(bin, 'npx.json');
+    // Matching global: `--version` == pinned; emit-event captures stdin + exits 0.
+    writeFileSync(
+      join(bin, 'mysecond'),
+      `#!/bin/sh\nif [ "$1" = "--version" ]; then echo "1.8.0"; exit 0; fi\ncat > "${globalCapture}"\nexit 0\n`
+    );
+    chmodSync(join(bin, 'mysecond'), 0o755);
+    writeFileSync(join(bin, 'npx'), `#!/bin/sh\ncat > "${npxCapture}"\n`);
+    chmodSync(join(bin, 'npx'), 0o755);
+
+    const eventJson = '{"hook_event_name":"SubagentStop","agent_type":"cto"}';
+    runInner('1.8.0', eventJson, bin);
+    expect(readFileSync(globalCapture, 'utf8')).toBe(eventJson); // global handled it
+    expect(existsSync(npxCapture)).toBe(false); // npx never ran
   });
 });

--- a/tests/lib/companion-hooks.test.ts
+++ b/tests/lib/companion-hooks.test.ts
@@ -35,10 +35,10 @@ function readSettings(root: string): Record<string, unknown> {
   return JSON.parse(readFileSync(settingsPathOf(root), 'utf8')) as Record<string, unknown>;
 }
 
-// Count hooks (across all UserPromptSubmit groups) whose command carries our marker.
-function countMarkedHooks(settings: Record<string, unknown>): string[] {
-  const hooks = settings.hooks as { UserPromptSubmit?: unknown } | undefined;
-  const groups = hooks?.UserPromptSubmit;
+// Count hooks (across all groups for the given event) whose command carries our marker.
+function countMarkedHooks(settings: Record<string, unknown>, eventName = 'UserPromptSubmit'): string[] {
+  const hooks = settings.hooks as Record<string, unknown> | undefined;
+  const groups = hooks?.[eventName];
   if (!Array.isArray(groups)) return [];
   const out: string[] = [];
   for (const g of groups) {
@@ -103,6 +103,42 @@ describe('planCompanionSettings — version rewrite (P0-3)', () => {
   });
 });
 
+describe('planCompanionSettings — SubagentStop hook (sub-agent tracking)', () => {
+  it('injects BOTH a UserPromptSubmit and a SubagentStop hook with the same command', () => {
+    const next = expectWrite(planCompanionSettings({}, '1.9.0', true));
+    const ups = countMarkedHooks(next, 'UserPromptSubmit');
+    const sas = countMarkedHooks(next, 'SubagentStop');
+    expect(ups).toHaveLength(1);
+    expect(sas).toHaveLength(1);
+    expect(sas[0]).toBe(ups[0]); // one command string, two events
+  });
+
+  it('is idempotent across both events (re-plan = noop)', () => {
+    const next = expectWrite(planCompanionSettings({}, '1.9.0', true));
+    expect(planCompanionSettings(next, '1.9.0', true).action).toBe('noop');
+  });
+
+  it('a version bump rewrites BOTH hooks in place (one each, new version)', () => {
+    const v1 = expectWrite(planCompanionSettings({}, '1.9.0', true));
+    const v2 = expectWrite(planCompanionSettings(v1, '2.0.0', true));
+    for (const ev of ['UserPromptSubmit', 'SubagentStop']) {
+      const marked = countMarkedHooks(v2, ev);
+      expect(marked).toHaveLength(1);
+      expect(marked[0]).toContain('@mysecond/cli@2.0.0');
+      expect(marked[0]).not.toContain('@mysecond/cli@1.9.0');
+    }
+  });
+
+  it('preserves a customer SubagentStop hook and appends ours', () => {
+    const customer = {
+      hooks: { SubagentStop: [{ matcher: '', hooks: [{ type: 'command', command: 'echo custom-subagent' }] }] },
+    };
+    const next = expectWrite(planCompanionSettings(customer, '1.9.0', true));
+    expect(JSON.stringify(next.hooks)).toContain('echo custom-subagent');
+    expect(countMarkedHooks(next, 'SubagentStop')).toHaveLength(1);
+  });
+});
+
 describe('planCompanionSettings — customer config is preserved', () => {
   it('appends our group while keeping a customer UserPromptSubmit hook', () => {
     const customer = {
@@ -148,25 +184,27 @@ describe('planCompanionSettings — fail closed (P0-2 / P1-5)', () => {
     expect(countMarkedHooks(next)).toHaveLength(0); // no hook injected into garbage
   });
 
-  it('leaves a non-array UserPromptSubmit untouched and skips the hook', () => {
+  it('leaves a non-array UserPromptSubmit untouched (SubagentStop still injected independently)', () => {
+    // env already set; UserPromptSubmit is malformed → skipped (NOT coerced); but
+    // SubagentStop is absent → it gets added, so the overall action is 'write'.
+    // The two events are independent: one malformed container never blocks the other.
     const input = { env: { [ENV_KEY]: '20000' }, hooks: { UserPromptSubmit: 'bad' } };
-    // env already set + hook skipped → nothing changes → noop.
-    expect(planCompanionSettings(input, '1.8.0', true).action).toBe('noop');
-    // and it definitely doesn't coerce the bad value:
-    const forced = planCompanionSettings({ hooks: { UserPromptSubmit: 'bad' } }, '1.8.0', true);
-    const next = expectWrite(forced); // env change forces a write
+    const next = expectWrite(planCompanionSettings(input, '1.8.0', true));
+    // the bad UserPromptSubmit value is preserved verbatim, not turned into an array:
     expect((next.hooks as { UserPromptSubmit: unknown }).UserPromptSubmit).toBe('bad');
-    expect(countMarkedHooks(next)).toHaveLength(0);
+    expect(countMarkedHooks(next, 'UserPromptSubmit')).toHaveLength(0);
+    expect(countMarkedHooks(next, 'SubagentStop')).toHaveLength(1);
   });
 });
 
 describe('ensureCompanionHooks — disk IO', () => {
-  it('creates settings.json with env + hook in a fresh project', async () => {
+  it('creates settings.json with env + both hooks in a fresh project', async () => {
     const root = tmpProject();
-    await ensureCompanionHooks(root, { silent: true, version: '1.8.0' });
+    await ensureCompanionHooks(root, { silent: true, version: '1.9.0' });
     const s = readSettings(root);
     expect((s.env as Record<string, string>)[ENV_KEY]).toBe('20000');
-    expect(countMarkedHooks(s)).toHaveLength(1);
+    expect(countMarkedHooks(s, 'UserPromptSubmit')).toHaveLength(1);
+    expect(countMarkedHooks(s, 'SubagentStop')).toHaveLength(1);
   });
 
   it('is idempotent on disk: running twice leaves exactly one hook', async () => {


### PR DESCRIPTION
## Customer impact
Sub-agents now show up on the Track page. Before this, the **Sub-agents** count was always **0** even when a skill spawned them (e.g. `/multi-review` runs parallel reviewer sub-agents) — because nothing detected sub-agent runs.

## Root cause
No working hook captured sub-agents:
- The plugin's `PostToolUse Task|Agent → emit-event` hook is **dead** (plugin-delivered hooks don't fire).
- The settings.json injector only added `UserPromptSubmit` (sub-agent tracking was a deliberate fast-follow).
- The dead path even read the **wrong field** — `tool_input.subagent_type`, which the live CC docs don't define. A sub-agent's type lives in a **top-level `agent_type`** on the `SubagentStop` event.

## The fix (CLI 1.9.0)
- **`companion-hooks.ts`** — inject a `SubagentStop` hook alongside `UserPromptSubmit` (one command, both events; `emit-event` dispatches on `hook_event_name`). Generalized `mergeUserPromptSubmitHook` → `mergeEventHook(eventName)`.
- **`emit-event.ts`** — new `SubagentStop` branch in `buildTypeEvent`: read top-level `agent_type` (with a `tool_input.subagent_type` fallback, since the exact field burned us once), synthesize a unique `subagent-<uuid>` id for server dedup, emit `subagent_run`.

## Why `SubagentStop` (not `PostToolUse Task` or `SubagentStart`)
Fires from `settings.json` (the only reliable channel), once per sub-agent **completion**, and carries the type in the documented top-level `agent_type`. `SubagentStart` would overcount (fires before the agent does anything; a cancelled agent still counts). `PostToolUse Task` only lives in the dead plugin manifest and has the uncertain `tool_input` shape.

## Files
**Modified:** `src/lib/companion-hooks.ts`, `src/commands/emit-event.ts`, `package.json` (1.8.0 → 1.9.0), `tests/lib/companion-hooks.test.ts`, `tests/commands/emit-event.test.ts`.

## Test evidence
- `tsc --noEmit` clean. Full `lib + commands` suite green: **609 tests**.
- `companion-hooks.test.ts` (26): both hooks injected, idempotent across both, version-rewrite across both, customer hooks preserved per-event, malformed-container independence, + execution-level **version-gate** tests (stale-version global skipped → npx; matching-version → global fast path).
- `emit-event.test.ts` (26): `SubagentStop` → `subagent_run` reading top-level `agent_type`; namespace stripping; the `tool_input.subagent_type` fallback; `agent_id`-based dedup id; no-emit when type is unresolvable.
- No double-count: `SubagentStop` / `UserPromptSubmit` / `PostToolUse` are mutually exclusive by `hook_event_name`.

## ⚠️ EMPIRICAL CONFIRMATION REQUIRED BEFORE PUBLISH
`agent_type` is **doc-sourced, not yet confirmed against a real `SubagentStop` payload** — and this exact class of assumption (the old `tool_input.subagent_type`) is what caused the original bug. Before publishing 1.9.0: run a skill that spawns sub-agents (e.g. `/multi-review`) on a machine with the new CLI, and confirm `subagent_run` rows appear with sensible names. If 0, capture the raw payload (remove `--silent` from the hook) to read the real field — the fallback chain covers `agent_type` + `tool_input.subagent_type`, but a totally different field name would need a one-line tweak.

## Independent review (Codex) — folded
No P0. **P1** (folded): version-gate the global `mysecond` arm — use it only when `mysecond --version` matches the pinned version, so a stale-but-functional global (e.g. an older binary lacking the `SubagentStop` branch) can't handle the event, emit nothing, exit 0, and starve the pinned npx fallback (the "stale global" class). **P2** (folded): prefer the `SubagentStop` payload's `agent_id` for the dedup `tool_call_id`. Codex independently verified `agent_type` is correct per live docs, the `mergeEventHook` logic across all scenarios, and that dispatch is mutually exclusive by `hook_event_name` (no double-count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
