### PR TITLE
feat(sync): customs catch-up sweep — reconcile locally-authored subagents/skills/workflows (Part B)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -38,9 +38,11 @@ import { maybePrintPluginRefreshNudge } from '../lib/plugin-refresh-nag.js';
 import {
   scanArtifacts,
   scanContextFiles,
+  scanCustoms,
   type BasePluginFile,
   type CompanionFile,
   type ContextFile,
+  type ContextFilePayload,
 } from '../lib/payload.js';
 import {
   CLAUDE_MD_MARKER_END,
@@ -81,6 +83,9 @@ interface SyncSummary {
   workflowsUpdated: number;
   artifactsPushed: number;
   contextFilesPushed: number;
+  // Customs catch-up sweep — count of .claude/{agents,skills,workflows} the
+  // sweep pushed UP this run (team-shared tools authored/edited locally).
+  customsPushed: number;
   claudeMdUpdated: boolean;
   npmUpdateRan: boolean;
   // Workstream H — base plugin update counters. baseSkippedDueToCustomization
@@ -112,6 +117,7 @@ function emptySummary(): SyncSummary {
     workflowsUpdated: 0,
     artifactsPushed: 0,
     contextFilesPushed: 0,
+    customsPushed: 0,
     claudeMdUpdated: false,
     npmUpdateRan: false,
     baseSkillsUpdated: 0,
@@ -413,6 +419,103 @@ async function upSyncContextFiles(
   return result.synced;
 }
 
+// Customs catch-up sweep. The realtime `artifact-sync` hook pushes customs the
+// instant they're written; this sweep reconciles anything that hook missed
+// (created before the hook installed, an older CLI, a non-Write creation path,
+// a transient failure). Same endpoint as context files (POST
+// /api/companion/files); the Part-A receiver lands them team-shared.
+//
+// Fail CLOSED to avoid flooding context_files with the entire stock catalog as
+// per-team rows. A custom is pushed ONLY when its content matches NOTHING the
+// server is known to have for that path — not the install-state base hash
+// (pristine stock we wrote), not the context_files channel's last cloud/local
+// hash (team customs + Part-A `origin='created'` rows arrive that way), and not
+// a prior sweep push. A file we have NEVER tracked is treated as a net-new
+// local custom and pushed — EXCEPT when install-state is empty (cold/never
+// base-synced), where we can't tell a hand-authored custom from un-recorded
+// stock, so we skip. The realtime hook still covers fresh authoring there.
+// Flood backstop for the never-tracked bucket. Hand-authored customs come in
+// handfuls; an un-recorded slice of the stock catalog (a partial/interrupted
+// base sync) is large. Above this many UNTRACKED files we treat the batch as a
+// likely stock flood and skip the untracked bucket rather than risk seeding the
+// stock catalog as per-team context_files rows. Set well above any realistic
+// hand-authored customs set, below a catalog flood. Edits to ALREADY-tracked
+// files are never capped (bounded by real customizations) and always push.
+const MAX_UNTRACKED_CUSTOMS_PER_SWEEP = 100;
+
+export function selectCustomsToSync(
+  rootDir: string,
+  state: SyncState,
+  installState: InstallState
+): ContextFilePayload[] {
+  const customs = scanCustoms(rootDir);
+  if (customs.length === 0) return [];
+  const installEmpty = Object.keys(installState.files).length === 0;
+
+  const knownOnServer = (f: ContextFilePayload): boolean => {
+    // Already on the server with this exact content (pristine stock,
+    // just-downsynced custom, or already pushed by a prior sweep).
+    if (installState.files[f.file_path] === f.current_hash) return true;
+    const cf = state.files[f.file_path];
+    if (cf && (cf.cloudHash === f.current_hash || cf.localHash === f.current_hash)) return true;
+    const c = state.customs[f.file_path];
+    if (c && c.hash === f.current_hash) return true;
+    return false;
+  };
+  const isUntracked = (f: ContextFilePayload): boolean =>
+    installState.files[f.file_path] === undefined &&
+    state.files[f.file_path] === undefined &&
+    state.customs[f.file_path] === undefined;
+
+  // Content diverges from everything known-on-server → a user edit OR a net-new
+  // custom. Split so the flood backstop only ever gates the ambiguous bucket.
+  const candidates = customs.filter((f) => !knownOnServer(f));
+  const trackedEdits = candidates.filter((f) => !isUntracked(f)); // edits to known files — bounded
+  const untracked = candidates.filter(isUntracked); // net-new local custom OR un-recorded stock
+
+  // Cold/partial-state flood guard: an empty install-state can't tell a
+  // hand-authored custom from un-recorded stock at all; a too-large untracked
+  // batch under a non-empty install-state looks like a catalog flood, not
+  // hand-authored customs. In either case skip the untracked bucket — the
+  // realtime hook still covers genuine fresh authoring on the next edit.
+  const floodRisk =
+    installEmpty || untracked.length > MAX_UNTRACKED_CUSTOMS_PER_SWEEP;
+  return floodRisk ? trackedEdits : [...trackedEdits, ...untracked];
+}
+
+// Returns the synced count plus the ledger entries to persist — the caller
+// merges `pushed` into sync-state (under a lock where concurrency matters).
+// Pure w.r.t. `state`: it does NOT mutate it, so the same selection logic is
+// safe across runSync / --push-all / --push-only without surprise side effects.
+async function upSyncCustoms(
+  ctx: CommandContext,
+  state: SyncState,
+  installState: InstallState
+): Promise<{ synced: number; pushed: Record<string, SyncStateContextEntry> }> {
+  const pushed: Record<string, SyncStateContextEntry> = {};
+  const toSync = selectCustomsToSync(ctx.rootDir, state, installState);
+  if (toSync.length === 0) return { synced: 0, pushed };
+
+  const result = await contextFilesPush(ctx, toSync, silentSyncOpts(ctx));
+  // Record once the server returns a per-file VERDICT — accepted (synced),
+  // already-current (skipped), OR a per-file rejection in errors[] (e.g.
+  // cannot_overwrite_stock for a non-admin shadowing a stock slug). Recording
+  // rejections too stops them re-pushing every sweep AND stops a mixed batch
+  // re-sending its accepted files; a future CONTENT change (hash) re-attempts.
+  // A transient whole-request failure returns {synced:0,skipped:0,errors:[]}
+  // (contextFilesPush maps HTTP>=400 to that) or THROWS — neither records, so
+  // those genuinely retry.
+  const gotVerdict =
+    result.synced > 0 || result.skipped > 0 || (result.errors?.length ?? 0) > 0;
+  if (gotVerdict) {
+    const now = new Date().toISOString();
+    for (const f of toSync) {
+      pushed[f.file_path] = { hash: f.current_hash, pushedAt: now };
+    }
+  }
+  return { synced: result.synced, pushed };
+}
+
 function printSummary(summary: SyncSummary, ctx: CommandContext): void {
   // CAIO finding: stderr from SessionStart hooks is silently dropped on exit 0.
   // Customer-relevant messages MUST go to stdout when ctx.silent so Claude sees
@@ -429,6 +532,7 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
     if (summary.workflowsUpdated > 0) parts.push(`${summary.workflowsUpdated} workflows`);
     if (summary.artifactsPushed > 0) parts.push(`${summary.artifactsPushed} artifacts pushed`);
     if (summary.contextFilesPushed > 0) parts.push(`${summary.contextFilesPushed} context files pushed`);
+    if (summary.customsPushed > 0) parts.push(`${summary.customsPushed} team tools shared`);
     const conflicts =
       summary.conflictsCloudKept + summary.conflictsLocalKept + summary.conflictsSkipped;
     if (conflicts > 0) parts.push(`${conflicts} conflicts (see .claude/sync-conflicts/)`);
@@ -472,6 +576,8 @@ function printSummary(summary: SyncSummary, ctx: CommandContext): void {
   if (summary.workflowsUpdated) parts.push(`${summary.workflowsUpdated} workflows`);
   if (summary.artifactsPushed) parts.push(`${summary.artifactsPushed} artifacts pushed`);
   if (summary.contextFilesPushed) parts.push(`${summary.contextFilesPushed} context files pushed`);
+  if (summary.customsPushed)
+    parts.push(`${summary.customsPushed} team tool(s) shared (visible to your whole team)`);
   if (summary.claudeMdUpdated) parts.push('CLAUDE.md updated');
   if (summary.baseSkillsUpdated)
     parts.push(`${summary.baseSkillsUpdated} skills updated from mysecond.ai`);
@@ -578,11 +684,44 @@ async function runPushAll(ctx: CommandContext): Promise<number> {
   const contextFiles = scanContextFiles(ctx.rootDir);
   const artifacts = scanArtifacts(ctx.rootDir);
 
+  // Customs (.claude/{agents,skills,workflows}) — run FIRST so a customs-only
+  // repair (no context/ or work outputs) still pushes instead of no-op'ing on
+  // the empty-files early return below. Same fail-closed selection as the
+  // SessionStart sweep; pristine stock is never re-uploaded. Best-effort — a
+  // customs failure never changes the context-file exit gate.
+  let customsSynced = 0;
+  try {
+    const state = readSyncState(ctx.rootDir);
+    const installState = readInstallState(ctx.rootDir);
+    const r = await upSyncCustoms(ctx, state, installState);
+    if (Object.keys(r.pushed).length > 0) {
+      // Locked read-modify-write: never clobber a concurrent hook's sync-state
+      // keys (mirrors runPushOnly). Persists skipped/rejected verdicts too.
+      await updateSyncState(ctx.rootDir, (s) => {
+        Object.assign((s.customs ??= {}), r.pushed);
+      });
+    }
+    customsSynced = r.synced;
+    if (r.synced > 0) {
+      process.stdout.write(
+        `mysecond: pushed ${r.synced} team tool(s) (visible to your whole team).\n`
+      );
+    }
+  } catch (err) {
+    if (!ctx.silent) {
+      process.stderr.write(
+        `mysecond: customs push failed (${err instanceof Error ? err.message : String(err)}).\n`
+      );
+    }
+  }
+
   if (contextFiles.length === 0 && artifacts.length === 0) {
-    process.stdout.write(
-      'mysecond: no local context/ or work output files found to push.\n' +
-        '  Run /welcome in Claude Code to create your context files first.\n'
-    );
+    if (customsSynced === 0) {
+      process.stdout.write(
+        'mysecond: no local context/ or work output files found to push.\n' +
+          '  Run /welcome in Claude Code to create your context files first.\n'
+      );
+    }
     return 0;
   }
 
@@ -657,10 +796,12 @@ async function runPushAll(ctx: CommandContext): Promise<number> {
  */
 export async function runPushOnly(ctx: CommandContext): Promise<number> {
   const state = readSyncState(ctx.rootDir);
+  const installState = readInstallState(ctx.rootDir);
   const opts = silentSyncOpts(ctx);
 
   const pushedArtifacts: Record<string, SyncStateArtifactEntry> = {};
   const pushedContext: Record<string, SyncStateContextEntry> = {};
+  const pushedCustoms: Record<string, SyncStateContextEntry> = {};
 
   // Artifacts (work outputs). scanArtifacts is hardened (size-capped + skips
   // unreadable files) so a single bad file can't fail the whole turn sweep.
@@ -726,14 +867,31 @@ export async function runPushOnly(ctx: CommandContext): Promise<number> {
     }
   }
 
+  // Customs (.claude/{agents,skills,workflows}). Redundant with the per-Write
+  // `artifact-sync` hook in the common case, but catches a custom written in a
+  // turn that didn't fire that hook. Same fail-closed selection + record-on-
+  // verdict semantics as the SessionStart sweep (shared upSyncCustoms).
+  try {
+    const r = await upSyncCustoms(ctx, state, installState);
+    Object.assign(pushedCustoms, r.pushed);
+  } catch (err) {
+    if (!ctx.silent) {
+      process.stderr.write(
+        `mysecond: customs push-only failed (${err instanceof Error ? err.message : String(err)}).\n`
+      );
+    }
+  }
+
   const artifactCount = Object.keys(pushedArtifacts).length;
   const contextCount = Object.keys(pushedContext).length;
-  if (artifactCount > 0 || contextCount > 0) {
+  const customsCount = Object.keys(pushedCustoms).length;
+  if (artifactCount > 0 || contextCount > 0 || customsCount > 0) {
     // Persist ONLY the keys we pushed, merged onto a freshly-read state under
     // lock — never overwrite hashes a concurrent writer recorded.
     await updateSyncState(ctx.rootDir, (s) => {
       Object.assign(s.artifacts, pushedArtifacts);
       Object.assign(s.contextFiles, pushedContext);
+      Object.assign((s.customs ??= {}), pushedCustoms);
     });
     // stdout so Claude (which reads hook stdout as context) can note the sync.
     // Emitted only when something was actually pushed — the common no-change
@@ -741,6 +899,7 @@ export async function runPushOnly(ctx: CommandContext): Promise<number> {
     const parts: string[] = [];
     if (artifactCount > 0) parts.push(`${artifactCount} artifact(s)`);
     if (contextCount > 0) parts.push(`${contextCount} context file(s)`);
+    if (customsCount > 0) parts.push(`${customsCount} team tool(s)`);
     process.stdout.write(`mysecond: pushed ${parts.join(' + ')}.\n`);
   }
 
@@ -957,6 +1116,21 @@ export async function runSync(
     if (!ctx.silent) {
       process.stderr.write(
         `mysecond: context-file up-sync failed (${err instanceof Error ? err.message : String(err)}). Down-sync OK.\n`
+      );
+    }
+  }
+
+  // Customs catch-up sweep. installState is fully populated by the base
+  // down-sync above (syncBaseTree), so by here it reflects every stock file we
+  // wrote — the fail-closed gate in selectCustomsToSync relies on that.
+  try {
+    const customsResult = await upSyncCustoms(ctx, state, installState);
+    Object.assign(state.customs, customsResult.pushed);
+    summary.customsPushed = customsResult.synced;
+  } catch (err) {
+    if (!ctx.silent) {
+      process.stderr.write(
+        `mysecond: customs up-sync failed (${err instanceof Error ? err.message : String(err)}). Down-sync OK.\n`
       );
     }
   }

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -308,6 +308,68 @@ export function scanContextFiles(rootDir: string): ContextFilePayload[] {
   return found;
 }
 
+// Customs catch-up sweep (SessionStart / --push-all / --push-only). Walk the
+// three on-disk customs roots and emit a ContextFilePayload per file that
+// `isCustomsArtifact` accepts — the SAME shape + endpoint the realtime
+// `artifact-sync` hook pushes (POST /api/companion/files). This is pure: the
+// fail-closed "is this already on the server / is it pristine stock?" decision
+// lives in the caller (upSyncCustoms in sync.ts), where install-state and
+// sync-state are in scope. Mirrors scanContextFiles (size guard, dotfile skip).
+//
+// We stamp authored_by so a sweep-pushed custom carries the same provenance the
+// realtime hook stamps. The receiver also records the real pushing member
+// server-side, so authored_by is provenance, not authority.
+const CUSTOMS_ROOTS = ['.claude/agents', '.claude/skills', '.claude/workflows'] as const;
+
+export function scanCustoms(rootDir: string): ContextFilePayload[] {
+  const found: ContextFilePayload[] = [];
+  for (const root of CUSTOMS_ROOTS) {
+    const dir = join(rootDir, root);
+    if (!existsSync(dir)) continue;
+    walkCustomsDir(rootDir, dir, found);
+  }
+  return found;
+}
+
+function walkCustomsDir(
+  rootDir: string,
+  currentDir: string,
+  results: ContextFilePayload[]
+): void {
+  for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+    // Skip dotfiles/dotdirs — scratch files shouldn't leak to the server.
+    if (entry.name.startsWith('.')) continue;
+    const fullPath = join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      walkCustomsDir(rootDir, fullPath, results);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    const rel = relative(rootDir, fullPath);
+    // Enforce the canonical customs shape (agents flat, skills/workflows nested)
+    // so stray .md files under these roots don't sync as malformed customs.
+    if (!isCustomsArtifact(rel)) continue;
+
+    let content: string;
+    try {
+      // stat first — readFileSync on a huge file would OOM the SessionStart
+      // hook before the size check. Read only after the size is known sane.
+      const stat = statSync(fullPath);
+      if (stat.size === 0 || stat.size > CONTEXT_PER_FILE_LIMIT) continue;
+      content = readFileSync(fullPath, 'utf8');
+    } catch {
+      continue;
+    }
+
+    results.push({
+      file_path: rel,
+      content,
+      current_hash: shortHash(content),
+      authored_by: buildAuthoredBy(),
+    });
+  }
+}
+
 function walkContextDir(
   rootDir: string,
   currentDir: string,

--- a/src/lib/sync-state.ts
+++ b/src/lib/sync-state.ts
@@ -27,6 +27,11 @@ export interface SyncState {
   files: Record<string, SyncStateFileEntry>;
   artifacts: Record<string, SyncStateArtifactEntry>;
   contextFiles: Record<string, SyncStateContextEntry>;
+  // Customs catch-up sweep ledger (.claude/{agents,skills,workflows}). Records
+  // the hash of each custom the sweep has pushed so it doesn't re-push an
+  // unchanged file. Same shape as contextFiles. Absent on pre-feature state →
+  // defaulted to {} on read.
+  customs: Record<string, SyncStateContextEntry>;
   lastSyncedAt: string | null;
   // EDD §5.3 — 24h npm-update timebox cache.
   lastNpmUpdateAt: string | null;
@@ -88,6 +93,7 @@ function freshEmptyState(): SyncState {
     files: {},
     artifacts: {},
     contextFiles: {},
+    customs: {},
     lastSyncedAt: null,
     lastNpmUpdateAt: null,
     initCompletedSteps: [],
@@ -115,6 +121,7 @@ export function readSyncState(rootDir: string): SyncState {
       files: parsed.files ?? {},
       artifacts: parsed.artifacts ?? {},
       contextFiles: parsed.contextFiles ?? {},
+      customs: parsed.customs ?? {},
       initCompletedSteps: parsed.initCompletedSteps ?? [],
       step9Auth401RetryCount: parsed.step9Auth401RetryCount ?? 0,
     };

--- a/tests/lib/customs-sweep.test.ts
+++ b/tests/lib/customs-sweep.test.ts
@@ -1,0 +1,149 @@
+// selectCustomsToSync — the fail-closed customs sweep decision matrix.
+//
+// A custom is pushed ONLY when its content matches nothing the server is known
+// to have for that path (install-state base hash, the context_files channel's
+// last cloud/local hash, or a prior sweep push). A never-tracked file is a
+// net-new local custom and IS pushed — except under an empty install-state,
+// where un-recorded stock can't be told apart from a hand-authored custom, so
+// it's skipped to avoid flooding context_files with the stock catalog.
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { selectCustomsToSync } from '../../src/commands/sync.js';
+import { shortHash } from '../../src/lib/files.js';
+import type { InstallState } from '../../src/lib/install-state.js';
+import type { SyncState } from '../../src/lib/sync-state.js';
+
+function tmpProject(): string {
+  return mkdtempSync(join(tmpdir(), 'mysecond-customs-sweep-'));
+}
+
+function writeAgent(root: string, name: string, content: string): { path: string; hash: string } {
+  mkdirSync(join(root, '.claude/agents'), { recursive: true });
+  writeFileSync(join(root, `.claude/agents/${name}.md`), content);
+  return { path: `.claude/agents/${name}.md`, hash: shortHash(content) };
+}
+
+function emptyState(): SyncState {
+  return {
+    files: {},
+    artifacts: {},
+    contextFiles: {},
+    customs: {},
+    lastSyncedAt: null,
+    lastNpmUpdateAt: null,
+    initCompletedSteps: [],
+    step9Auth401RetryCount: 0,
+    customerId: null,
+    workspaceScope: null,
+    customerSlug: null,
+    lastKnownLatestNpmVersion: null,
+    lastUpgradePromptAt: null,
+    lastClaudeBinPath: null,
+    installedPluginVersion: null,
+    installedPluginContractVersion: null,
+    lastPluginRefreshPromptAt: null,
+  };
+}
+
+function installWith(files: Record<string, string>): InstallState {
+  return { base_plugin_version: 'sha', files };
+}
+
+function selectedPaths(root: string, state: SyncState, install: InstallState): string[] {
+  return selectCustomsToSync(root, state, install).map((f) => f.file_path).sort();
+}
+
+describe('selectCustomsToSync', () => {
+  it('pushes a net-new custom when install-state is populated (healthy install)', () => {
+    const root = tmpProject();
+    const cro = writeAgent(root, 'cro', '# CRO reviewer');
+    // install-state non-empty (some unrelated stock recorded) → not cold.
+    const install = installWith({ '.claude/skills/stock/SKILL.md': 'abc123abc123' });
+    expect(selectedPaths(root, emptyState(), install)).toEqual([cro.path]);
+  });
+
+  it('SKIPS a never-tracked custom when install-state is EMPTY (cold-state flood guard)', () => {
+    const root = tmpProject();
+    writeAgent(root, 'cro', '# CRO reviewer');
+    // Empty install-state: a not-tracked file could be un-recorded stock — skip.
+    expect(selectedPaths(root, emptyState(), installWith({}))).toEqual([]);
+  });
+
+  it('SKIPS pristine stock (install-state hash matches current content)', () => {
+    const root = tmpProject();
+    const cto = writeAgent(root, 'cto', '# CTO reviewer (stock)');
+    const install = installWith({ [cto.path]: cto.hash });
+    expect(selectedPaths(root, emptyState(), install)).toEqual([]);
+  });
+
+  it('pushes a customer-modified stock file (install-state hash differs)', () => {
+    const root = tmpProject();
+    const cto = writeAgent(root, 'cto', '# CTO reviewer EDITED by the customer');
+    // install-state recorded a DIFFERENT (original stock) hash for this path.
+    const install = installWith({ [cto.path]: 'deadbeefdead' });
+    expect(selectedPaths(root, emptyState(), install)).toEqual([cto.path]);
+  });
+
+  it('SKIPS a custom that just arrived via the context_files channel (state.files cloudHash matches)', () => {
+    const root = tmpProject();
+    const cro = writeAgent(root, 'cro', '# CRO from server');
+    const state = emptyState();
+    state.files[cro.path] = { localHash: cro.hash, cloudHash: cro.hash, lastSyncedAt: 'now' };
+    // install-state non-empty so the cold guard isn't what's skipping it.
+    const install = installWith({ '.claude/skills/stock/SKILL.md': 'x'.repeat(12) });
+    expect(selectedPaths(root, state, install)).toEqual([]);
+  });
+
+  it('SKIPS a custom already pushed by a prior sweep (state.customs hash matches)', () => {
+    const root = tmpProject();
+    const cro = writeAgent(root, 'cro', '# CRO already pushed');
+    const state = emptyState();
+    state.customs[cro.path] = { hash: cro.hash, pushedAt: 'now' };
+    const install = installWith({ '.claude/skills/stock/SKILL.md': 'x'.repeat(12) });
+    expect(selectedPaths(root, state, install)).toEqual([]);
+  });
+
+  it('caps the untracked bucket — a flood-sized set of never-tracked customs is skipped (partial-state guard)', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, '.claude/agents'), { recursive: true });
+    for (let i = 0; i < 101; i++) {
+      writeFileSync(join(root, `.claude/agents/a${i}.md`), `# agent ${i}`);
+    }
+    // install-state non-empty (some stock recorded) — so this is NOT the empty
+    // cold guard; it's the >MAX_UNTRACKED count backstop against a partial-state
+    // stock flood. None of the 101 untracked files should be selected.
+    const install = installWith({ '.claude/skills/stock/SKILL.md': 'x'.repeat(12) });
+    expect(selectedPaths(root, emptyState(), install)).toEqual([]);
+  });
+
+  it('still pushes a tracked EDIT even when the untracked bucket is flooded/capped', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, '.claude/agents'), { recursive: true });
+    for (let i = 0; i < 101; i++) {
+      writeFileSync(join(root, `.claude/agents/a${i}.md`), `# agent ${i}`);
+    }
+    // A customer-edited stock file (tracked in install-state with a different
+    // hash) must NOT be capped — edits are bounded by real customizations.
+    const cto = writeAgent(root, 'cto', '# CTO edited');
+    const install = installWith({
+      '.claude/skills/stock/SKILL.md': 'x'.repeat(12),
+      [cto.path]: 'origstockhash',
+    });
+    expect(selectedPaths(root, emptyState(), install)).toEqual([cto.path]);
+  });
+
+  it('pushes an EDIT to a context_files-channel custom (local content diverged from cloudHash)', () => {
+    const root = tmpProject();
+    const cro = writeAgent(root, 'cro', '# CRO locally edited after download');
+    const state = emptyState();
+    // The server's last-known hash is for the OLD content; local now differs.
+    state.files[cro.path] = { localHash: 'oldhashold01', cloudHash: 'oldhashold01', lastSyncedAt: 'now' };
+    const install = installWith({ '.claude/skills/stock/SKILL.md': 'x'.repeat(12) });
+    expect(selectedPaths(root, state, install)).toEqual([cro.path]);
+  });
+});

--- a/tests/lib/scan-customs.test.ts
+++ b/tests/lib/scan-customs.test.ts
@@ -1,0 +1,70 @@
+// scanCustoms — the SessionStart/--push customs sweep scanner. Walks
+// .claude/{agents,skills,workflows}, emits a ContextFilePayload per file that
+// isCustomsArtifact accepts (agents flat, skills/workflows nested), with the
+// same size guard + dotfile skip as scanContextFiles.
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { scanCustoms, CONTEXT_PER_FILE_LIMIT } from '../../src/lib/payload.js';
+
+function tmpProject(): string {
+  return mkdtempSync(join(tmpdir(), 'mysecond-customs-scan-'));
+}
+
+describe('scanCustoms', () => {
+  it('returns [] when no .claude customs dirs exist', () => {
+    expect(scanCustoms(tmpProject())).toEqual([]);
+  });
+
+  it('picks up flat agents and nested skills/workflows', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, '.claude/agents'), { recursive: true });
+    mkdirSync(join(root, '.claude/skills/prd-gen'), { recursive: true });
+    mkdirSync(join(root, '.claude/workflows/launch'), { recursive: true });
+    writeFileSync(join(root, '.claude/agents/cro.md'), '# CRO');
+    writeFileSync(join(root, '.claude/skills/prd-gen/SKILL.md'), '# PRD');
+    writeFileSync(join(root, '.claude/workflows/launch/workflow.md'), '# Launch');
+
+    const paths = scanCustoms(root).map((f) => f.file_path).sort();
+    expect(paths).toEqual([
+      '.claude/agents/cro.md',
+      '.claude/skills/prd-gen/SKILL.md',
+      '.claude/workflows/launch/workflow.md',
+    ]);
+  });
+
+  it('enforces the customs shape — a bare .md directly under skills/ is rejected', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, '.claude/skills'), { recursive: true });
+    // isCustomsArtifact requires .claude/skills/<slug>/<file>.md — a file
+    // directly under skills/ has no slug dir and must NOT sync.
+    writeFileSync(join(root, '.claude/skills/loose.md'), 'x');
+    expect(scanCustoms(root)).toEqual([]);
+  });
+
+  it('skips empty files and anything over the per-file size cap', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, '.claude/agents'), { recursive: true });
+    writeFileSync(join(root, '.claude/agents/empty.md'), '');
+    writeFileSync(join(root, '.claude/agents/huge.md'), 'x'.repeat(CONTEXT_PER_FILE_LIMIT + 1));
+    writeFileSync(join(root, '.claude/agents/ok.md'), 'tiny');
+
+    const paths = scanCustoms(root).map((f) => f.file_path);
+    expect(paths).toEqual(['.claude/agents/ok.md']);
+  });
+
+  it('stamps current_hash and authored_by provenance', () => {
+    const root = tmpProject();
+    mkdirSync(join(root, '.claude/agents'), { recursive: true });
+    writeFileSync(join(root, '.claude/agents/cro.md'), '# CRO');
+
+    const [file] = scanCustoms(root);
+    expect(file?.current_hash).toMatch(/^[0-9a-f]{12}$/);
+    expect(file?.authored_by?.kind).toBe('ai');
+    expect(file?.authored_by?.source).toBe('claude-code');
+  });
+});


### PR DESCRIPTION
## Customer impact

Part B of the "create a subagent/skill/workflow in Claude Code → it shows up in the mySecond Customize catalog" work. Part A ([app#377](https://github.com/mysecond-ai/mysecond-app/pull/377)) fixed the *receiver* so a pushed custom lands team-shared. This adds the **catch-up sweep** on the CLI side so a custom that the realtime `artifact-sync` hook missed (created before the hook installed, an older CLI, a non-Write creation path, a transient failure) still reconciles up on the next `mysecond sync` — instead of being stranded locally forever.

For a PM: their CRO subagent reliably reaches the team catalog whether the realtime push fired or not. Nothing is silently lost.

## What changed

- **`scanCustoms`** (payload.ts) — walks `.claude/{agents,skills,workflows}`, emits a `ContextFilePayload` per file `isCustomsArtifact` accepts (same shape + `/api/companion/files` endpoint the realtime hook uses), with the same size/dotfile guards as `scanContextFiles`.
- **`selectCustomsToSync` + `upSyncCustoms`** (sync.ts) — the sweep, wired into `runSync` (SessionStart), `runPushOnly` (per-turn), and `runPushAll` (repair). New `customs` ledger in sync-state.

### Fail-closed (the safety requirement)
A custom is pushed **only** when its content matches *nothing* the server is known to have for that path — not the install-state base hash (pristine stock we wrote), not the context_files channel's last cloud/local hash (team customs + Part-A `origin='created'` rows arrive that way), not a prior sweep push. A never-tracked file is treated as a net-new local custom and pushed — **except** the untracked bucket is skipped when install-state is empty (cold) **or** the untracked count exceeds 100 (a partial/interrupted base sync looks like a catalog flood). This keeps the sweep from ever seeding the stock catalog as per-team `context_files` rows. Edits to already-tracked files are never capped.

### Reviewed by codex (clean-home), all findings fixed
- **P1** — partial install-state could still flood stock → added the untracked count cap (empty-guard alone was insufficient).
- **P2** — rejected/mixed-batch re-push → `upSyncCustoms` records on any per-file *verdict* (synced/skipped/errors), so permanent rejects (e.g. a non-admin shadowing a stock slug) don't re-push every sweep and accepted files in a mixed batch aren't re-sent; whole-request/network failures still retry.
- **P2** — `runPushAll` clobbered concurrent sync-state writes → now uses locked `updateSyncState`; persists skipped-only verdicts; and runs the sweep **before** the empty-files early-return so a customs-only repair works.

## Tests
- `scan-customs.test.ts` (5): picks up agents/skills/workflows, enforces shape, size/dotfile guards, hash + authored_by.
- `customs-sweep.test.ts` (9): the full decision matrix — net-new pushed (healthy), skipped (cold/empty), pristine stock skipped, modified stock pushed, context_files-channel + prior-push skipped, edit pushed, and the >100 flood cap (+ tracked edit still pushes alongside a flood).
- **Full suite green; `tsc` clean; esbuild bundle builds.**

## Rollout
Deploys **after** app#377 is live (else the sweep pushes at a server still rejecting customs). Does not change the realtime hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
